### PR TITLE
W-19127491 bump limit for remote agents

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -135,7 +135,7 @@ export class Agent {
    */
   public static async listRemote(connection: Connection): Promise<BotMetadata[]> {
     const agentsQuery = await connection.query<BotMetadata>(
-      'SELECT FIELDS(ALL), (SELECT FIELDS(ALL) FROM BotVersions LIMIT 10) FROM BotDefinition LIMIT 100'
+      'SELECT FIELDS(ALL), (SELECT FIELDS(ALL) FROM BotVersions LIMIT 10) FROM BotDefinition LIMIT 200'
     );
     return agentsQuery.records;
   }


### PR DESCRIPTION
### What does this PR do?
Increases the LIMIT on agent query to 200

### What issues does this PR fix or reference?
[@W-19127491@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-19127491)