### PR TITLE
fix(W-17801301): dont wrap yaml files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/agents",
   "description": "Client side APIs for working with Salesforce agents",
-  "version": "0.9.8-dev.1",
+  "version": "0.9.8-dev.2",
   "license": "BSD-3-Clause",
   "author": "Salesforce",
   "main": "lib/index",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/agents",
   "description": "Client side APIs for working with Salesforce agents",
-  "version": "0.9.7",
+  "version": "0.9.8-dev.0",
   "license": "BSD-3-Clause",
   "author": "Salesforce",
   "main": "lib/index",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/agents",
   "description": "Client side APIs for working with Salesforce agents",
-  "version": "0.9.8-dev.0",
+  "version": "0.9.8-dev.1",
   "license": "BSD-3-Clause",
   "author": "Salesforce",
   "main": "lib/index",

--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -471,7 +471,10 @@ export async function generateTestSpec(spec: TestSpec, outputFile: string): Prom
     return acc;
   }, {});
 
-  const yml = stringify(clean);
+  const yml = stringify(clean, undefined, {
+    minContentWidth: 0,
+    lineWidth: 0,
+  });
   await mkdir(dirname(outputFile), { recursive: true });
   await writeFile(outputFile, yml);
 }

--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -109,15 +109,15 @@ export class AgentTester {
   /**
    * Starts an AI evaluation run based on the provided name or ID.
    *
-   * @param nameOrId - The name or ID of the AI evaluation definition.
+   * @param aiEvalDefName - The name or ID of the AI evaluation definition.
    * @param type - Specifies whether the provided identifier is a 'name' or 'id'. Defaults to 'name'. If 'name' is provided, nameOrId is treated as the name of the AiEvaluationDefinition. If 'id' is provided, nameOrId is treated as the unique ID of the AiEvaluationDefinition.
    * @returns A promise that resolves to an object containing the ID of the started AI evaluation run.
    */
-  public async start(nameOrId: string, type: 'name' | 'id' = 'name'): Promise<AgentTestStartResponse> {
+  public async start(aiEvalDefName: string): Promise<AgentTestStartResponse> {
     const url = '/einstein/ai-evaluations/runs';
 
     return this.maybeMock.request<AgentTestStartResponse>('POST', url, {
-      [type === 'name' ? 'aiEvaluationDefinitionName' : 'aiEvaluationDefinitionVersionId']: nameOrId,
+      aiEvaluationDefinitionName: aiEvalDefName,
     });
   }
 

--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -107,11 +107,10 @@ export class AgentTester {
   }
 
   /**
-   * Starts an AI evaluation run based on the provided name or ID.
+   * Initiates an AI evaluation run.
    *
-   * @param aiEvalDefName - The name or ID of the AI evaluation definition.
-   * @param type - Specifies whether the provided identifier is a 'name' or 'id'. Defaults to 'name'. If 'name' is provided, nameOrId is treated as the name of the AiEvaluationDefinition. If 'id' is provided, nameOrId is treated as the unique ID of the AiEvaluationDefinition.
-   * @returns A promise that resolves to an object containing the ID of the started AI evaluation run.
+   * @param aiEvalDefName - The name of the AI evaluation definition to run.
+   * @returns Promise that resolves with the response from starting the test.
    */
   public async start(aiEvalDefName: string): Promise<AgentTestStartResponse> {
     const url = '/einstein/ai-evaluations/runs';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,10 @@ export {
 export { Agent, AgentCreateLifecycleStages, AgentCreateLifecycleStagesV2, generateAgentApiName } from './agent';
 export {
   AgentTester,
-  convertTestResultsToFormat,
-  generateTestSpec,
   AgentTestCreateLifecycleStages,
+  convertTestResultsToFormat,
+  writeTestSpec,
+  generateTestSpecFromAiEvalDefinition,
   humanFriendlyName,
   type AvailableDefinition,
   type AgentTestResultsResponse,

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -14,7 +14,8 @@ import {
   AgentTestResultsResponse,
   AgentTester,
   convertTestResultsToFormat,
-  generateTestSpec,
+  writeTestSpec,
+  generateTestSpecFromAiEvalDefinition,
 } from '../src/agentTester';
 
 describe('AgentTester', () => {
@@ -217,7 +218,7 @@ not ok 9 3.bot_response_rating
   });
 });
 
-describe('generateTestSpec', () => {
+describe('writeTestSpec', () => {
   let writeFileStub: sinon.SinonStub;
   beforeEach(() => {
     writeFileStub = sinon.stub(fs, 'writeFile');
@@ -228,7 +229,7 @@ describe('generateTestSpec', () => {
   });
 
   it('should generate a yaml file', async () => {
-    await generateTestSpec(
+    await writeTestSpec(
       {
         name: 'Test',
         description: 'Test',
@@ -275,7 +276,7 @@ testCases:
   });
 
   it('should remove empty strings', async () => {
-    await generateTestSpec(
+    await writeTestSpec(
       {
         name: 'Test',
         description: '',
@@ -309,7 +310,7 @@ testCases:
   });
 
   it('should remove undefined values', async () => {
-    await generateTestSpec(
+    await writeTestSpec(
       {
         name: 'Test',
         description: undefined,
@@ -340,5 +341,162 @@ testCases:
     expectedTopic: GeneralCRM
 `,
     ]);
+  });
+});
+
+describe('generateTestSpecFromAiEvalDefinition', () => {
+  let readFileStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    readFileStub = sinon.stub(fs, 'readFile');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should parse AiEvaluationDefinition XML into TestSpec', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+      <description>Test Description</description>
+      <name>TestSpec</name>
+      <subjectType>AGENT</subjectType>
+      <subjectName>WeatherBot</subjectName>
+      <subjectVersion>1</subjectVersion>
+      <testCase>
+        <inputs>
+          <utterance>What's the weather like?</utterance>
+        </inputs>
+        <expectation>
+          <name>topic_sequence_match</name>
+          <expectedValue>Weather</expectedValue>
+        </expectation>
+        <expectation>
+          <name>action_sequence_match</name>
+          <expectedValue>["GetLocation","GetWeather"]</expectedValue>
+        </expectation>
+        <expectation>
+          <name>bot_response_rating</name>
+          <expectedValue>Sunny with a high of 75F</expectedValue>
+        </expectation>
+      </testCase>
+    </AiEvaluationDefinition>`;
+
+    readFileStub.resolves(xml);
+
+    const result = await generateTestSpecFromAiEvalDefinition('test.xml');
+
+    expect(result).to.deep.equal({
+      name: 'TestSpec',
+      description: 'Test Description',
+      subjectType: 'AGENT',
+      subjectName: 'WeatherBot',
+      subjectVersion: 1,
+      testCases: [
+        {
+          utterance: "What's the weather like?",
+          expectedTopic: 'Weather',
+          expectedActions: ['GetLocation', 'GetWeather'],
+          expectedOutcome: 'Sunny with a high of 75F',
+        },
+      ],
+    });
+  });
+
+  it('should handle missing optional fields', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+      <name>TestSpec</name>
+      <subjectType>AGENT</subjectType>
+      <subjectName>WeatherBot</subjectName>
+      <testCase>
+        <inputs>
+          <utterance>What's the weather like?</utterance>
+        </inputs>
+        <expectation>
+          <name>topic_sequence_match</name>
+          <expectedValue>Weather</expectedValue>
+        </expectation>
+      </testCase>
+    </AiEvaluationDefinition>`;
+
+    readFileStub.resolves(xml);
+
+    const result = await generateTestSpecFromAiEvalDefinition('test.xml');
+
+    expect(result).to.deep.equal({
+      description: undefined,
+      name: 'TestSpec',
+      subjectType: 'AGENT',
+      subjectName: 'WeatherBot',
+      subjectVersion: undefined,
+      testCases: [
+        {
+          utterance: "What's the weather like?",
+          expectedTopic: 'Weather',
+          expectedActions: [],
+          expectedOutcome: undefined,
+        },
+      ],
+    });
+  });
+
+  it('should handle multiple test cases', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+      <name>TestSpec</name>
+      <subjectType>AGENT</subjectType>
+      <subjectName>WeatherBot</subjectName>
+      <testCase>
+        <inputs>
+          <utterance>What's the weather like?</utterance>
+        </inputs>
+        <expectation>
+          <name>action_sequence_match</name>
+          <expectedValue>["GetWeather"]</expectedValue>
+        </expectation>
+      </testCase>
+      <testCase>
+        <inputs>
+          <utterance>Will it rain tomorrow?</utterance>
+        </inputs>
+        <expectation>
+          <name>action_sequence_match</name>
+          <expectedValue>["GetForecast"]</expectedValue>
+        </expectation>
+      </testCase>
+    </AiEvaluationDefinition>`;
+
+    readFileStub.resolves(xml);
+
+    const result = await generateTestSpecFromAiEvalDefinition('test.xml');
+
+    expect(result.testCases).to.have.length(2);
+    expect(result.testCases[0].expectedActions).to.deep.equal(['GetWeather']);
+    expect(result.testCases[1].expectedActions).to.deep.equal(['GetForecast']);
+  });
+
+  it('should handle malformed action sequence JSON', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+      <name>TestSpec</name>
+      <subjectType>AGENT</subjectType>
+      <subjectName>WeatherBot</subjectName>
+      <testCase>
+        <inputs>
+          <utterance>Test</utterance>
+        </inputs>
+        <expectation>
+          <name>action_sequence_match</name>
+          <expectedValue>invalid json</expectedValue>
+        </expectation>
+      </testCase>
+    </AiEvaluationDefinition>`;
+
+    readFileStub.resolves(xml);
+
+    const result = await generateTestSpecFromAiEvalDefinition('test.xml');
+
+    expect(result.testCases[0].expectedActions).to.deep.equal([]);
   });
 });

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -120,7 +120,7 @@ testCases:
       const tester = new AgentTester(connection);
       sinon.stub(fs, 'readFile').resolves(yml);
       sinon.stub(tester, 'list').resolves([]);
-      const { contents } = await tester.create('test.yaml', {
+      const { contents } = await tester.create('MyTest', 'test.yaml', {
         outputDir: 'tmp',
         preview: true,
       });


### PR DESCRIPTION
### What does this PR do?

- Disable line wrapping in yaml files
- Pass `apiName` to `AgentTester.create`
- Decode html entities inside of `AgentTester.results` so that consumers don't have to do it
- Add `generateTestSpecFromAiEvalDefinition` function

### What issues does this PR fix or reference?
@W-17801301@