### PR TITLE
feat: export test formatters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
 export { Agent } from './agent';
 export {
   AgentTester,
+  humanFormat,
+  jsonFormat,
   type AgentTestDetailsResponse,
   type AgentTestStartResponse,
   type AgentTestStatusResponse,

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -51,25 +51,13 @@ describe('AgentTester', () => {
   });
 
   describe('poll', () => {
-    it('should poll until test run is complete (human format)', async () => {
+    it('should poll until test run is complete', async () => {
       const tester = new AgentTester(connection);
       await tester.start('suiteId');
-      const output = await tester.poll('4KBSM000000003F4AQ');
-      expect(output).to.be.ok;
+      const response = await tester.poll('4KBSM000000003F4AQ');
+      expect(response).to.be.ok;
       // TODO: make these assertions more meaningful
-      expect(output.formatted).to.include('Test Case #1');
-      expect(output.formatted).to.include('Test Case #2');
-      expect(output.response.testCases[0].status).to.equal('COMPLETED');
-    });
-
-    it('should poll until test run is complete (json format)', async () => {
-      const tester = new AgentTester(connection);
-      await tester.start('suiteId');
-      const output = await tester.poll('4KBSM000000003F4AQ', { format: 'json' });
-      expect(output).to.be.ok;
-      // TODO: make these assertions more meaningful
-      expect(JSON.parse(output.formatted)).to.deep.equal(output.response);
-      expect(output.response.testCases[0].status).to.equal('COMPLETED');
+      expect(response.testCases[0].status).to.equal('COMPLETED');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Export test result formatters instead of coupling them into `AgentTester.details`. Doing this prevents ink-ception† issues when plugin-agent and agents are using the same copy of `ink` in node_modules

†oclif/table unmounts an ink component during `makeTable`, which was being called before plugin-agent's unmount of oclif/multi-stage-output. This causes ink to get confused when trying to restore the console which was resulting in a `TypeError: console.error is not a function`

### What issues does this PR fix or reference?
[skip-validate-pr]