### PR TITLE
fix: add context variables to spec,types,metadata W-18366912

### DIFF
--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -285,6 +285,7 @@ const convertToSpec = (data: AiEvaluationDefinition): TestSpec => ({
     const expectations = ensureArray(tc.expectation);
     return {
       utterance: tc.inputs.utterance,
+      contextVariable: tc.inputs.contextVariable,
       // TODO: remove old names once removed in 258 (topic_sequence_match, action_sequence_match, bot_response_rating)
       expectedTopic: expectations.find((e) => e.name === 'topic_sequence_match' || e.name === 'topic_assertion')
         ?.expectedValue,
@@ -325,6 +326,7 @@ const convertToMetadata = (spec: TestSpec): AiEvaluationDefinition => ({
     ],
     inputs: {
       utterance: tc.utterance,
+      contextVariable: tc.contextVariable,
     },
     number: spec.testCases.indexOf(tc) + 1,
   })),

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -326,7 +326,7 @@ const convertToMetadata = (spec: TestSpec): AiEvaluationDefinition => ({
     ],
     inputs: {
       utterance: tc.utterance,
-      contextVariable: tc.contextVariable,
+      contextVariable: tc.contextVariables?.map((cv) => ({ variableName: cv.name, variableValue: cv.value })),
     },
     number: spec.testCases.indexOf(tc) + 1,
   })),

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,9 +297,10 @@ export type TestCase = {
   expectedOutcome: string | undefined;
   expectedTopic: string | undefined;
   metrics?: Array<(typeof metric)[number]>;
-  contextVariable?: Array<{ variableName: string; variableValue: string }>;
+  contextVariables?: Array<{ name: string; value: string }>;
 };
 
+// yaml representation
 export type TestSpec = {
   name: string;
   description?: string;
@@ -309,6 +310,7 @@ export type TestSpec = {
   testCases: TestCase[];
 };
 
+// metadata xml
 export type AiEvaluationDefinition = {
   description?: string;
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,7 @@ export type TestCase = {
   expectedOutcome: string | undefined;
   expectedTopic: string | undefined;
   metrics?: Array<(typeof metric)[number]>;
+  contextVariable?: Array<{ variableName: string; variableValue: string }>;
 };
 
 export type TestSpec = {
@@ -320,6 +321,7 @@ export type AiEvaluationDefinition = {
       expectedValue?: string;
     }>;
     inputs: {
+      contextVariable?: Array<{ variableName: string; variableValue: string }>;
       utterance: string;
     };
   }>;

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -55,6 +55,16 @@ describe('AgentTest', () => {
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
             metrics: ['coherence', 'output_latency_milliseconds'],
+            contextVariable: [
+              {
+                variableName: 'myVariable',
+                variableValue: 'myValue',
+              },
+              {
+                variableName: 'myVariable2',
+                variableValue: 'myValue2',
+              },
+            ],
           },
           {
             utterance: 'List contact emails associated with Acme account',
@@ -85,6 +95,11 @@ testCases:
     metrics:
       - coherence
       - output_latency_milliseconds
+    contextVariable:
+      - variableName: myVariable
+        variableValue: myValue
+      - variableName: myVariable2
+        variableValue: myValue2
   - utterance: List contact emails associated with Acme account
     expectedActions:
       - IdentifyRecordByName
@@ -112,6 +127,7 @@ testCases:
             expectedActions: ['IdentifyRecordByName', 'QueryRecords'],
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
+            contextVariable: [],
             metrics: [],
           },
         ],
@@ -131,6 +147,7 @@ testCases:
       - QueryRecords
     expectedOutcome: contacts available name available with Acme are listed
     expectedTopic: GeneralCRM
+    contextVariable: []
     metrics: []
 `,
       ]);
@@ -150,6 +167,7 @@ testCases:
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
             metrics: undefined,
+            contextVariable: undefined,
           },
         ],
       };
@@ -205,6 +223,10 @@ testCases:
         <testCase>
           <inputs>
             <utterance>What's the weather like?</utterance>
+            <contextVariable>
+                <variableName>myVariable</variableName>
+                <variableValue>myValue</variableValue>
+            </contextVariable>
           </inputs>
           <expectation>
             <name>topic_sequence_match</name>
@@ -239,6 +261,10 @@ testCases:
         subjectVersion: 1,
         testCases: [
           {
+            contextVariable: {
+              variableName: 'myVariable',
+              variableValue: 'myValue',
+            },
             utterance: "What's the weather like?",
             expectedTopic: 'Weather',
             expectedActions: ['GetLocation', 'GetWeather'],
@@ -262,6 +288,14 @@ testCases:
         <testCase>
           <inputs>
             <utterance>What's the weather like?</utterance>
+             <contextVariable>
+                <variableName>myVariable</variableName>
+                <variableValue>myValue</variableValue>
+            </contextVariable>
+            <contextVariable>
+                <variableName>myVariable2</variableName>
+                <variableValue>myValue2</variableValue>
+            </contextVariable>
           </inputs>
           <expectation>
             <name>topic_assertion</name>
@@ -300,6 +334,16 @@ testCases:
         testCases: [
           {
             utterance: "What's the weather like?",
+            contextVariable: [
+              {
+                variableName: 'myVariable',
+                variableValue: 'myValue',
+              },
+              {
+                variableName: 'myVariable2',
+                variableValue: 'myValue2',
+              },
+            ],
             expectedTopic: 'Weather',
             expectedActions: ['GetLocation', 'GetWeather'],
             expectedOutcome: 'Sunny with a high of 75F',
@@ -341,6 +385,7 @@ testCases:
         testCases: [
           {
             utterance: "What's the weather like?",
+            contextVariable: undefined,
             expectedTopic: 'Weather',
             expectedActions: [],
             metrics: [],
@@ -361,6 +406,10 @@ testCases:
         <testCase>
           <inputs>
             <utterance>What's the weather like?</utterance>
+            <contextVariable>
+              <variableName>myVariable</variableName>
+              <variableValue>myValue</variableValue>
+            </contextVariable>
           </inputs>
           <expectation>
             <name>action_sequence_match</name>
@@ -369,6 +418,10 @@ testCases:
         </testCase>
         <testCase>
           <inputs>
+             <contextVariable>
+                <variableName>myVariable</variableName>
+                <variableValue>myValue</variableValue>
+            </contextVariable>
             <utterance>Will it rain tomorrow?</utterance>
           </inputs>
           <expectation>

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -55,14 +55,14 @@ describe('AgentTest', () => {
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
             metrics: ['coherence', 'output_latency_milliseconds'],
-            contextVariable: [
+            contextVariables: [
               {
-                variableName: 'myVariable',
-                variableValue: 'myValue',
+                name: 'myVariable',
+                value: 'myValue',
               },
               {
-                variableName: 'myVariable2',
-                variableValue: 'myValue2',
+                name: 'myVariable2',
+                value: 'myValue2',
               },
             ],
           },
@@ -95,11 +95,11 @@ testCases:
     metrics:
       - coherence
       - output_latency_milliseconds
-    contextVariable:
-      - variableName: myVariable
-        variableValue: myValue
-      - variableName: myVariable2
-        variableValue: myValue2
+    contextVariables:
+      - name: myVariable
+        value: myValue
+      - name: myVariable2
+        value: myValue2
   - utterance: List contact emails associated with Acme account
     expectedActions:
       - IdentifyRecordByName
@@ -127,7 +127,7 @@ testCases:
             expectedActions: ['IdentifyRecordByName', 'QueryRecords'],
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
-            contextVariable: [],
+            contextVariables: [],
             metrics: [],
           },
         ],
@@ -147,7 +147,7 @@ testCases:
       - QueryRecords
     expectedOutcome: contacts available name available with Acme are listed
     expectedTopic: GeneralCRM
-    contextVariable: []
+    contextVariables: []
     metrics: []
 `,
       ]);
@@ -167,7 +167,7 @@ testCases:
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
             metrics: undefined,
-            contextVariable: undefined,
+            contextVariables: undefined,
           },
         ],
       };
@@ -224,8 +224,8 @@ testCases:
           <inputs>
             <utterance>What's the weather like?</utterance>
             <contextVariable>
-                <variableName>myVariable</variableName>
-                <variableValue>myValue</variableValue>
+                <name>myVariable</name>
+                <value>myValue</value>
             </contextVariable>
           </inputs>
           <expectation>
@@ -262,8 +262,8 @@ testCases:
         testCases: [
           {
             contextVariable: {
-              variableName: 'myVariable',
-              variableValue: 'myValue',
+              name: 'myVariable',
+              value: 'myValue',
             },
             utterance: "What's the weather like?",
             expectedTopic: 'Weather',
@@ -289,12 +289,12 @@ testCases:
           <inputs>
             <utterance>What's the weather like?</utterance>
              <contextVariable>
-                <variableName>myVariable</variableName>
-                <variableValue>myValue</variableValue>
+                <name>myVariable</name>
+                <value>myValue</value>
             </contextVariable>
             <contextVariable>
-                <variableName>myVariable2</variableName>
-                <variableValue>myValue2</variableValue>
+                <name>myVariable2</name>
+                <value>myValue2</value>
             </contextVariable>
           </inputs>
           <expectation>
@@ -336,12 +336,12 @@ testCases:
             utterance: "What's the weather like?",
             contextVariable: [
               {
-                variableName: 'myVariable',
-                variableValue: 'myValue',
+                name: 'myVariable',
+                value: 'myValue',
               },
               {
-                variableName: 'myVariable2',
-                variableValue: 'myValue2',
+                name: 'myVariable2',
+                value: 'myValue2',
               },
             ],
             expectedTopic: 'Weather',
@@ -407,8 +407,8 @@ testCases:
           <inputs>
             <utterance>What's the weather like?</utterance>
             <contextVariable>
-              <variableName>myVariable</variableName>
-              <variableValue>myValue</variableValue>
+              <name>myVariable</name>
+              <value>myValue</value>
             </contextVariable>
           </inputs>
           <expectation>
@@ -419,8 +419,8 @@ testCases:
         <testCase>
           <inputs>
              <contextVariable>
-                <variableName>myVariable</variableName>
-                <variableValue>myValue</variableValue>
+                <name>myVariable</name>
+                <value>myValue</value>
             </contextVariable>
             <utterance>Will it rain tomorrow?</utterance>
           </inputs>


### PR DESCRIPTION
### What does this PR do?

onces `contextVariables` are supported in metadata, we need to be able to create them via specs

adds functionality to add `contextVariables`
```xml
    <testCase>
        <number>int</number>
        <inputs>
            <utterance>string</utterance>
            <contextVariable>
                <variableName>string</variableName>
                <variableValue>string</variableValue>
            </contextVariable>
        </inputs>
```

---

```yaml
    contextVariables:
      - name: myVariable
        value: myValue
      - name: myVariable2
        value: myValue2
```

### What issues does this PR fix or reference?
@W-18366912@