### PR TITLE
feat: add list method to AgentTester

### DIFF
--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -65,7 +65,7 @@ export type AgentTestResultsResponse = {
   };
 };
 
-type Definitions = Omit<FileProperties, 'manageableState' | 'namespacePrefix'>;
+export type AvailableDefinition = Omit<FileProperties, 'manageableState' | 'namespacePrefix'>;
 
 /**
  * AgentTester class to test Agents
@@ -79,7 +79,7 @@ export class AgentTester {
   /**
    * List the AiEvaluationDefinitions available in the org.
    */
-  public async list(): Promise<Definitions[]> {
+  public async list(): Promise<AvailableDefinition[]> {
     return this.connection.metadata.list({ type: 'AiEvaluationDefinition' });
   }
 

--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -7,6 +7,7 @@
 import { Connection, Lifecycle, PollingClient, StatusResult } from '@salesforce/core';
 import { Duration, env } from '@salesforce/kit';
 import ansis from 'ansis';
+import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from './maybe-mock';
 
 export type TestStatus = 'New' | 'InProgress' | 'Completed' | 'Error';
@@ -64,13 +65,22 @@ export type AgentTestResultsResponse = {
   };
 };
 
+type Definitions = Omit<FileProperties, 'manageableState' | 'namespacePrefix'>;
+
 /**
  * AgentTester class to test Agents
  */
 export class AgentTester {
   private maybeMock: MaybeMock;
-  public constructor(connection: Connection) {
+  public constructor(private connection: Connection) {
     this.maybeMock = new MaybeMock(connection);
+  }
+
+  /**
+   * List the AiEvaluationDefinitions available in the org.
+   */
+  public async list(): Promise<Definitions[]> {
+    return this.connection.metadata.list({ type: 'AiEvaluationDefinition' });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2 } from 
 export {
   AgentTester,
   convertTestResultsToFormat,
+  type AvailableDefinition,
   type AgentTestResultsResponse,
   type AgentTestStartResponse,
   type AgentTestStatusResponse,


### PR DESCRIPTION
### What does this PR do?

Adds `list` method to `AgentTester` that lists all the `AiEvaluationDefinition`s in the org

### What issues does this PR fix or reference?
@W-17669110@