### PR TITLE
fix: update expected response from details API

### DIFF
--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -58,7 +58,7 @@ describe('AgentTester', () => {
       const response = await tester.poll('4KBSM000000003F4AQ');
       expect(response).to.be.ok;
       // TODO: make these assertions more meaningful
-      expect(response.testCases[0].status).to.equal('COMPLETED');
+      expect(response.testSet.testCases[0].status).to.equal('COMPLETED');
     });
   });
 

--- a/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ_details.json
+++ b/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ_details.json
@@ -4,95 +4,97 @@
   "endTime": "2024-11-28T12:05:00Z",
   "errorMessage": null,
   "subjectName": "Copilot_for_Salesforce",
-  "testSetName": "CRM_Sanity_v1",
-  "testCases": [
-    {
-      "status": "COMPLETED",
-      "number": 1,
-      "startTime": "2024-11-28T12:00:10Z",
-      "endTime": "2024-11-28T12:00:20Z",
-      "generatedData": {
-        "type": "AGENT",
-        "actionsSequence": ["Action1", "Action2"],
-        "outcome": "Success",
-        "topic": "Mathematics",
-        "inputTokensCount": 50,
-        "outputTokensCount": 55
-      },
-      "expectationResults": [
-        {
-          "name": "topic_sequence_match",
-          "actualValue": "Result A",
-          "expectedValue": "Result A",
-          "score": 1.0,
-          "result": "Passed",
-          "metricLabel": "Accuracy",
-          "metricExplainability": "Measures the correctness of the result.",
-          "status": "Completed",
-          "startTime": "2024-11-28T12:00:12Z",
-          "endTime": "2024-11-28T12:00:13Z",
-          "errorCode": null,
-          "errorMessage": null
+  "testSet": {
+    "name": "CRM_Sanity_v1",
+    "testCases": [
+      {
+        "status": "COMPLETED",
+        "number": 1,
+        "startTime": "2024-11-28T12:00:10Z",
+        "endTime": "2024-11-28T12:00:20Z",
+        "generatedData": {
+          "type": "AGENT",
+          "actionsSequence": ["Action1", "Action2"],
+          "outcome": "Success",
+          "topic": "Mathematics",
+          "inputTokensCount": 50,
+          "outputTokensCount": 55
         },
-        {
-          "name": "action_sequence_match",
-          "actualValue": "Result B",
-          "expectedValue": "Result B",
-          "score": 0.9,
-          "result": "Passed",
-          "metricLabel": "Precision",
-          "metricExplainability": "Measures the precision of the result.",
-          "status": "Completed",
-          "startTime": "2024-11-28T12:00:14Z",
-          "endTime": "2024-11-28T12:00:15Z",
-          "errorCode": null,
-          "errorMessage": null
-        }
-      ]
-    },
-    {
-      "status": "ERROR",
-      "number": 2,
-      "startTime": "2024-11-28T12:00:30Z",
-      "endTime": "2024-11-28T12:00:40Z",
-      "generatedData": {
-        "type": "AGENT",
-        "actionsSequence": ["Action3", "Action4"],
-        "outcome": "Failure",
-        "topic": "Physics",
-        "inputTokensCount": 60,
-        "outputTokensCount": 50
+        "expectationResults": [
+          {
+            "name": "topic_sequence_match",
+            "actualValue": "Result A",
+            "expectedValue": "Result A",
+            "score": 1.0,
+            "result": "Passed",
+            "metricLabel": "Accuracy",
+            "metricExplainability": "Measures the correctness of the result.",
+            "status": "Completed",
+            "startTime": "2024-11-28T12:00:12Z",
+            "endTime": "2024-11-28T12:00:13Z",
+            "errorCode": null,
+            "errorMessage": null
+          },
+          {
+            "name": "action_sequence_match",
+            "actualValue": "Result B",
+            "expectedValue": "Result B",
+            "score": 0.9,
+            "result": "Passed",
+            "metricLabel": "Precision",
+            "metricExplainability": "Measures the precision of the result.",
+            "status": "Completed",
+            "startTime": "2024-11-28T12:00:14Z",
+            "endTime": "2024-11-28T12:00:15Z",
+            "errorCode": null,
+            "errorMessage": null
+          }
+        ]
       },
-      "expectationResults": [
-        {
-          "name": "topic_sequence_match",
-          "actualValue": "Result C",
-          "expectedValue": "Result D",
-          "score": 0.5,
-          "result": "Failed",
-          "metricLabel": "Accuracy",
-          "metricExplainability": "Measures the correctness of the result.",
-          "status": "Completed",
-          "startTime": "2024-11-28T12:00:32Z",
-          "endTime": "2024-11-28T12:00:33Z",
-          "errorCode": null,
-          "errorMessage": "Expected \"Result D\" but got \"Result C\"."
+      {
+        "status": "ERROR",
+        "number": 2,
+        "startTime": "2024-11-28T12:00:30Z",
+        "endTime": "2024-11-28T12:00:40Z",
+        "generatedData": {
+          "type": "AGENT",
+          "actionsSequence": ["Action3", "Action4"],
+          "outcome": "Failure",
+          "topic": "Physics",
+          "inputTokensCount": 60,
+          "outputTokensCount": 50
         },
-        {
-          "name": "topic_sequence_match",
-          "actualValue": "Result C",
-          "expectedValue": "Result D",
-          "score": 0.5,
-          "result": "Failed",
-          "metricLabel": "Accuracy",
-          "metricExplainability": "Measures the correctness of the result.",
-          "status": "Completed",
-          "startTime": "2024-11-28T12:00:32Z",
-          "endTime": "2024-11-28T12:00:33Z",
-          "errorCode": null,
-          "errorMessage": "Expected \"Result D\" but got \"Result C\"."
-        }
-      ]
-    }
-  ]
+        "expectationResults": [
+          {
+            "name": "topic_sequence_match",
+            "actualValue": "Result C",
+            "expectedValue": "Result D",
+            "score": 0.5,
+            "result": "Failed",
+            "metricLabel": "Accuracy",
+            "metricExplainability": "Measures the correctness of the result.",
+            "status": "Completed",
+            "startTime": "2024-11-28T12:00:32Z",
+            "endTime": "2024-11-28T12:00:33Z",
+            "errorCode": null,
+            "errorMessage": "Expected \"Result D\" but got \"Result C\"."
+          },
+          {
+            "name": "topic_sequence_match",
+            "actualValue": "Result C",
+            "expectedValue": "Result D",
+            "score": 0.5,
+            "result": "Failed",
+            "metricLabel": "Accuracy",
+            "metricExplainability": "Measures the correctness of the result.",
+            "status": "Completed",
+            "startTime": "2024-11-28T12:00:32Z",
+            "endTime": "2024-11-28T12:00:33Z",
+            "errorCode": null,
+            "errorMessage": "Expected \"Result D\" but got \"Result C\"."
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Updates expected response from `details` API

### What issues does this PR fix or reference?
[skip-validate-pr]