### PR TITLE
fix: improve error handling around the nameduser call

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,6 +219,31 @@ export const useNamedUserJwt = async (connection: Connection): Promise<Connectio
       },
       { retry: { maxRetries: 3 } }
     );
+
+    // Validate the response contains a valid access token
+    if (!response) {
+      throw SfError.create({
+        name: 'ApiAccessError',
+        message: 'Error obtaining API token: empty response.',
+      });
+    }
+
+    if (!response.access_token || typeof response.access_token !== 'string' || response.access_token.trim() === '') {
+      throw SfError.create({
+        name: 'ApiAccessError',
+        message: 'Error obtaining API token: invalid or missing access token.',
+      });
+    }
+
+    // Validate token format is JWT (three parts separated by dots)
+    const tokenParts = response.access_token.split('.');
+    if (tokenParts.length !== 3) {
+      throw SfError.create({
+        name: 'ApiAccessError',
+        message: 'Error obtaining API token: access token does not have valid JWT format.',
+      });
+    }
+
     connection.accessToken = response.access_token;
     return connection;
   } catch (error) {
@@ -643,6 +668,7 @@ export async function requestWithEndpointFallback<T>(
       );
     } catch (error) {
       const statusCode = getHttpStatusCode(error);
+      logger.debug(`Request failed for url ${modifiedUrl} with status code ${statusCode ?? 'unknown'}`);
       if (statusCode === 404) {
         lastError = error;
         continue; // Try next endpoint

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,6 +247,17 @@ export const useNamedUserJwt = async (connection: Connection): Promise<Connectio
     connection.accessToken = response.access_token;
     return connection;
   } catch (error) {
+    // If it's already an SfError with our specific message, re-throw it as-is
+    if (error instanceof SfError && error.name === 'ApiAccessError') {
+      error.actions = [
+        'If using your own connected app or ECA, ensure it grants access to the SFAP APIs by providing these scopes:',
+        '   * Access chatbot services (chatbot_api)',
+        '   * Access the Salesforce API Platform (sfap_api)',
+        '   * Manage user data via Web browsers (web)',
+      ];
+      throw error;
+    }
+    // Otherwise wrap it with a generic error
     throw SfError.create({
       name: 'ApiAccessError',
       message: 'Error obtaining API token',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -364,7 +364,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: empty response.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 
@@ -389,7 +391,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: invalid or missing access token.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 
@@ -414,7 +418,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: invalid or missing access token.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 
@@ -439,7 +445,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: invalid or missing access token.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 
@@ -465,7 +473,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: access token does not have valid JWT format.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 
@@ -491,7 +501,9 @@ describe('useNamedUserJwt', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(SfError);
       expect((error as SfError).name).to.equal('ApiAccessError');
-      expect((error as SfError).message).to.include('Error obtaining API token');
+      expect((error as SfError).message).to.equal('Error obtaining API token: access token does not have valid JWT format.');
+      expect((error as SfError).actions).to.exist;
+      expect((error as SfError).actions).to.have.lengthOf(4);
     }
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -163,6 +163,50 @@ describe('requestWithEndpointFallback', () => {
       'https://api.salesforce.com/einstein/ai-agent/v1/test'
     );
   });
+
+  it('should continue to next endpoint after logging 404 error', async () => {
+    const error404 = new Error('Not Found') as Error & { name: string };
+    error404.name = 'ERROR_HTTP_404';
+
+    const requestStub = $$.SANDBOX.stub(connection, 'request');
+    requestStub.onFirstCall().rejects(error404);
+    requestStub.onSecondCall().resolves({ success: true });
+
+    // This test verifies that the function continues to try the next endpoint after a 404
+    // The logging happens internally, but the important behavior is the retry logic
+    const result = await requestWithEndpointFallback(connection, {
+      method: 'POST',
+      url: 'https://api.salesforce.com/einstein/ai-agent/v1/test',
+      headers: { 'x-client-name': 'test' },
+      body: '{}',
+    });
+
+    expect(result).to.deep.equal({ success: true });
+    expect(requestStub.calledTwice).to.be.true;
+  });
+
+  it('should log error and throw immediately on non-404 errors', async () => {
+    const error500 = new Error('Internal Server Error') as Error & { name: string };
+    error500.name = 'ERROR_HTTP_500';
+
+    const requestStub = $$.SANDBOX.stub(connection, 'request').rejects(error500);
+
+    // This test verifies that non-404 errors are thrown immediately
+    // The logging happens internally before throwing
+    try {
+      await requestWithEndpointFallback(connection, {
+        method: 'POST',
+        url: 'https://api.salesforce.com/einstein/ai-agent/v1/test',
+        headers: { 'x-client-name': 'test' },
+        body: '{}',
+      });
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.equal(error500);
+      // Should only be called once since non-404 errors throw immediately
+      expect(requestStub.calledOnce).to.be.true;
+    }
+  });
 });
 
 describe('useNamedUserJwt', () => {
@@ -192,9 +236,14 @@ describe('useNamedUserJwt', () => {
       instanceUrl: 'https://test.my.salesforce.com',
     });
 
-    // Stub the nameduser endpoint request
-    // eslint-disable-next-line camelcase
-    $$.SANDBOX.stub(connection, 'request').resolves({ access_token: 'new-jwt-token' });
+    // Stub the nameduser endpoint request with valid JWT token
+    const validJwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: validJwtToken,
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    });
 
     await useNamedUserJwt(connection);
 
@@ -213,9 +262,14 @@ describe('useNamedUserJwt', () => {
       instanceUrl: 'https://test.my.salesforce.com',
     });
 
-    // Stub the nameduser endpoint request
-    // eslint-disable-next-line camelcase
-    $$.SANDBOX.stub(connection, 'request').resolves({ access_token: 'new-jwt-token' });
+    // Stub the nameduser endpoint request with valid JWT token
+    const validJwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: validJwtToken,
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    });
 
     await useNamedUserJwt(connection);
 
@@ -250,12 +304,216 @@ describe('useNamedUserJwt', () => {
       instanceUrl: 'https://test.my.salesforce.com',
     });
 
-    // Stub the nameduser endpoint request
-    // eslint-disable-next-line camelcase
-    $$.SANDBOX.stub(connection, 'request').resolves({ access_token: 'new-jwt-token' });
+    // Stub the nameduser endpoint request with valid JWT token
+    const validJwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: validJwtToken,
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    });
 
     const result = await useNamedUserJwt(connection);
 
-    expect(result.accessToken).to.equal('new-jwt-token');
+    expect(result.accessToken).to.equal(validJwtToken);
+  });
+
+  it('should succeed with valid JWT token response', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    // Valid JWT token with three parts (header.payload.signature)
+    const validJwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: validJwtToken,
+      // eslint-disable-next-line camelcase
+      token_format: 'jwt',
+      scope: 'full',
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+      // eslint-disable-next-line camelcase
+      issued_at: Date.now(),
+      // eslint-disable-next-line camelcase
+      api_instance_url: 'https://test.my.salesforce.com',
+    });
+
+    const result = await useNamedUserJwt(connection);
+
+    expect(result.accessToken).to.equal(validJwtToken);
+  });
+
+  it('should throw ApiAccessError when response is empty', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    // Return null/undefined response
+    $$.SANDBOX.stub(connection, 'request').resolves(null as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw ApiAccessError when access_token is missing', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    // Response without access_token
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+      scope: 'full',
+    } as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw ApiAccessError when access_token is empty string', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: '   ',
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    } as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw ApiAccessError when access_token is not a string', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: 12345,
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    } as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw ApiAccessError when access_token does not have valid JWT format', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    // Token with only 2 parts instead of 3
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: 'invalid.token',
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    } as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw ApiAccessError when access_token has too many parts', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    // Token with 4 parts instead of 3
+    $$.SANDBOX.stub(connection, 'request').resolves({
+      // eslint-disable-next-line camelcase
+      access_token: 'part1.part2.part3.part4',
+      // eslint-disable-next-line camelcase
+      token_type: 'Bearer',
+    } as never);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.include('Error obtaining API token');
+    }
+  });
+
+  it('should throw wrapped ApiAccessError for network errors', async () => {
+    $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
+
+    $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+      accessToken: 'valid-access-token',
+      instanceUrl: 'https://test.my.salesforce.com',
+    });
+
+    const networkError = new Error('Network error');
+    $$.SANDBOX.stub(connection, 'request').rejects(networkError);
+
+    try {
+      await useNamedUserJwt(connection);
+      expect.fail('Expected error was not thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(SfError);
+      expect((error as SfError).name).to.equal('ApiAccessError');
+      expect((error as SfError).message).to.equal('Error obtaining API token');
+      expect((error as SfError).cause).to.equal(networkError);
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?
Verifies the named OrgJWT is valid.
Adds logging to failed calls to Agent APIs.
### What issues does this PR fix or reference?
[@W-22049636@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YCfD9YAL/view)