### PR TITLE
fix: W-17669635 - retrieve created agents

### DIFF
--- a/messages/agents.md
+++ b/messages/agents.md
@@ -9,3 +9,7 @@ The "agentName" configuration property is required when saving an agent.
 # agentRetrievalError
 
 Unable to retrieve newly created Agent metadata. Due to: %s
+
+# agentRetrievalErrorActions
+
+Retrieve the agent metadata using the "project retrieve start" command.

--- a/messages/agents.md
+++ b/messages/agents.md
@@ -1,3 +1,11 @@
 # invalidAgentSpecConfig
 
 Missing one or more of the required agent spec arguments: type, role, companyName, companyDescription
+
+# missingAgentName
+
+The "agentName" configuration property is required when saving an agent.
+
+# agentRetrievalError
+
+Unable to retrieve newly created Agent metadata. Due to: %s

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@salesforce/core": "^8.8.2",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12.1.2",
-    "@salesforce/source-deploy-retrieve": "^12.14.0",
+    "@salesforce/source-deploy-retrieve": "^12.14.1",
     "ansis": "^3.9.0",
     "fast-xml-parser": "^4",
     "nock": "^13.5.6"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -149,7 +149,7 @@ export class Agent implements SfAgent {
    * Creates an agent from a configuration, optionally saving the agent in an org.
    *
    * @param config a configuration for creating or previewing an agent
-   * @returns
+   * @returns the agent definition
    */
   public async createV2(config: AgentCreateConfigV2): Promise<AgentCreateResponseV2> {
     const url = '/connect/ai-assist/create-agent';
@@ -163,39 +163,47 @@ export class Agent implements SfAgent {
       return this.maybeMock.request<AgentCreateResponseV2>('POST', url, config);
     }
 
-    // When saving agent creation we need to retrieve the created metadata.
+    if (!config.agentSettings?.agentName) {
+      throw messages.createError('missingAgentName');
+    }
+
     this.logger.debug(`Creating agent using config: ${inspect(config)} in project: ${this.project.getPath()}`);
     await Lifecycle.getInstance().emit(AgentCreateLifecycleStagesV2.Creating, {});
+    if (!config.agentSettings.agentApiName) {
+      config.agentSettings.agentApiName = generateAgentApiName(config.agentSettings?.agentName);
+    }
     const response = await this.maybeMock.request<AgentCreateResponseV2>('POST', url, config);
 
-    await Lifecycle.getInstance().emit(AgentCreateLifecycleStagesV2.Retrieving, {});
+    // When saving agent creation we need to retrieve the created metadata.
+    if (response.isSuccess) {
+      await Lifecycle.getInstance().emit(AgentCreateLifecycleStagesV2.Retrieving, {});
+      const defaultPackagePath = this.project.getDefaultPackage().path ?? 'force-app';
+      const cs = await ComponentSetBuilder.build({
+        metadata: {
+          metadataEntries: [`Agent:${config.agentSettings.agentApiName}`],
+          directoryPaths: [defaultPackagePath],
+        },
+        org: {
+          username: this.connection.getUsername() as string,
+          exclude: [],
+        },
+      });
 
-    //
-    // When retrieving all agent metadata by a Bot API name works in SDR we can use that.
-    //
-
-    // Query for the Bot API name by the Bot ID.
-    // const botApiName = this.connection.singleRecordQuery('get bot from response.agentId?.botId');
-    // const cs = await ComponentSetBuilder.build({
-    //   metadata: {
-    //     metadataEntries: [`Bot:${}`],
-    //     directoryPaths: [this.project.getDefaultPackage().path],
-    //   }
-    // });
-    // const retrieve = await cs.retrieve({
-    //   usernameOrConnection: this.connection,
-    //   merge: true,
-    //   format: 'source',
-    //   output: this.project.getDefaultPackage().path ?? 'force-app',
-    // });
-    // const retrieveResult = await retrieve.pollStatus({
-    //   frequency: Duration.milliseconds(200),
-    //   timeout: Duration.minutes(5),
-    // });
-
-    // if (!retrieveResult.response.success) {
-    //   throw new SfError(`Unable to retrieve ${retrieveResult.response.id}`);
-    // }
+      const retrieve = await cs.retrieve({
+        usernameOrConnection: this.connection,
+        merge: true,
+        format: 'source',
+        output: defaultPackagePath,
+      });
+      const retrieveResult = await retrieve.pollStatus({
+        frequency: Duration.milliseconds(200),
+        timeout: Duration.minutes(5),
+      });
+      if (!retrieveResult.response.success) {
+        const errMessages = retrieveResult.response.messages?.toString() ?? 'unknown';
+        throw messages.createError('agentRetrievalError', [errMessages]);
+      }
+    }
 
     return response;
   }
@@ -555,3 +563,22 @@ export class Agent implements SfAgent {
     return [genAiSourcePath, botSourcePath, botVersionSourcePath];
   }
 }
+
+/**
+ * Generate an API name from an agent name. Matches what the UI does.
+ */
+export const generateAgentApiName = (agentName: string): string => {
+  const maxLength = 255;
+  let apiName = agentName;
+  apiName = apiName.replace(/[\W_]+/g, '_');
+  if (apiName.charAt(0).match(/_/i)) {
+    apiName = apiName.slice(1);
+  }
+  apiName = apiName
+    .replace(/(^\d+)/, 'X$1')
+    .slice(0, maxLength)
+    .replace(/_$/, '');
+  const logger = Logger.childFromRoot('Agent-GenApiName');
+  logger.debug(`Generated Agent API name: [${apiName}] from Agent name: [${agentName}]`);
+  return apiName;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
   type DraftAgentTopicsResponse,
   SfAgent,
 } from './types';
-export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2 } from './agent';
+export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2, generateAgentApiName } from './agent';
 export {
   AgentTester,
   convertTestResultsToFormat,

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,10 +699,10 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/source-deploy-retrieve@^12.14.0":
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.14.0.tgz#04036f76301071b2188c92f70d77a138bc0d72cf"
-  integrity sha512-3WOQCUY0a8cNYx5/NVtaubLEgxo/vHS/7k4Kw/FEZY3ysALpPCqWk2psJQP56xsp/SDAI3lV0VpMZadrL+ryMw==
+"@salesforce/source-deploy-retrieve@^12.14.1":
+  version "12.14.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.14.1.tgz#9067388b1eb9fadda7e6ccd894e9d1bb0e8407d5"
+  integrity sha512-8POp6tqoeciDFAv7a40LG21aHZ2XGHvX0/ySqcjcAVhTVhVhcP0EpC+qO+SSKjB6Ocf0/6iXMo5ciU2Eq32ydw==
   dependencies:
     "@salesforce/core" "^8.8.2"
     "@salesforce/kit" "^3.2.3"


### PR DESCRIPTION
### What does this PR do?
After a successful agent creation, the agent is now retrieved to the local project.
If an agent API name is not provided, one will be generated based on the required agent name property and sent to the agent creator API.
Adds tests.

### What issues does this PR fix or reference?
@W-17669635@