### PR TITLE
fix: create expected actions with ' instead of " W-18383948

### DIFF
--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -308,7 +308,7 @@ const convertToMetadata = (spec: TestSpec): AiEvaluationDefinition => ({
         name: 'topic_sequence_match',
       },
       {
-        expectedValue: `[${(tc.expectedActions ?? []).map((v) => `"${v}"`).join(',')}]`,
+        expectedValue: `[${(tc.expectedActions ?? []).map((v) => `'${v}'`).join(',')}]`,
         name: 'action_sequence_match',
       },
       {

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -425,7 +425,7 @@ testCases:
             <name>topic_sequence_match</name>
         </expectation>
         <expectation>
-            <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
+            <expectedValue>[&apos;IdentifyRecordByName&apos;,&apos;QueryRecords&apos;]</expectedValue>
             <name>action_sequence_match</name>
         </expectation>
         <expectation>
@@ -443,7 +443,7 @@ testCases:
             <name>topic_sequence_match</name>
         </expectation>
         <expectation>
-            <expectedValue>[&quot;IdentifyRecordByName&quot;,&quot;QueryRecords&quot;]</expectedValue>
+            <expectedValue>[&apos;IdentifyRecordByName&apos;,&apos;QueryRecords&apos;]</expectedValue>
             <name>action_sequence_match</name>
         </expectation>
         <expectation>


### PR DESCRIPTION
### What does this PR do?
```xml
<expectedValue>[&quot;AnswerQuestionsWithKnowledge&quot;]
```

which should be 
```xml
<expectedValue>[&apos;AnswerQuestionsWithKnowledge&apos;]
```

### What issues does this PR fix or reference?
@W-18383948@