### PR TITLE
fix: allow reading from new MD format W-18131845

### DIFF
--- a/src/agentTester.ts
+++ b/src/agentTester.ts
@@ -46,7 +46,7 @@ export type TestCaseResult = {
     actualValue: string;
     expectedValue: string;
     score: number;
-    result: 'PASS' | 'FAILURE';
+    result: null | 'PASS' | 'FAILURE';
     metricLabel: 'Accuracy' | 'Precision';
     metricExplainability: string;
     status: TestStatus;
@@ -553,11 +553,14 @@ export async function generateTestSpecFromAiEvalDefinition(path: string): Promis
       const expectations = castArray(tc.expectation);
       return {
         utterance: tc.inputs.utterance,
-        expectedTopic: expectations.find((e) => e.name === 'topic_sequence_match')?.expectedValue,
+        // TODO: remove old names once removed in 258 (topic_sequence_match, action_sequence_match, bot_response_rating)
+        expectedTopic: expectations.find((e) => e.name === 'topic_sequence_match' || e.name === 'topic_assertion')
+          ?.expectedValue,
         expectedActions: transformStringToArray(
-          expectations.find((e) => e.name === 'action_sequence_match')?.expectedValue
+          expectations.find((e) => e.name === 'action_sequence_match' || e.name === 'actions_assertion')?.expectedValue
         ),
-        expectedOutcome: expectations.find((e) => e.name === 'bot_response_rating')?.expectedValue,
+        expectedOutcome: expectations.find((e) => e.name === 'bot_response_rating' || e.name === 'output_validation')
+          ?.expectedValue,
       };
     }),
   };

--- a/test/agentTester.test.ts
+++ b/test/agentTester.test.ts
@@ -403,6 +403,53 @@ describe('generateTestSpecFromAiEvalDefinition', () => {
       ],
     });
   });
+  it('should parse 258 AiEvaluationDefinition XML into TestSpec', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+      <description>Test Description</description>
+      <name>TestSpec</name>
+      <subjectType>AGENT</subjectType>
+      <subjectName>WeatherBot</subjectName>
+      <subjectVersion>1</subjectVersion>
+      <testCase>
+        <inputs>
+          <utterance>What's the weather like?</utterance>
+        </inputs>
+        <expectation>
+          <name>topic_assertion</name>
+          <expectedValue>Weather</expectedValue>
+        </expectation>
+        <expectation>
+          <name>actions_assertion</name>
+          <expectedValue>["GetLocation","GetWeather"]</expectedValue>
+        </expectation>
+        <expectation>
+          <name>output_validation</name>
+          <expectedValue>Sunny with a high of 75F</expectedValue>
+        </expectation>
+      </testCase>
+    </AiEvaluationDefinition>`;
+
+    readFileStub.resolves(xml);
+
+    const result = await generateTestSpecFromAiEvalDefinition('test.xml');
+
+    expect(result).to.deep.equal({
+      name: 'TestSpec',
+      description: 'Test Description',
+      subjectType: 'AGENT',
+      subjectName: 'WeatherBot',
+      subjectVersion: 1,
+      testCases: [
+        {
+          utterance: "What's the weather like?",
+          expectedTopic: 'Weather',
+          expectedActions: ['GetLocation', 'GetWeather'],
+          expectedOutcome: 'Sunny with a high of 75F',
+        },
+      ],
+    });
+  });
 
   it('should handle missing optional fields', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6356,7 +6356,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.5.1, yaml@^2.6.1, yaml@^2.7.0, "yaml@^2.7.0 ":
+yaml@^2.5.1, yaml@^2.7.0, "yaml@^2.7.0 ":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
   integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==


### PR DESCRIPTION
### What does this PR do?
the metadata for `AiEvaluationDefinition` is changing in 258 - update the expected xml field names to work with the new names
### What issues does this PR fix or reference?
@W-18131845@