### PR TITLE
chore: add parameters to use for bundle publishing

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -36,4 +36,5 @@ jobs:
     needs: [getDistTag, npm]
     with:
       branch: 'main'
+      tag: ${{ needs.getDistTag.outputs.tag  }}
     secrets: inherit

--- a/.github/workflows/releaseWithCoreBundle.yml
+++ b/.github/workflows/releaseWithCoreBundle.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: false
         default: 'main'
+      tag:
+        required: false
+        type: string
+        default: 'latest'
+        description: 'tag to publish under, default: latest'
+
   workflow_dispatch:
     inputs:
       branch:
@@ -14,6 +20,11 @@ on:
         type: string
         required: false
         default: 'main'
+      tag:
+        required: false
+        type: string
+        default: 'latest'
+        description: 'tag to publish under, default: latest'
 
 jobs:
   call-release-workflow:
@@ -22,3 +33,4 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ inputs.branch }}
+      tag: ${{ inputs.tag }}


### PR DESCRIPTION
### What does this PR do?
adds options to pass to bundler workflow to publish under a different tag,

useful for testing

### What issues does this PR fix or reference?
