### PR TITLE
Wr/custom evals W-18407960

### DIFF
--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -286,6 +286,7 @@ const convertToSpec = (data: AiEvaluationDefinition): TestSpec => ({
     return {
       utterance: tc.inputs.utterance,
       contextVariable: tc.inputs.contextVariable,
+      customEvaluation: expectations.filter((e) => 'parameter' in e),
       // TODO: remove old names once removed in 258 (topic_sequence_match, action_sequence_match, bot_response_rating)
       expectedTopic: expectations.find((e) => e.name === 'topic_sequence_match' || e.name === 'topic_assertion')
         ?.expectedValue,

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,7 @@ export type AgentTestResultsResponse = {
 
 export type AvailableDefinition = Omit<FileProperties, 'manageableState' | 'namespacePrefix'>;
 
+// yaml type
 export type TestCase = {
   utterance: string;
   expectedActions: string[] | undefined;
@@ -298,6 +299,11 @@ export type TestCase = {
   expectedTopic: string | undefined;
   metrics?: Array<(typeof metric)[number]>;
   contextVariables?: Array<{ name: string; value: string }>;
+  customEvaluation?: Array<{
+    label?: string;
+    name: string;
+    parameters?: Array<{ name: string; value: string; isReference: boolean }>;
+  }>;
 };
 
 // yaml representation
@@ -321,6 +327,8 @@ export type AiEvaluationDefinition = {
     expectation: Array<{
       name: string;
       expectedValue?: string;
+      label?: string;
+      parameter?: Array<{ name: string; value: string; isReference: boolean }>;
     }>;
     inputs: {
       contextVariable?: Array<{ variableName: string; variableValue: string }>;
@@ -328,6 +336,46 @@ export type AiEvaluationDefinition = {
     };
   }>;
 };
+
+// export type AiEvaluationDefinition = {
+//   description?: string;
+//   name: string;
+//   subjectType: 'AGENT';
+//   subjectName: string;
+//   subjectVersion?: string;
+//   testCase: Array<{
+//     expectation: Array<
+//       | {
+//           // OOTB metrics
+//           name: string;
+//         }
+//       | {
+//           // topic/action/outcome matching
+//           name:
+//             | 'topic_sequence_match'
+//             | 'topic_assertion'
+//             | 'action_sequence_match'
+//             | 'actions_assertion'
+//             | 'bot_response_rating'
+//             | 'output_validation';
+//           expectedValue: string;
+//         }
+//       | {
+//           // custom evaluators
+//           name: string;
+//           label: string;
+//           parameter: Array<{ name: string; value: string; isReference: boolean }>;
+//           //        | { name: 'operator'; value: string; isReference: false }
+//           //         | { name: 'actual'; value: string; isReference: true }
+//           //         | { name: 'expected'; value: string; isReference: boolean }
+//         }
+//     >;
+//     inputs: {
+//       contextVariable?: Array<{ variableName: string; variableValue: string }>;
+//       utterance: string;
+//     };
+//   }>;
+// };
 
 // ====================================================
 //               Agent Preview Types

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,7 +291,7 @@ export type AgentTestResultsResponse = {
 
 export type AvailableDefinition = Omit<FileProperties, 'manageableState' | 'namespacePrefix'>;
 
-// yaml type
+// yaml type representation
 export type TestCase = {
   utterance: string;
   expectedActions: string[] | undefined;
@@ -299,10 +299,14 @@ export type TestCase = {
   expectedTopic: string | undefined;
   metrics?: Array<(typeof metric)[number]>;
   contextVariables?: Array<{ name: string; value: string }>;
-  customEvaluation?: Array<{
-    label?: string;
+  customEvaluations?: Array<{
+    label: string;
     name: string;
-    parameters?: Array<{ name: string; value: string; isReference: boolean }>;
+    parameters: Array<
+      | { name: 'operator'; value: string; isReference: false }
+      | { name: 'actual'; value: string; isReference: true }
+      | { name: 'expected'; value: string; isReference: boolean }
+    >;
   }>;
 };
 
@@ -316,6 +320,32 @@ export type TestSpec = {
   testCases: TestCase[];
 };
 
+// Metadata XML representation of what's required for a metric (just name)
+export type MetadataMetric = { name: string };
+// Metadata XML representation of evaluation (name / expectedValue)
+export type MetadataExpectation = {
+  // topic/action/outcome matching
+  name:
+    | 'topic_sequence_match'
+    | 'topic_assertion'
+    | 'action_sequence_match'
+    | 'actions_assertion'
+    | 'bot_response_rating'
+    | 'output_validation';
+  expectedValue: string;
+};
+
+export type MetadataCustomEvaluation = {
+  // custom evaluators
+  name: string;
+  label: string;
+  parameter: Array<
+    | { name: 'operator'; value: string; isReference: false }
+    | { name: 'actual'; value: string; isReference: true }
+    | { name: 'expected'; value: string; isReference: boolean }
+  >;
+};
+
 // metadata xml
 export type AiEvaluationDefinition = {
   description?: string;
@@ -324,58 +354,13 @@ export type AiEvaluationDefinition = {
   subjectName: string;
   subjectVersion?: string;
   testCase: Array<{
-    expectation: Array<{
-      name: string;
-      expectedValue?: string;
-      label?: string;
-      parameter?: Array<{ name: string; value: string; isReference: boolean }>;
-    }>;
+    expectation: Array<MetadataMetric | MetadataExpectation | MetadataCustomEvaluation>;
     inputs: {
       contextVariable?: Array<{ variableName: string; variableValue: string }>;
       utterance: string;
     };
   }>;
 };
-
-// export type AiEvaluationDefinition = {
-//   description?: string;
-//   name: string;
-//   subjectType: 'AGENT';
-//   subjectName: string;
-//   subjectVersion?: string;
-//   testCase: Array<{
-//     expectation: Array<
-//       | {
-//           // OOTB metrics
-//           name: string;
-//         }
-//       | {
-//           // topic/action/outcome matching
-//           name:
-//             | 'topic_sequence_match'
-//             | 'topic_assertion'
-//             | 'action_sequence_match'
-//             | 'actions_assertion'
-//             | 'bot_response_rating'
-//             | 'output_validation';
-//           expectedValue: string;
-//         }
-//       | {
-//           // custom evaluators
-//           name: string;
-//           label: string;
-//           parameter: Array<{ name: string; value: string; isReference: boolean }>;
-//           //        | { name: 'operator'; value: string; isReference: false }
-//           //         | { name: 'actual'; value: string; isReference: true }
-//           //         | { name: 'expected'; value: string; isReference: boolean }
-//         }
-//     >;
-//     inputs: {
-//       contextVariable?: Array<{ variableName: string; variableValue: string }>;
-//       utterance: string;
-//     };
-//   }>;
-// };
 
 // ====================================================
 //               Agent Preview Types

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -51,7 +51,7 @@ describe('AgentTest', () => {
         testCases: [
           {
             utterance: 'List contact names associated with Acme account',
-            customEvaluation: [
+            customEvaluations: [
               {
                 name: 'has_the_rhythm',
                 label: 'has the real rhythm',
@@ -103,7 +103,7 @@ subjectType: AGENT
 subjectName: MyAgent
 testCases:
   - utterance: List contact names associated with Acme account
-    customEvaluation:
+    customEvaluations:
       - name: has_the_rhythm
         label: has the real rhythm
         parameters:
@@ -197,7 +197,7 @@ testCases:
             expectedTopic: 'GeneralCRM',
             metrics: undefined,
             contextVariables: undefined,
-            customEvaluation: undefined,
+            customEvaluations: undefined,
           },
         ],
       };
@@ -316,11 +316,11 @@ testCases:
             },
             utterance: "What's the weather like?",
             expectedTopic: 'Weather',
-            customEvaluation: [
+            customEvaluations: [
               {
                 label: 'my Custom Comparison',
                 name: 'string_comparisson',
-                parameter: [
+                parameters: [
                   {
                     isReference: false,
                     name: 'operator',
@@ -438,11 +438,11 @@ testCases:
             ],
             expectedTopic: 'Weather',
             expectedActions: ['GetLocation', 'GetWeather'],
-            customEvaluation: [
+            customEvaluations: [
               {
                 label: 'my Custom Comparison',
                 name: 'string_comparisson',
-                parameter: [
+                parameters: [
                   {
                     isReference: false,
                     name: 'operator',
@@ -502,7 +502,7 @@ testCases:
           {
             utterance: "What's the weather like?",
             contextVariable: undefined,
-            customEvaluation: [],
+            customEvaluations: [],
             expectedTopic: 'Weather',
             expectedActions: [],
             metrics: [],

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -51,6 +51,22 @@ describe('AgentTest', () => {
         testCases: [
           {
             utterance: 'List contact names associated with Acme account',
+            customEvaluation: [
+              {
+                name: 'has_the_rhythm',
+                label: 'has the real rhythm',
+                parameters: [
+                  { name: 'operator', value: 'equals', isReference: false },
+                  { name: 'expected', value: 'Jerry', isReference: false },
+                  {
+                    name: 'actual',
+                    isReference: true,
+                    value:
+                      "$.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify",
+                  },
+                ],
+              },
+            ],
             expectedActions: ['IdentifyRecordByName', 'QueryRecords'],
             expectedOutcome: 'contacts available name available with Acme are listed',
             expectedTopic: 'GeneralCRM',
@@ -79,14 +95,27 @@ describe('AgentTest', () => {
 
       await agentTest.writeTestSpec('test-spec.yaml');
 
-      expect(writeFileStub.firstCall.args).to.deep.equal([
-        'test-spec.yaml',
+      expect(writeFileStub.firstCall.args[0]).to.equal('test-spec.yaml');
+      expect(writeFileStub.firstCall.args[1]).to.equal(
         `name: Test
 description: Test
 subjectType: AGENT
 subjectName: MyAgent
 testCases:
   - utterance: List contact names associated with Acme account
+    customEvaluation:
+      - name: has_the_rhythm
+        label: has the real rhythm
+        parameters:
+          - name: operator
+            value: equals
+            isReference: false
+          - name: expected
+            value: Jerry
+            isReference: false
+          - name: actual
+            isReference: true
+            value: $.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify
     expectedActions:
       - IdentifyRecordByName
       - QueryRecords
@@ -110,8 +139,8 @@ testCases:
       - coherence
       - factuality
       - instruction_following
-`,
-      ]);
+`
+      );
     });
 
     it('should remove empty strings', async () => {
@@ -168,6 +197,7 @@ testCases:
             expectedTopic: 'GeneralCRM',
             metrics: undefined,
             contextVariables: undefined,
+            customEvaluation: undefined,
           },
         ],
       };
@@ -229,6 +259,25 @@ testCases:
             </contextVariable>
           </inputs>
           <expectation>
+            <name>string_comparisson</name>
+            <label>my Custom Comparison</label>
+            <parameter>
+                <name>operator</name>
+                <value>equals</value>
+                <isReference>false</isReference>
+            </parameter>
+            <parameter>
+                <name>actual</name>
+                <value>$.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify</value>
+                <isReference>true</isReference>
+            </parameter>
+            <parameter>
+                <name>expected</name>
+                <value>Jerry</value>
+                <isReference>false</isReference>
+            </parameter>
+        </expectation>
+          <expectation>
             <name>topic_sequence_match</name>
             <expectedValue>Weather</expectedValue>
           </expectation>
@@ -267,6 +316,30 @@ testCases:
             },
             utterance: "What's the weather like?",
             expectedTopic: 'Weather',
+            customEvaluation: [
+              {
+                label: 'my Custom Comparison',
+                name: 'string_comparisson',
+                parameter: [
+                  {
+                    isReference: false,
+                    name: 'operator',
+                    value: 'equals',
+                  },
+                  {
+                    isReference: true,
+                    name: 'actual',
+                    value:
+                      "$.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify",
+                  },
+                  {
+                    isReference: false,
+                    name: 'expected',
+                    value: 'Jerry',
+                  },
+                ],
+              },
+            ],
             expectedActions: ['GetLocation', 'GetWeather'],
             expectedOutcome: 'Sunny with a high of 75F',
             metrics: ['completeness', 'coherence'],
@@ -300,6 +373,25 @@ testCases:
           <expectation>
             <name>topic_assertion</name>
             <expectedValue>Weather</expectedValue>
+          </expectation>
+          <expectation>
+            <name>string_comparisson</name>
+            <label>my Custom Comparison</label>
+            <parameter>
+                <name>operator</name>
+                <value>equals</value>
+                <isReference>false</isReference>
+            </parameter>
+            <parameter>
+                <name>actual</name>
+                <value>$.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify</value>
+                <isReference>true</isReference>
+            </parameter>
+            <parameter>
+                <name>expected</name>
+                <value>Jerry</value>
+                <isReference>false</isReference>
+            </parameter>
           </expectation>
           <expectation>
             <name>actions_assertion</name>
@@ -346,6 +438,30 @@ testCases:
             ],
             expectedTopic: 'Weather',
             expectedActions: ['GetLocation', 'GetWeather'],
+            customEvaluation: [
+              {
+                label: 'my Custom Comparison',
+                name: 'string_comparisson',
+                parameter: [
+                  {
+                    isReference: false,
+                    name: 'operator',
+                    value: 'equals',
+                  },
+                  {
+                    isReference: true,
+                    name: 'actual',
+                    value:
+                      "$.generatedData.invokedActions[*][?(@.function.name == 'SvcCopilotTmpl__SendEmailVerificationCode')].function.input.customerToVerify",
+                  },
+                  {
+                    isReference: false,
+                    name: 'expected',
+                    value: 'Jerry',
+                  },
+                ],
+              },
+            ],
             expectedOutcome: 'Sunny with a high of 75F',
             metrics: ['completeness', 'conciseness', 'output_latency_milliseconds'],
           },
@@ -386,6 +502,7 @@ testCases:
           {
             utterance: "What's the weather like?",
             contextVariable: undefined,
+            customEvaluation: [],
             expectedTopic: 'Weather',
             expectedActions: [],
             metrics: [],


### PR DESCRIPTION
### What does this PR do?

updates spec to accept custom evals
```yaml
   customEvaluations:
    - label: Expected Recipient Match
      name: string_comparison
      parameters:
       - name: operator
         value: equals
         isReference: false
       - name: actual
         value: $.generatedData.invokedActions[*][?(@.function.name == 'DraftGenericReplyEmail')].function.input.recipient
         isReference: true
       - name: expected
         value: Jon
         isReference: false
```

### What issues does this PR fix or reference?
@W-18407960@