### PR TITLE
feat(W-17671338): create and deploy tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "@salesforce/sf-plugins-core": "^12.1.2",
     "@salesforce/source-deploy-retrieve": "^12.14.0",
     "ansis": "^3.9.0",
-    "fast-xml-parser": "^4",
-    "nock": "^13.5.6"
+    "fast-xml-parser": "^4.5.1",
+    "nock": "^13.5.6",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@salesforce/cli-plugins-testkit": "^5.3.38",

--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -278,6 +278,7 @@ export class AgentTester {
         name: parsed.name,
         subjectType: parsed.subjectType,
         subjectName: parsed.subjectName,
+        // TODO: Once SF Eval removes AiEvaluationTestSet, we can remove testSetName and uncomment testCase
         testSetName: 'CliTestSet',
         // testCase: parsed.testCases.map((tc) => ({
         //   number: parsed.testCases.indexOf(tc) + 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2 } from 
 export {
   AgentTester,
   convertTestResultsToFormat,
+  generateTestSpec,
+  AgentTestCreateLifecycleStages,
   type AvailableDefinition,
   type AgentTestResultsResponse,
   type AgentTestStartResponse,

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -52,7 +52,7 @@ describe('AgentTester', () => {
       const output = await tester.status('4KBSM000000003F4AQ');
       expect(output).to.be.ok;
       expect(output).to.deep.equal({
-        status: 'InProgress',
+        status: 'IN_PROGRESS',
         startTime: '2024-11-13T15:00:00.000Z',
       });
     });
@@ -153,13 +153,13 @@ describe('junit formatter', () => {
     const output = await convertTestResultsToFormat(input, 'junit');
     expect(output).to.deep.equal(`<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Copilot_for_Salesforce" tests="2" failures="1" time="20000">
-  <property name="status" value="Completed"></property>
+  <property name="status" value="COMPLETED"></property>
   <property name="start-time" value="2024-11-28T12:00:00Z"></property>
   <property name="end-time" value="2024-11-28T12:00:48.56Z"></property>
   <testsuite name="CRM_Sanity_v1.1" time="10000" assertions="3"></testsuite>
   <testsuite name="CRM_Sanity_v1.2" time="10000" assertions="3">
-    <failure message="Actual response does not match the expected response" name="action_sequence_match"></failure>
-    <failure message="Actual response does not match the expected response" name="bot_response_rating"></failure>
+    <failure message="Actual response does not match the expected response" name="expectedActions"></failure>
+    <failure message="Actual response does not match the expected response" name="expectedOutcome"></failure>
   </testsuite>
 </testsuites>`);
   });
@@ -179,14 +179,14 @@ ok 4 CRM_Sanity_v1.2
 not ok 5 CRM_Sanity_v1.2
   ---
   message: Actual response does not match the expected response
-  expectation: action_sequence_match
+  expectation: expectedActions
   actual: ["IdentifyRecordByName","QueryRecords"]
   expected: ["IdentifyRecordByName","QueryRecords","GetActivitiesTimeline"]
   ...
 not ok 6 CRM_Sanity_v1.2
   ---
   message: Actual response does not match the expected response
-  expectation: bot_response_rating
+  expectation: expectedOutcome
   actual: It looks like I am unable to find the information you are looking for due to access restrictions. How else can I assist you?
   expected: Summary of open cases and activities associated with timeline
   ...`);

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -87,6 +87,54 @@ describe('AgentTester', () => {
       expect(output.success).to.be.true;
     });
   });
+
+  describe('create', () => {
+    const yml = `name: Test
+description: Test
+subjectType: AGENT
+subjectName: MyAgent
+testCases:
+  - utterance: List contact names associated with Acme account
+    expectedActions:
+      - IdentifyRecordByName
+      - QueryRecords
+    expectedOutcome: contacts available name available with Acme are listed
+    expectedTopic: GeneralCRM
+  - utterance: List contact emails associated with Acme account
+    expectedActions:
+      - IdentifyRecordByName
+      - QueryRecords
+    expectedOutcome: contacts available emails available with Acme are listed
+    expectedTopic: GeneralCRM
+`;
+    beforeEach(() => {
+      sinon.stub(fs, 'writeFile').resolves();
+      sinon.stub(fs, 'mkdir').resolves();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should generate preview of AiEvaluationDefinition', async () => {
+      const tester = new AgentTester(connection);
+      sinon.stub(fs, 'readFile').resolves(yml);
+      sinon.stub(tester, 'list').resolves([]);
+      const { contents } = await tester.create('test.yaml', {
+        outputDir: 'tmp',
+        preview: true,
+      });
+
+      expect(contents).to.equal(`<AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+  <description>Test</description>
+  <name>Test</name>
+  <subjectType>AGENT</subjectType>
+  <subjectName>MyAgent</subjectName>
+  <testSetName>CliTestSet</testSetName>
+</AiEvaluationDefinition>
+`);
+    });
+  });
 });
 
 describe('human format', () => {

--- a/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/1.json
+++ b/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/1.json
@@ -1,4 +1,4 @@
 {
-  "status": "InProgress",
+  "status": "IN_PROGRESS",
   "startTime": "2024-11-13T15:00:00.000Z"
 }

--- a/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/2.json
+++ b/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/2.json
@@ -1,4 +1,4 @@
 {
-  "status": "InProgress",
+  "status": "IN_PROGRESS",
   "startTime": "2024-11-13T15:00:00.000Z"
 }

--- a/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/3.json
+++ b/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ/3.json
@@ -1,4 +1,4 @@
 {
-  "status": "Completed",
+  "status": "COMPLETED",
   "startTime": "2024-11-13T15:00:00.000Z"
 }

--- a/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ_results.json
+++ b/test/mocks/einstein_ai-evaluations_runs_4KBSM000000003F4AQ_results.json
@@ -1,5 +1,5 @@
 {
-  "status": "Completed",
+  "status": "COMPLETED",
   "startTime": "2024-11-28T12:00:00Z",
   "endTime": "2024-11-28T12:00:48.56Z",
   "errorMessage": null,
@@ -9,20 +9,20 @@
     "testCases": [
       {
         "status": "COMPLETED",
-        "utterance": "Summarize account Acme",
+        "inputs": {
+          "utterance": "Summarize account Acme"
+        },
         "startTime": "2024-11-28T12:00:10Z",
         "endTime": "2024-11-28T12:00:20Z",
         "generatedData": {
           "type": "AGENT",
           "actionsSequence": ["Action1", "Action2"],
           "outcome": "Success",
-          "topic": "Mathematics",
-          "inputTokensCount": 50,
-          "outputTokensCount": 55
+          "topic": "Mathematics"
         },
-        "expectationResults": [
+        "testResults": [
           {
-            "name": "topic_sequence_match",
+            "name": "expectedTopic",
             "actualValue": "GeneralCRM",
             "expectedValue": "GeneralCRM",
             "score": 1.0,
@@ -36,7 +36,7 @@
             "errorMessage": null
           },
           {
-            "name": "action_sequence_match",
+            "name": "expectedActions",
             "actualValue": "[\"IdentifyRecordByName\",\"SummarizeRecord\"]",
             "expectedValue": "[\"IdentifyRecordByName\",\"SummarizeRecord\"]",
             "score": 1.0,
@@ -50,7 +50,7 @@
             "errorMessage": null
           },
           {
-            "name": "bot_response_rating",
+            "name": "expectedOutcome",
             "actualValue": "Here is the summary of the account Acme. How else can I assist you? Acme is a customer since 2019. They have 3 open opportunities and 2 open cases.",
             "expectedValue": "Summary of account details are shown",
             "score": 0.9,
@@ -68,19 +68,19 @@
       {
         "status": "COMPLETED",
         "startTime": "2024-11-28T12:00:30Z",
-        "utterance": "Summarize the open cases and Activities of acme from sep to nov 2024",
+        "inputs": {
+          "utterance": "Summarize the open cases and Activities of acme from sep to nov 2024"
+        },
         "endTime": "2024-11-28T12:00:40Z",
         "generatedData": {
           "type": "AGENT",
           "actionsSequence": ["Action3", "Action4"],
           "outcome": "Failure",
-          "topic": "Physics",
-          "inputTokensCount": 60,
-          "outputTokensCount": 50
+          "topic": "Physics"
         },
-        "expectationResults": [
+        "testResults": [
           {
-            "name": "topic_sequence_match",
+            "name": "expectedTopic",
             "actualValue": "GeneralCRM",
             "expectedValue": "GeneralCRM",
             "score": 1,
@@ -94,7 +94,7 @@
             "errorMessage": null
           },
           {
-            "name": "action_sequence_match",
+            "name": "expectedActions",
             "actualValue": "[\"IdentifyRecordByName\",\"QueryRecords\"]",
             "expectedValue": "[\"IdentifyRecordByName\",\"QueryRecords\",\"GetActivitiesTimeline\"]",
             "score": 0.5,
@@ -108,7 +108,7 @@
             "errorMessage": "Actual response does not match the expected response"
           },
           {
-            "name": "bot_response_rating",
+            "name": "expectedOutcome",
             "actualValue": "It looks like I am unable to find the information you are looking for due to access restrictions. How else can I assist you?",
             "expectedValue": "Summary of open cases and activities associated with timeline",
             "score": 0.1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,7 +2686,7 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.3.tgz#892a1c91802d5d7860de728f18608a0573142241"
   integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
 
-fast-xml-parser@^4, fast-xml-parser@^4.5.1:
+fast-xml-parser@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz#a7e665ff79b7919100a5202f23984b6150f9b31e"
   integrity sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==
@@ -5662,16 +5662,7 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5748,14 +5739,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6362,7 +6346,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6375,15 +6359,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -6465,7 +6440,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.5.1, yaml@^2.6.1:
+yaml@^2.5.1, yaml@^2.6.1, yaml@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
   integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==


### PR DESCRIPTION
### What does this PR do?

Add `create` method to `AgentTester` that will generate an `AiEvaluationDefinition` from a spec and deploy it to the org

**NOTE** the generated `AiEvaluationDefinition` matches the old, two-entity approach. Once SF Eval gets the new single-entity change into lower orgs, we can uncomment the necessary code

### What issues does this PR fix or reference?
@W-17671338@