### PR TITLE
fix: use generateApiName from core W-18394863

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/forcedotcom/agents.git"
   },
   "dependencies": {
-    "@salesforce/core": "^8.10.0",
+    "@salesforce/core": "^8.10.1",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/source-deploy-retrieve": "^12.19.3",
     "fast-xml-parser": "^4.5.3",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,7 +8,7 @@
 import { inspect } from 'node:util';
 import * as path from 'node:path';
 import { stat, readdir } from 'node:fs/promises';
-import { Connection, Lifecycle, Logger, Messages, SfError, SfProject } from '@salesforce/core';
+import { Connection, Lifecycle, Logger, Messages, SfError, SfProject, generateApiName } from '@salesforce/core';
 import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
 import {
@@ -138,7 +138,7 @@ export class Agent {
     getLogger().debug(`Creating agent using config: ${inspect(config)} in project: ${project.getPath()}`);
     await Lifecycle.getInstance().emit(AgentCreateLifecycleStages.Creating, {});
     if (!config.agentSettings.agentApiName) {
-      config.agentSettings.agentApiName = generateAgentApiName(config.agentSettings?.agentName);
+      config.agentSettings.agentApiName = generateApiName(config.agentSettings?.agentName);
     }
     const response = await maybeMock.request<AgentCreateResponse>('POST', url, config);
 
@@ -260,25 +260,6 @@ const verifyAgentSpecConfig = (config: AgentJobSpecCreateConfig): void => {
   if (!agentType || !role || !companyName || !companyDescription) {
     throw messages.createError('invalidAgentSpecConfig');
   }
-};
-
-/**
- * Generate an API name from an agent name. Matches what the UI does.
- */
-export const generateAgentApiName = (agentName: string): string => {
-  const maxLength = 255;
-  let apiName = agentName;
-  apiName = apiName.replace(/[\W_]+/g, '_');
-  if (apiName.charAt(0).match(/_/i)) {
-    apiName = apiName.slice(1);
-  }
-  apiName = apiName
-    .replace(/(^\d+)/, 'X$1')
-    .slice(0, maxLength)
-    .replace(/_$/, '');
-  const genLogger = Logger.childFromRoot('Agent-GenApiName');
-  genLogger.debug(`Generated Agent API name: [${apiName}] from Agent name: [${agentName}]`);
-  return apiName;
 };
 
 // Decodes all HTML entities in ai-assist API responses.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export {
   type TestCaseResult,
   type TestStatus,
 } from './types';
-export { Agent, AgentCreateLifecycleStages, generateAgentApiName } from './agent';
+export { Agent, AgentCreateLifecycleStages } from './agent';
 export { AgentTester } from './agentTester';
 export { AgentTest, AgentTestCreateLifecycleStages } from './agentTest';
 export { convertTestResultsToFormat, humanFriendlyName } from './agentTestResults';

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -9,8 +9,7 @@ import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection, SfProject } from '@salesforce/core';
 import { ComponentSetBuilder, ComponentSet, MetadataApiRetrieve } from '@salesforce/source-deploy-retrieve';
-import { Agent, generateAgentApiName } from '../src/agent';
-import { type AgentCreateConfig } from '../src/types';
+import { Agent, type AgentCreateConfig } from '../src';
 
 describe('Agents', () => {
   const $$ = new TestContext();
@@ -114,26 +113,5 @@ describe('Agents', () => {
     expect(response).to.have.property('isSuccess', true);
     expect(response).to.not.have.property('agentId');
     expect(response).to.have.property('agentDefinition');
-  });
-});
-
-describe('generateAgentApiName', () => {
-  it('should create valid agent API name with spaces', () => {
-    expect(generateAgentApiName('My Test Agent')).to.equal('My_Test_Agent');
-  });
-  it('should create valid agent API name with no spaces', () => {
-    expect(generateAgentApiName('MyTestAgent')).to.equal('MyTestAgent');
-  });
-  it('should create valid agent API name with beginning underscore', () => {
-    expect(generateAgentApiName('_My Test Agent')).to.equal('My_Test_Agent');
-  });
-  it('should create valid agent API name with multiple beginning underscores', () => {
-    expect(generateAgentApiName('___My Test Agent')).to.equal('My_Test_Agent');
-  });
-  it('should create valid agent API name with special characters', () => {
-    expect(generateAgentApiName('My ()*&^$% Test @!""; Agent')).to.equal('My_Test_Agent');
-  });
-  it('should create valid agent API name with weird spacing', () => {
-    expect(generateAgentApiName(' My   Test Agent  ')).to.equal('My_Test_Agent');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,10 +639,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.10.0", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.7":
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.0.tgz#017fe618b1dd086298d1133a6ed0f509d56ea495"
-  integrity sha512-gStIzB8wPjjwyKZCK8eSfwkLiv9h9qzP64b51U5THBskEjm6Sw6ZyWqZmCzA85FEZ/IM/n1nh4e3R9JoG6Z6mA==
+"@salesforce/core@^8.10.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.7":
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.1.tgz#d80283ac9515a5e38677c1aadd4ab91a00866f0d"
+  integrity sha512-2Pk8MUlO9HTUo6K9bpFxLyc7KUxuIIgmGrFliCQJiUW2N85uvMdB8F+WJD2b8ZOH+6bQ575qynmJlbKmfcLAtQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.7.0"
     "@salesforce/kit" "^3.2.2"


### PR DESCRIPTION
### What does this PR do?
updates library to use `generateApiName` from core

depends on https://github.com/forcedotcom/sfdx-core/pull/1183

### What issues does this PR fix or reference?
@W-18394863@