### PR TITLE
feat: add support for activating and deactivating agents (W-19127473)

### DIFF
--- a/messages/agents.md
+++ b/messages/agents.md
@@ -21,3 +21,7 @@ The "nameOrId" agent option is required when creating an Agent instance.
 # agentIsDeleted
 
 The %s agent is deleted and cannot change activation state.
+
+# agentActivationError
+
+Changing agent activation status was unsuccessful due to %s.

--- a/messages/agents.md
+++ b/messages/agents.md
@@ -17,3 +17,7 @@ Retrieve the agent metadata using the "project retrieve start" command.
 # missingAgentNameOrId
 
 The "nameOrId" agent option is required when creating an Agent instance.
+
+# agentIsDeleted
+
+The %s agent is deleted and cannot change activation state.

--- a/messages/agents.md
+++ b/messages/agents.md
@@ -20,8 +20,8 @@ The "nameOrId" agent option is required when creating an Agent instance.
 
 # agentIsDeleted
 
-The %s agent is deleted and cannot change activation state.
+The %s agent has been deleted and its activation state can't be changed.
 
 # agentActivationError
 
-Changing agent activation status was unsuccessful due to %s.
+Changing the agent's activation status was unsuccessful due to %s.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,6 +18,7 @@ import {
   type AgentJobSpecCreateConfig,
   type AgentOptions,
   type BotMetadata,
+  type BotVersionMetadata,
   type DraftAgentTopicsBody,
   type DraftAgentTopicsResponse,
 } from './types.js';
@@ -69,7 +70,7 @@ export class Agent {
   private id?: string;
   // The name of the agent (Bot)
   private name?: string;
-  // The metadata fields for the agent (Bot)
+  // The metadata fields for the agent (Bot and BotVersion)
   private botMetadata?: BotMetadata;
 
   /**
@@ -120,6 +121,19 @@ export class Agent {
     }
 
     return bots;
+  }
+
+  /**
+   * Lists all agents in the org.
+   *
+   * @param connection a `Connection` to an org.
+   * @returns the list of agents
+   */
+  public static async listRemote(connection: Connection): Promise<BotMetadata[]> {
+    const agentsQuery = await connection.query<BotMetadata>(
+      'SELECT FIELDS(ALL), (SELECT FIELDS(ALL) FROM BotVersions LIMIT 10) FROM BotDefinition LIMIT 100'
+    );
+    return agentsQuery.records;
   }
 
   /**
@@ -269,20 +283,70 @@ export class Agent {
   }
 
   /**
-   * Queries BotDefinition for the bot metadata and assigns:
+   * Queries BotDefinition and BotVersions (limited to 10) for the bot metadata and assigns:
    * 1. this.id
    * 2. this.name
    * 3. this.botMetadata
+   * 4. this.botVersionMetadata
    */
   public async getBotMetadata(): Promise<BotMetadata> {
     if (!this.botMetadata) {
       const whereClause = this.id ? `Id = '${this.id}'` : `DeveloperName = '${this.name as string}'`;
-      const query = `SELECT FIELDS(ALL) FROM BotDefinition WHERE ${whereClause} LIMIT 1`;
+      const query = `SELECT FIELDS(ALL), (SELECT FIELDS(ALL) FROM BotVersions LIMIT 10) FROM BotDefinition WHERE ${whereClause} LIMIT 1`;
       this.botMetadata = await this.options.connection.singleRecordQuery<BotMetadata>(query);
       this.id = this.botMetadata.Id;
       this.name = this.botMetadata.DeveloperName;
     }
     return this.botMetadata;
+  }
+
+  /**
+   * Returns the latest bot version metadata.
+   *
+   * @returns the latest bot version metadata
+   */
+  public async getLatestBotVersionMetadata(): Promise<BotVersionMetadata> {
+    if (!this.botMetadata) {
+      this.botMetadata = await this.getBotMetadata();
+    }
+    const botVersions = this.botMetadata.BotVersions.records;
+    return botVersions[botVersions.length - 1];
+  }
+
+  /**
+   * Activates the agent.
+   *
+   * @returns void
+   */
+  public async activate(): Promise<void> {
+    return this.setAgentStatus('Active');
+  }
+
+  /**
+   * Deactivates the agent.
+   *
+   * @returns void
+   */
+  public async deactivate(): Promise<void> {
+    return this.setAgentStatus('Inactive');
+  }
+
+  private async setAgentStatus(desiredState: 'Active' | 'Inactive'): Promise<void> {
+    const botMetadata = await this.getBotMetadata();
+    const botVersionMetadata = await this.getLatestBotVersionMetadata();
+
+    if (botMetadata.IsDeleted) {
+      throw messages.createError('agentIsDeleted', [botMetadata.DeveloperName]);
+    }
+
+    if (botVersionMetadata.Status === desiredState) {
+      getLogger().debug(`Agent ${botMetadata.DeveloperName} is already ${desiredState}. Nothing to do.`);
+      return;
+    }
+
+    const url = `/connect/bot-versions/${botVersionMetadata.Id}/activation`;
+    const maybeMock = new MaybeMock(this.options.connection);
+    await maybeMock.request('POST', url, { status: desiredState });
   }
 }
 
@@ -297,3 +361,9 @@ const verifyAgentSpecConfig = (config: AgentJobSpecCreateConfig): void => {
 // Decodes all HTML entities in ai-assist API responses.
 const decodeResponse = <T extends object>(response: T): T =>
   JSON.parse(decodeHtmlEntities(JSON.stringify(response))) as T;
+
+// QUERY_RESULT=$(sf data query -q "SELECT Id, DeveloperName, (SELECT Status, Id FROM BotVersions) FROM BotDefinition WHERE IsDeleted = false AND DeveloperName='$AGENT_API_NAME'" --json)
+// BOT_VERSION_ID=$(echo "$QUERY_RESULT" | jq -r '.result.records[0].BotVersions.records[0].Id')
+// CURRENT_STATUS=$(echo "$QUERY_RESULT" | jq -r '.result.records[0].BotVersions.records[0].Status')
+
+// sf api request rest "/services/data/v60.0/connect/bot-versions/$BOT_VERSION_ID/activation"  --method POST --body '{"status": "'"${DESIRED_STATE}"'"}'

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,7 @@ import {
   type AgentJobSpec,
   type AgentJobSpecCreateConfig,
   type AgentOptions,
+  type BotActivationResponse,
   type BotMetadata,
   type BotVersionMetadata,
   type DraftAgentTopicsBody,
@@ -346,7 +347,12 @@ export class Agent {
 
     const url = `/connect/bot-versions/${botVersionMetadata.Id}/activation`;
     const maybeMock = new MaybeMock(this.options.connection);
-    await maybeMock.request('POST', url, { status: desiredState });
+    const response = await maybeMock.request<BotActivationResponse>('POST', url, { status: desiredState });
+    if (response.success) {
+      this.botMetadata!.BotVersions.records[0].Status = response.isActivated ? 'Active' : 'Inactive';
+    } else {
+      throw messages.createError('agentActivationError', [response.messages?.toString() ?? 'unknown']);
+    }
   }
 }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -361,9 +361,3 @@ const verifyAgentSpecConfig = (config: AgentJobSpecCreateConfig): void => {
 // Decodes all HTML entities in ai-assist API responses.
 const decodeResponse = <T extends object>(response: T): T =>
   JSON.parse(decodeHtmlEntities(JSON.stringify(response))) as T;
-
-// QUERY_RESULT=$(sf data query -q "SELECT Id, DeveloperName, (SELECT Status, Id FROM BotVersions) FROM BotDefinition WHERE IsDeleted = false AND DeveloperName='$AGENT_API_NAME'" --json)
-// BOT_VERSION_ID=$(echo "$QUERY_RESULT" | jq -r '.result.records[0].BotVersions.records[0].Id')
-// CURRENT_STATUS=$(echo "$QUERY_RESULT" | jq -r '.result.records[0].BotVersions.records[0].Status')
-
-// sf api request rest "/services/data/v60.0/connect/bot-versions/$BOT_VERSION_ID/activation"  --method POST --body '{"status": "'"${DESIRED_STATE}"'"}'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export {
   type AgentPreviewStartResponse,
   type AgentPreviewSendResponse,
   type AgentPreviewEndResponse,
+  type BotMetadata,
+  type BotVersionMetadata,
   type DraftAgentTopics,
   type DraftAgentTopicsBody,
   type DraftAgentTopicsResponse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export type AgentOptions = {
 
 export type BotMetadata = {
   Id: string;
-  IsDeleted: false;
+  IsDeleted: boolean;
   DeveloperName: string;
   MasterLabel: string;
   CreatedDate: string; // eg., "2025-02-13T18:25:17.000+0000",
@@ -40,6 +40,24 @@ export type BotMetadata = {
   Type: string;
   AgentType: string;
   AgentTemplate: null | string;
+  BotVersions: { records: BotVersionMetadata[] };
+};
+
+export type BotVersionMetadata = {
+  Id: string;
+  Status: 'Active' | 'Inactive';
+  IsDeleted: boolean;
+  BotDefinitionId: string;
+  DeveloperName: string;
+  CreatedDate: string; // eg., "2025-06-02T23:16:20.000+0000",
+  CreatedById: string;
+  LastModifiedDate: string; // eg., "2025-06-02T23:16:21.000+0000",
+  LastModifiedById: string;
+  SystemModstamp: string; // eg., "2025-06-02T23:16:21.000+0000",
+  VersionNumber: number;
+  CopilotPrimaryLanguage: null | string;
+  ToneType: AgentTone;
+  CopilotSecondaryLanguages: null | string[];
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,12 @@ export type BotVersionMetadata = {
   CopilotSecondaryLanguages: null | string[];
 };
 
+export type BotActivationResponse = {
+  success: boolean;
+  isActivated: boolean;
+  messages?: string[];
+};
+
 /**
  * An agent job spec is a list of job titles and descriptions
  * to be performed by the agent.


### PR DESCRIPTION
### What does this PR do?
Adds the ability to activate and deactivate agents.
Adds a static method to get all agents from an org as Bot and BotVersion metadata definitions.

### What issues does this PR fix or reference?
@W-19127473@