### PR TITLE
fix: emit additional deploy event, even when done W-17891684

### DIFF
--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -330,6 +330,9 @@ export class AgentTester {
     });
 
     deploy.onFinish((result) => {
+      // small deploys like this, 1 file, can happen without an 'update' event being fired
+      // onFinish, emit the update, and then the done event to create proper output
+      void lifecycle.emit(AgentTestCreateLifecycleStages.DeployingMetadata, result);
       void lifecycle.emit(AgentTestCreateLifecycleStages.Done, result);
     });
 


### PR DESCRIPTION
### What does this PR do?
emits an additonal update event on deploy, to avoid 
```bash
 ✔ Creating Local Metadata 864ms
 ✔ Waiting for the org to respond 1.98s
 ◯ Deploying Metadata - Skipped
 ✔ Done 0ms
```
if the deploy happens without emitting an `onUpdate`

### What issues does this PR fix or reference?
@W-17891684@