### PR TITLE
fix: rename topic_selector to agent_router @W-21951410@

### DIFF
--- a/src/templates/agentScriptTemplate.ts
+++ b/src/templates/agentScriptTemplate.ts
@@ -61,9 +61,9 @@ language:
     additional_locales: ""
     all_additional_locales: False
 
-start_agent topic_selector:
-    label: "Topic Selector"
-    description: "Welcome the user and determine the appropriate topic based on user input"
+start_agent agent_router:
+    label: "Agent Router"
+    description: "Welcome the user and determine the appropriate subagent based on user input"
 
     reasoning:
         instructions: ->

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -915,8 +915,8 @@ describe('Agents', () => {
 
       // Verify .agent file content
       expect(agentContent).to.include('developer_name: "Test_Agent"');
-      // Should not include any subagent transitions in the topic_selector
-      expect(agentContent).to.include('start_agent topic_selector:');
+      // Should not include any subagent transitions in the agent_router
+      expect(agentContent).to.include('start_agent agent_router:');
       // Should still include default subagents (escalation, off_topic, ambiguous_question)
       expect(agentContent).to.include('subagent escalation:');
       expect(agentContent).to.include('subagent off_topic:');

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -112,7 +112,7 @@ connection messaging:
    outbound_route_name: "agent_support_flow"
    adaptive_response_allowed: True
 
-start_agent topic_selector:
+start_agent agent_router:
    description: "Welcome the user and determine the appropriate subagent based on user input"
 
               `;


### PR DESCRIPTION
## What does this PR do?

Completes the topic → subagent rename by updating remaining references from `topic_selector` to `agent_router` that were missed in PR #260.

## Changes
- Updated agent script template to use `agent_router` instead of `topic_selector`
- Updated label from "Topic Selector" to "Agent Router"
- Updated description to refer to "subagent" for consistency
- Updated test data and test assertions

## What issues does this PR fix or reference?

@W-21951410@

🤖 Generated with [Claude Code](https://claude.com/claude-code)