### PR TITLE
feat: add mock agentCreateV2 API and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@
 
 export {
   type AgentCreateConfig,
+  type AgentCreateConfigV2,
   type AgentCreateResponse,
+  type AgentCreateResponseV2,
   type AgentJobSpec,
   type AgentJobSpecV2,
   type AgentJobSpecCreateConfig,
@@ -18,7 +20,7 @@ export {
   type DraftAgentTopicsResponse,
   SfAgent,
 } from './types';
-export { Agent, AgentCreateLifecycleStages } from './agent';
+export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2 } from './agent';
 export {
   AgentTester,
   humanFormat,

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,73 @@ export type AgentCreateConfig = AgentJobSpecCreateConfig & {
   jobSpec: AgentJobSpec;
 };
 
+export type AgentCreateConfigV2 = DraftAgentTopicsBody & {
+  generationInfo: {
+    defaultInfo: {
+      /**
+       * List of topics from an agent spec.
+       */
+      preDefinedTopics?: DraftAgentTopics;
+    };
+  };
+  /**
+   * Whether to persist the agent creation in the org (true) or preview
+   * what would be created (false).
+   *
+   * Default: false
+   */
+  saveAgent?: boolean;
+
+  /**
+   * Settings for the agent being created. Needed only when saveAgent=true
+   */
+  agentSettings?: {
+    /**
+     * The name to use for the Agent metadata to be created.
+     */
+    agentName: string;
+    /**
+     * The API name to use for the Agent metadata to be created.
+     */
+    agentApiName: string;
+    /**
+     * The GenAiPlanner metadata ID if already created in the org.
+     */
+    plannerId?: string;
+    /**
+     * User ID of an existing user or "new" to create a new user.
+     *
+     * Determines what this agent can access and do. If your agent uses
+     * features or objects that require additional permissions, assign
+     * a custom user.
+     *
+     * Default: new
+     */
+    userId: string;
+    /**
+     * Store conversation transcripts, including end-user data, in event logs
+     * for this agent for troubleshooting. If false, conversation data is
+     * replaced with, "Sensitive data not available."
+     *
+     * Default: false
+     */
+    enrichLogs?: boolean;
+    /**
+     * The conversational style of your agent's responses.
+     *
+     * Default: Casual
+     */
+    tone?: 'Casual';
+    /**
+     * The language your agent uses in conversations. Agent currently
+     * supports English only.
+     *
+     * Default: en_US
+     */
+    primaryLanguage?: 'en_US';
+  };
+};
+
 /**
  * The request body to send to the `draft-agent-topics` API.
  */
@@ -127,6 +194,53 @@ export type AgentJobSpecCreateResponse = {
 export type AgentCreateResponse = {
   isSuccess: boolean;
   errorMessage?: string;
+};
+
+export type AgentCreateResponseV2 = {
+  isSuccess: boolean;
+  errorMessage?: string;
+  /**
+   * If the agent was created with saveAgent=true, these are the
+   * IDs that make up an agent; Bot, BotVersion, and GenAiPlanner metadata.
+   */
+  agentId?: {
+    botId: string;
+    botVersionId: string;
+    plannerId: string;
+  };
+  agentDefinition: {
+    agentDescription: string;
+    topics: [
+      {
+        scope: string;
+        topic: string;
+        actions: [
+          {
+            actionName: string;
+            exampleOutput: string;
+            actionDescription: string;
+            inputs: [
+              {
+                inputName: string;
+                inputDataType: string;
+                inputDescription: string;
+              }
+            ];
+            outputs: [
+              {
+                outputName: string;
+                outputDataType: string;
+                outputDescription: string;
+              }
+            ];
+          }
+        ];
+        instructions: string[];
+        classificationDescription: string;
+      }
+    ];
+    sampleUtterances: string[];
+  };
 };
 
 export type DraftAgentTopics = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export type AgentCreateConfigV2 = DraftAgentTopicsBody & {
      *
      * Default: casual
      */
-    tone?: 'casual';
+    tone?: 'casual' | 'formal' | 'neutral';
     /**
      * The language your agent uses in conversations. Agent currently
      * supports English only.

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,21 +110,19 @@ export type AgentCreateConfigV2 = DraftAgentTopicsBody & {
     /**
      * The API name to use for the Agent metadata to be created.
      */
-    agentApiName: string;
+    agentApiName?: string;
     /**
      * The GenAiPlanner metadata ID if already created in the org.
      */
     plannerId?: string;
     /**
-     * User ID of an existing user or "new" to create a new user.
+     * User ID of an existing user.
      *
      * Determines what this agent can access and do. If your agent uses
      * features or objects that require additional permissions, assign
      * a custom user.
-     *
-     * Default: new
      */
-    userId: string;
+    userId?: string;
     /**
      * Store conversation transcripts, including end-user data, in event logs
      * for this agent for troubleshooting. If false, conversation data is

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,11 +132,12 @@ export type AgentCreateConfigV2 = DraftAgentTopicsBody & {
      */
     enrichLogs?: boolean;
     /**
-     * The conversational style of your agent's responses.
+     * The conversational style of your agent's responses. Can be one of:
+     * formal, casual, or neutral.
      *
-     * Default: Casual
+     * Default: casual
      */
-    tone?: 'Casual';
+    tone?: 'casual';
     /**
      * The language your agent uses in conversations. Agent currently
      * supports English only.

--- a/test/mocks/createAgent-Preview/connect_ai-assist_create-agent.json
+++ b/test/mocks/createAgent-Preview/connect_ai-assist_create-agent.json
@@ -1,0 +1,41 @@
+{
+  "isSuccess": true,
+  "agentDefinition": {
+    "agentDescription": "some agent description",
+    "topics": [
+      {
+        "scope": "some scope",
+        "topic": "topic_name",
+        "actions": [
+          {
+            "actionName": "some_action_name",
+            "exampleOutput": "some example output",
+            "actionDescription": "some description",
+            "inputs": [
+              {
+                "inputName": "input_name_1",
+                "inputDataType": "string",
+                "inputDescription": "some description"
+              },
+              {
+                "inputName": "input_name_2",
+                "inputDataType": "date",
+                "inputDescription": "some description"
+              }
+            ],
+            "outputs": [
+              {
+                "outputName": "output_name",
+                "outputDataType": "string",
+                "outputDescription": "some description"
+              }
+            ]
+          }
+        ],
+        "instructions": ["instruction 1", "instruction 2"],
+        "classificationDescription": "some classification description"
+      }
+    ],
+    "Sample_Utterances": ["sample utterance 1", "sample utterance 2", "sample utterance 3"]
+  }
+}

--- a/test/mocks/createAgent-Save/connect_ai-assist_create-agent.json
+++ b/test/mocks/createAgent-Save/connect_ai-assist_create-agent.json
@@ -1,0 +1,46 @@
+{
+  "isSuccess": true,
+  "agentId": {
+    "botId": "12345",
+    "botVersionId": "12345",
+    "plannerId": "12345"
+  },
+  "agentDefinition": {
+    "agentDescription": "some agent description",
+    "topics": [
+      {
+        "scope": "some scope",
+        "topic": "topic_name",
+        "actions": [
+          {
+            "actionName": "some_action_name",
+            "exampleOutput": "some example output",
+            "actionDescription": "some description",
+            "inputs": [
+              {
+                "inputName": "input_name_1",
+                "inputDataType": "string",
+                "inputDescription": "some description"
+              },
+              {
+                "inputName": "input_name_2",
+                "inputDataType": "date",
+                "inputDescription": "some description"
+              }
+            ],
+            "outputs": [
+              {
+                "outputName": "output_name",
+                "outputDataType": "string",
+                "outputDescription": "some description"
+              }
+            ]
+          }
+        ],
+        "instructions": ["instruction 1", "instruction 2"],
+        "classificationDescription": "some classification description"
+      }
+    ],
+    "Sample_Utterances": ["sample utterance 1", "sample utterance 2", "sample utterance 3"]
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds `createV2` mock API that will use the v2 Agent Creator APIs.  Adds tests for saving agents and previewing agents during create.

### What issues does this PR fix or reference?
@W-17606916@