### PR TITLE
fix: order aiEvalDefs in server-order W-17875268

### DIFF
--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -276,6 +276,7 @@ export class AgentTester {
     const builder = new XMLBuilder({
       format: true,
       attributeNamePrefix: '$',
+      indentBy: '    ',
       ignoreAttributes: false,
     });
 
@@ -284,28 +285,28 @@ export class AgentTester {
         $xmlns: 'http://soap.sforce.com/2006/04/metadata',
         ...(parsed.description && { description: parsed.description }),
         name: parsed.name,
-        subjectType: parsed.subjectType,
         subjectName: parsed.subjectName,
+        subjectType: parsed.subjectType,
         ...(parsed.subjectVersion && { subjectVersion: parsed.subjectVersion }),
         testCase: parsed.testCases.map((tc) => ({
-          number: parsed.testCases.indexOf(tc) + 1,
+          expectation: [
+            {
+              expectedValue: tc.expectedTopic,
+              name: 'topic_sequence_match',
+            },
+            {
+              expectedValue: `[${(tc.expectedActions ?? []).map((v) => `"${v}"`).join(',')}]`,
+              name: 'action_sequence_match',
+            },
+            {
+              expectedValue: tc.expectedOutcome,
+              name: 'bot_response_rating',
+            },
+          ],
           inputs: {
             utterance: tc.utterance,
           },
-          expectation: [
-            {
-              name: 'topic_sequence_match',
-              expectedValue: tc.expectedTopic,
-            },
-            {
-              name: 'action_sequence_match',
-              expectedValue: `[${(tc.expectedActions ?? []).map((v) => `"${v}"`).join(',')}]`,
-            },
-            {
-              name: 'bot_response_rating',
-              expectedValue: tc.expectedOutcome,
-            },
-          ],
+          number: parsed.testCases.indexOf(tc) + 1,
         })),
       },
     }) as string;

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -129,46 +129,46 @@ testCases:
 
       expect(contents).to.equal(`<?xml version="1.0" encoding="UTF-8"?>
 <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
-  <description>Test</description>
-  <name>Test</name>
-  <subjectType>AGENT</subjectType>
-  <subjectName>MyAgent</subjectName>
-  <testCase>
-    <number>1</number>
-    <inputs>
-      <utterance>List contact names associated with Acme account</utterance>
-    </inputs>
-    <expectation>
-      <name>topic_sequence_match</name>
-      <expectedValue>GeneralCRM</expectedValue>
-    </expectation>
-    <expectation>
-      <name>action_sequence_match</name>
-      <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
-    </expectation>
-    <expectation>
-      <name>bot_response_rating</name>
-      <expectedValue>contacts available name available with Acme are listed</expectedValue>
-    </expectation>
-  </testCase>
-  <testCase>
-    <number>2</number>
-    <inputs>
-      <utterance>List contact emails associated with Acme account</utterance>
-    </inputs>
-    <expectation>
-      <name>topic_sequence_match</name>
-      <expectedValue>GeneralCRM</expectedValue>
-    </expectation>
-    <expectation>
-      <name>action_sequence_match</name>
-      <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
-    </expectation>
-    <expectation>
-      <name>bot_response_rating</name>
-      <expectedValue>contacts available emails available with Acme are listed</expectedValue>
-    </expectation>
-  </testCase>
+    <description>Test</description>
+    <name>Test</name>
+    <subjectName>MyAgent</subjectName>
+    <subjectType>AGENT</subjectType>
+    <testCase>
+        <expectation>
+            <expectedValue>GeneralCRM</expectedValue>
+            <name>topic_sequence_match</name>
+        </expectation>
+        <expectation>
+            <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
+            <name>action_sequence_match</name>
+        </expectation>
+        <expectation>
+            <expectedValue>contacts available name available with Acme are listed</expectedValue>
+            <name>bot_response_rating</name>
+        </expectation>
+        <inputs>
+            <utterance>List contact names associated with Acme account</utterance>
+        </inputs>
+        <number>1</number>
+    </testCase>
+    <testCase>
+        <expectation>
+            <expectedValue>GeneralCRM</expectedValue>
+            <name>topic_sequence_match</name>
+        </expectation>
+        <expectation>
+            <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
+            <name>action_sequence_match</name>
+        </expectation>
+        <expectation>
+            <expectedValue>contacts available emails available with Acme are listed</expectedValue>
+            <name>bot_response_rating</name>
+        </expectation>
+        <inputs>
+            <utterance>List contact emails associated with Acme account</utterance>
+        </inputs>
+        <number>2</number>
+    </testCase>
 </AiEvaluationDefinition>
 `);
     });


### PR DESCRIPTION
### What does this PR do?
generated `aiEvaluationDefinitions` more closely match what the server returns, to avoid excessive git diffs

### What issues does this PR fix or reference?
@W-17875268@