### PR TITLE
W-22203667: add preview session store functions to utils

### DIFF
--- a/.claude/skills/agents-pr-review/SKILL.md
+++ b/.claude/skills/agents-pr-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: agents-pr-review
+description: Review pull requests in the agents library. Use for "review PR", "code review", or "gh pr view".
+---
+
+# PR Review Skill (agents library)
+
+## Required
+
+- `gh` CLI
+- `git` (PR branch must be checked out locally for authoritative diff)
+
+## Working directory
+
+- repo root (parent of this `.claude`)
+
+## Commands
+
+Run all three together:
+
+- `gh pr view <PR_NUMBER> --json title,number,body,files,commits,additions,deletions,changedFiles,baseRefName,headRefName,author,labels`
+- `gh pr diff <PR_NUMBER>` — GitHub API diff (may be stale)
+- `git diff $(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName') -- $(gh pr view <PR_NUMBER> --json files --jq '[.files[].path] | join(" ")')` — authoritative local diff
+
+## Diff precedence
+
+- `gh pr diff` can be stale after a recent push
+- cross-check with local `git diff <base>` and `Read` tool on changed files
+- local git diff + file contents win any disagreement
+
+## Review checklist
+
+### Commit message
+- Follows `type: message` format (enforced by commitizen)
+- Valid types: `feat, fix, improvement, docs, style, refactor, perf, test, build, ci, chore, revert`
+- PR will be squash-merged — the PR title becomes the commit message; flag if it doesn't follow the convention
+
+### License header
+- Every new `.ts` file must include the Apache 2.0 license header
+- Check any added files; missing header will fail the lint check
+
+### TypeScript quality
+- No `any` types — this repo uses `tsconfig-strict-esm`
+- All public APIs should be typed explicitly
+- New exports must be added to `src/index.ts`
+
+### Code correctness
+- Correctness, regressions, edge cases
+- Error handling: errors must not be swallowed; rethrown errors must set the original as `cause`
+- Input validation at API boundaries
+
+### Messages / i18n
+- User-facing strings belong in `messages/` — not hardcoded in source
+- New messages must have entries in the appropriate `.md` file under `messages/`
+
+### Tests
+- New code should have corresponding tests in `test/` (mirrors `src/` structure)
+- Unit tests use `.test.ts` suffix; NUTs use `.nut.ts`
+- Coverage target is 95%+ on new code
+- Tests should use `TestContext` and `MockTestOrgData` from `@salesforce/core/testSetup`
+- HTTP calls must be mocked using fixtures in `test/mocks/` — no live org calls in unit tests
+- Assertions use Chai (`expect`, not `assert`)
+
+### Dependencies
+- New packages must use approved Salesforce packages (`@salesforce/core`, `@salesforce/kit`, etc.)
+- Flag any new `npm` dependencies — they require deliberate justification in a library
+
+### Agent-specific patterns
+- `AgentBase`, `ScriptAgent`, `ProductionAgent` follow a class hierarchy — new agent types should extend `AgentBase`
+- Static methods on the `Agent` class (`create`, `list`, `init`) are the public entry points — keep their signatures stable
+- Template files live in `src/templates/` — new templates belong there
+
+## Output format
+
+- Findings first, severity order (Critical → High → Medium → Low)
+- Cite file paths and line numbers for each finding
+- Questions/Assumptions section if needed
+- Brief summary last

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,21 @@ export {
   COMPILATION_API_EXIT_CODES,
 } from './types';
 
-export { metric, findAuthoringBundle, readTranscriptEntries } from './utils';
+export {
+  metric,
+  findAuthoringBundle,
+  readTranscriptEntries,
+  createPreviewSessionCache,
+  validatePreviewSession,
+  removePreviewSessionCache,
+  getCachedPreviewSessionIds,
+  getCurrentPreviewSessionId,
+  listCachedPreviewSessions,
+  type SessionType,
+  type PreviewSessionMeta,
+  type CachedPreviewSessionInfo,
+  type CachedPreviewSessionEntry,
+} from './utils';
 export { Agent, AgentCreateLifecycleStages, type AgentInstance } from './agent';
 export { AgentTester } from './agentTester';
 export { AgentTest, AgentTestCreateLifecycleStages } from './agentTest';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { mkdir, appendFile, readFile, writeFile, readdir, stat } from 'node:fs/promises';
+import { mkdir, appendFile, readFile, rename, writeFile, readdir, stat, unlink } from 'node:fs/promises';
 import * as path from 'node:path';
 import { Connection, Logger, SfError, SfProject } from '@salesforce/core';
 import { NamedUserJwtResponse, type PlannerResponse, PreviewMetadata } from './types';
@@ -888,3 +888,252 @@ export const readTranscriptEntries = async (agentId: string, sessionId: string):
     return [];
   }
 };
+
+// ====================================================
+//               Preview Session Store
+// ====================================================
+
+const SESSION_META_FILE = 'session-meta.json';
+const SESSION_INDEX_FILE = 'index.json';
+
+export type SessionType = 'simulated' | 'live' | 'published';
+export type PreviewSessionMeta = { displayName?: string; timestamp?: string; sessionType?: SessionType };
+type PreviewSessionIndex = Array<{
+  sessionId: string;
+  displayName?: string;
+  timestamp?: string;
+  sessionType?: SessionType;
+}>;
+
+async function readPreviewSessionIndex(indexPath: string): Promise<PreviewSessionIndex> {
+  try {
+    const raw = await readFile(indexPath, 'utf-8');
+    return JSON.parse(raw) as PreviewSessionIndex;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Atomically read-modify-write the preview sessions index.
+ * Writes to a temp file then renames to avoid partial writes and reduce
+ * the window for concurrent-write races (last writer wins, no silent drops).
+ * Propagates errors so callers are aware of index failures.
+ */
+async function updatePreviewSessionIndex(
+  indexPath: string,
+  updater: (index: PreviewSessionIndex) => PreviewSessionIndex
+): Promise<void> {
+  const index = await readPreviewSessionIndex(indexPath);
+  const updated = updater(index);
+  const tmpPath = `${indexPath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(updated, null, 2), 'utf-8');
+  await rename(tmpPath, indexPath);
+}
+
+/**
+ * Save a marker so send/end can validate that the session was started for this agent.
+ * Caller must have started the session (agent has sessionId set). Uses agent.getHistoryDir() for the path.
+ * Pass displayName (authoring bundle name or production agent API name) so "agent preview sessions" can show it.
+ */
+export async function createPreviewSessionCache(
+  agent: { getHistoryDir: () => Promise<string> },
+  options?: { displayName?: string; sessionType?: SessionType }
+): Promise<void> {
+  const historyDir = await agent.getHistoryDir();
+  const metaPath = path.join(historyDir, SESSION_META_FILE);
+  const meta: PreviewSessionMeta = {
+    displayName: options?.displayName,
+    timestamp: new Date().toISOString(),
+    sessionType: options?.sessionType,
+  };
+  await writeFile(metaPath, JSON.stringify(meta), 'utf-8');
+
+  // Update the sessions index for ordered browsing
+  const sessionId = path.basename(historyDir);
+  const sessionsDir = path.dirname(historyDir);
+  const indexPath = path.join(sessionsDir, SESSION_INDEX_FILE);
+  await updatePreviewSessionIndex(indexPath, (index) => {
+    if (!index.some((e) => e.sessionId === sessionId)) {
+      index.push({
+        sessionId,
+        displayName: meta.displayName,
+        timestamp: meta.timestamp,
+        sessionType: meta.sessionType,
+      });
+    }
+    return index;
+  });
+}
+
+/**
+ * Validate that the session was started for this agent (marker file exists in agent's history dir for current sessionId).
+ * Caller must set sessionId on the agent (agent.setSessionId) before calling.
+ * Throws SfError if the session marker is not found.
+ */
+export async function validatePreviewSession(agent: { getHistoryDir: () => Promise<string> }): Promise<void> {
+  const historyDir = await agent.getHistoryDir();
+  const metaPath = path.join(historyDir, SESSION_META_FILE);
+  try {
+    await readFile(metaPath, 'utf-8');
+  } catch {
+    throw new SfError(
+      'No preview session found for this session ID. Run "sf agent preview start" first.',
+      'PreviewSessionNotFound'
+    );
+  }
+}
+
+/**
+ * Remove the session marker so this session is no longer considered "active" for send/end without --session-id.
+ * Call after ending the session. Caller must set sessionId on the agent before calling.
+ */
+export async function removePreviewSessionCache(agent: { getHistoryDir: () => Promise<string> }): Promise<void> {
+  const historyDir = await agent.getHistoryDir();
+  const metaPath = path.join(historyDir, SESSION_META_FILE);
+  try {
+    await unlink(metaPath);
+  } catch {
+    // already removed or never created
+  }
+
+  // Remove entry from the sessions index
+  const sessionId = path.basename(historyDir);
+  const sessionsDir = path.dirname(historyDir);
+  const indexPath = path.join(sessionsDir, SESSION_INDEX_FILE);
+  await updatePreviewSessionIndex(indexPath, (index) => index.filter((e) => e.sessionId !== sessionId));
+}
+
+/**
+ * List session IDs that have a cache marker (started via "agent preview start") for this agent.
+ * Uses project path and agent's storage ID to find .sfdx/agents/<agentId>/sessions/<sessionId>/session-meta.json.
+ */
+export async function getCachedPreviewSessionIds(
+  project: SfProject,
+  agent: { getAgentIdForStorage: () => string | Promise<string> }
+): Promise<string[]> {
+  const agentId = await agent.getAgentIdForStorage();
+  const base = path.join(project.getPath(), '.sfdx');
+  const sessionsDir = path.join(base, 'agents', agentId, 'sessions');
+  const sessionIds: string[] = [];
+  try {
+    const entries = await readdir(sessionsDir, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    const hasMarker = await Promise.all(
+      dirs.map(async (name) => {
+        try {
+          await readFile(path.join(sessionsDir, name, SESSION_META_FILE), 'utf-8');
+          return true;
+        } catch {
+          return false;
+        }
+      })
+    );
+    dirs.forEach((name, i) => {
+      if (hasMarker[i]) sessionIds.push(name);
+    });
+  } catch {
+    // sessions dir missing or unreadable
+  }
+  return sessionIds;
+}
+
+/**
+ * Return the single "current" session ID when safe: exactly one cached session for this agent.
+ * Returns undefined when there are zero or multiple sessions (caller should require --session-id).
+ */
+export async function getCurrentPreviewSessionId(
+  project: SfProject,
+  agent: { getAgentIdForStorage: () => string | Promise<string> }
+): Promise<string | undefined> {
+  const ids = await getCachedPreviewSessionIds(project, agent);
+  return ids.length === 1 ? ids[0] : undefined;
+}
+
+export type CachedPreviewSessionInfo = { sessionId: string; timestamp?: string; sessionType?: SessionType };
+export type CachedPreviewSessionEntry = {
+  agentId: string;
+  displayName?: string;
+  sessions: CachedPreviewSessionInfo[];
+};
+
+/**
+ * List all cached preview sessions in the project, grouped by agent ID.
+ * displayName (when present in session-meta.json) is the authoring bundle name or production agent API name for display.
+ * Use this to show users which sessions exist so they can end or clean up.
+ */
+export async function listCachedPreviewSessions(project: SfProject): Promise<CachedPreviewSessionEntry[]> {
+  const base = path.join(project.getPath(), '.sfdx', 'agents');
+  const result: CachedPreviewSessionEntry[] = [];
+  try {
+    const agentDirs = await readdir(base, { withFileTypes: true });
+    const entries = await Promise.all(
+      agentDirs
+        .filter((ent) => ent.isDirectory())
+        .map(async (ent) => {
+          const agentId = ent.name;
+          const sessionsDir = path.join(base, agentId, 'sessions');
+          let sessions: CachedPreviewSessionInfo[] = [];
+          let displayName: string | undefined;
+          try {
+            // Prefer the index for ordered, metadata-rich results
+            const index = await readPreviewSessionIndex(path.join(sessionsDir, SESSION_INDEX_FILE));
+            if (index.length > 0) {
+              // Verify each indexed session still has its marker file (guard against manual cleanup)
+              const verified = await Promise.all(
+                index.map(async (entry) => {
+                  try {
+                    await readFile(path.join(sessionsDir, entry.sessionId, SESSION_META_FILE), 'utf-8');
+                    return entry;
+                  } catch {
+                    return null;
+                  }
+                })
+              );
+              sessions = verified
+                .filter((e): e is PreviewSessionIndex[number] => e !== null)
+                .map(({ sessionId, timestamp, sessionType }) => ({ sessionId, timestamp, sessionType }));
+              displayName = index.find((e) => e.displayName !== undefined)?.displayName;
+            } else {
+              // Fallback: scan directories (no index yet, e.g. sessions started before this feature)
+              const sessionDirs = await readdir(sessionsDir, { withFileTypes: true });
+              const sessionInfos = await Promise.all(
+                sessionDirs
+                  .filter((s) => s.isDirectory())
+                  .map(async (s): Promise<(CachedPreviewSessionInfo & { displayName?: string }) | null> => {
+                    try {
+                      const raw = await readFile(path.join(sessionsDir, s.name, SESSION_META_FILE), 'utf-8');
+                      const meta = JSON.parse(raw) as PreviewSessionMeta;
+                      return {
+                        sessionId: s.name,
+                        timestamp: meta.timestamp,
+                        sessionType: meta.sessionType,
+                        displayName: meta.displayName,
+                      };
+                    } catch {
+                      return null;
+                    }
+                  })
+              );
+              const validSessions = sessionInfos.filter(
+                (s): s is CachedPreviewSessionInfo & { displayName?: string } => s !== null
+              );
+              sessions = validSessions.map(({ sessionId, timestamp, sessionType }) => ({
+                sessionId,
+                timestamp,
+                sessionType,
+              }));
+              displayName = validSessions[0]?.displayName;
+            }
+          } catch {
+            // no sessions dir or unreadable
+          }
+          return { agentId, displayName, sessions };
+        })
+    );
+    result.push(...entries.filter((e) => e.sessions.length > 0));
+  } catch {
+    // no agents dir or unreadable
+  }
+  return result;
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,10 +14,24 @@
  * limitations under the License.
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
-import { Connection, SfError } from '@salesforce/core';
-import { requestWithEndpointFallback, useNamedUserJwt, type RequestInfo } from '../src/utils';
+import { Connection, SfError, SfProject } from '@salesforce/core';
+import {
+  requestWithEndpointFallback,
+  useNamedUserJwt,
+  type RequestInfo,
+  createPreviewSessionCache,
+  validatePreviewSession,
+  removePreviewSessionCache,
+  getCachedPreviewSessionIds,
+  getCurrentPreviewSessionId,
+  listCachedPreviewSessions,
+} from '../src/utils';
 
 describe('requestWithEndpointFallback', () => {
   const $$ = new TestContext();
@@ -527,5 +541,273 @@ describe('useNamedUserJwt', () => {
       expect((error as SfError).message).to.equal('Error obtaining API token');
       expect((error as SfError).cause).to.equal(networkError);
     }
+  });
+});
+
+// ====================================================
+//           Preview Session Store Tests
+// ====================================================
+
+function makeMockProject(getPath: () => string): SfProject {
+  return { getPath } as SfProject;
+}
+
+function makeMockAgent(projectDir: string, agentId: string): {
+  setSessionId: (id: string) => void;
+  getAgentIdForStorage: () => string;
+  getHistoryDir: () => Promise<string>;
+} {
+  let sessionId: string | undefined;
+  return {
+    setSessionId(id: string) {
+      sessionId = id;
+    },
+    getAgentIdForStorage(): string {
+      return agentId;
+    },
+    async getHistoryDir(): Promise<string> {
+      if (!sessionId) throw new Error('sessionId not set');
+      const dir = join(projectDir, '.sfdx', 'agents', agentId, 'sessions', sessionId);
+      const { mkdir } = await import('node:fs/promises');
+      await mkdir(dir, { recursive: true });
+      return dir;
+    },
+  };
+}
+
+describe('Preview Session Store', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'preview-session-store-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  describe('createPreviewSessionCache', () => {
+    it('saves session and validates with same agent', async () => {
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-1');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-1');
+      await validatePreviewSession(agent);
+    });
+
+    it('allows multiple sessions for same agent', async () => {
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-a');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-b');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-a');
+      await validatePreviewSession(agent);
+      agent.setSessionId('sess-b');
+      await validatePreviewSession(agent);
+    });
+  });
+
+  describe('validatePreviewSession', () => {
+    it('throws PreviewSessionNotFound when session file does not exist', async () => {
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('unknown-sess');
+      try {
+        await validatePreviewSession(agent);
+        expect.fail('Expected validatePreviewSession to throw');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).name).to.equal('PreviewSessionNotFound');
+        expect((e as SfError).message).to.include('No preview session found');
+      }
+    });
+
+    it('throws PreviewSessionNotFound when session id is for different agent', async () => {
+      const agentA = makeMockAgent(projectPath, 'agent-a');
+      const agentB = makeMockAgent(projectPath, 'agent-b');
+      agentA.setSessionId('sess-1');
+      await createPreviewSessionCache(agentA);
+      agentB.setSessionId('sess-1');
+      try {
+        await validatePreviewSession(agentB);
+        expect.fail('Expected validatePreviewSession to throw');
+      } catch (e) {
+        expect(e).to.be.instanceOf(SfError);
+        expect((e as SfError).name).to.equal('PreviewSessionNotFound');
+      }
+    });
+  });
+
+  describe('getCachedPreviewSessionIds', () => {
+    it('returns empty when no sessions', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      const ids = await getCachedPreviewSessionIds(project, agent);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('returns session ids that have session-meta.json', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-1');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-2');
+      await createPreviewSessionCache(agent);
+      const ids = await getCachedPreviewSessionIds(project, agent);
+      expect(ids).to.have.members(['sess-1', 'sess-2']);
+    });
+  });
+
+  describe('removePreviewSessionCache', () => {
+    it('removes session from cache', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-1');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-2');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-1');
+      await removePreviewSessionCache(agent);
+      const ids = await getCachedPreviewSessionIds(project, agent);
+      expect(ids).to.deep.equal(['sess-2']);
+    });
+
+    it('after removing one session getCurrentPreviewSessionId returns the remaining one', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-a');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-b');
+      await createPreviewSessionCache(agent);
+      expect(await getCurrentPreviewSessionId(project, agent)).to.be.undefined;
+      agent.setSessionId('sess-a');
+      await removePreviewSessionCache(agent);
+      expect(await getCurrentPreviewSessionId(project, agent)).to.equal('sess-b');
+    });
+  });
+
+  describe('listCachedPreviewSessions', () => {
+    it('returns empty when no cached sessions', async () => {
+      const project = makeMockProject(() => projectPath);
+      const list = await listCachedPreviewSessions(project);
+      expect(list).to.deep.equal([]);
+    });
+
+    it('returns agent ids and session ids for all cached sessions', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent1 = makeMockAgent(projectPath, 'bundle-a');
+      agent1.setSessionId('s1');
+      await createPreviewSessionCache(agent1);
+      agent1.setSessionId('s2');
+      await createPreviewSessionCache(agent1);
+      const agent2 = makeMockAgent(projectPath, 'bundle-b');
+      agent2.setSessionId('s3');
+      await createPreviewSessionCache(agent2);
+      const list = await listCachedPreviewSessions(project);
+      expect(list).to.have.lengthOf(2);
+      const byAgent = Object.fromEntries(list.map((e) => [e.agentId, e.sessions.map((s) => s.sessionId)]));
+      expect(byAgent['bundle-a']).to.have.members(['s1', 's2']);
+      expect(byAgent['bundle-b']).to.deep.equal(['s3']);
+    });
+
+    it('returns displayName and sessionType from session-meta', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'some-id');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent, { displayName: 'My_Production_Agent', sessionType: 'published' });
+      const list = await listCachedPreviewSessions(project);
+      expect(list[0].displayName).to.equal('My_Production_Agent');
+      expect(list[0].sessions[0].sessionType).to.equal('published');
+    });
+
+    it('returns timestamp for each session', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'some-id');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent, { sessionType: 'simulated' });
+      const list = await listCachedPreviewSessions(project);
+      expect(list[0].sessions[0].timestamp)
+        .to.be.a('string')
+        .and.match(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('returns sessions in creation order from index', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'bundle-a');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('s2');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('s3');
+      await createPreviewSessionCache(agent);
+      const list = await listCachedPreviewSessions(project);
+      expect(list[0].sessions.map((s) => s.sessionId)).to.deep.equal(['s1', 's2', 's3']);
+    });
+
+    it('index file is written to the sessions directory', async () => {
+      const agent = makeMockAgent(projectPath, 'bundle-a');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent, { displayName: 'MyAgent', sessionType: 'live' });
+      const indexPath = join(projectPath, '.sfdx', 'agents', 'bundle-a', 'sessions', 'index.json');
+      const raw = await readFile(indexPath, 'utf-8');
+      const index = JSON.parse(raw) as Array<{ sessionId: string; sessionType: string }>;
+      expect(index).to.have.lengthOf(1);
+      expect(index[0].sessionId).to.equal('s1');
+      expect(index[0].sessionType).to.equal('live');
+    });
+
+    it('removes entry from index when session is ended', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'bundle-a');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('s2');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('s1');
+      await removePreviewSessionCache(agent);
+      const list = await listCachedPreviewSessions(project);
+      expect(list[0].sessions.map((s) => s.sessionId)).to.deep.equal(['s2']);
+    });
+
+    it('falls back to directory scan when no index exists', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'bundle-a');
+      agent.setSessionId('s1');
+      await createPreviewSessionCache(agent);
+      // Remove the index to simulate pre-index sessions
+      const { unlink: unlinkFn } = await import('node:fs/promises');
+      await unlinkFn(join(projectPath, '.sfdx', 'agents', 'bundle-a', 'sessions', 'index.json'));
+      const list = await listCachedPreviewSessions(project);
+      expect(list[0].sessions.map((s) => s.sessionId)).to.deep.equal(['s1']);
+    });
+  });
+
+  describe('getCurrentPreviewSessionId', () => {
+    it('returns undefined when no sessions', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      const id = await getCurrentPreviewSessionId(project, agent);
+      expect(id).to.be.undefined;
+    });
+
+    it('returns session id when exactly one session', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-1');
+      await createPreviewSessionCache(agent);
+      const id = await getCurrentPreviewSessionId(project, agent);
+      expect(id).to.equal('sess-1');
+    });
+
+    it('returns undefined when multiple sessions', async () => {
+      const project = makeMockProject(() => projectPath);
+      const agent = makeMockAgent(projectPath, 'agent-1');
+      agent.setSessionId('sess-a');
+      await createPreviewSessionCache(agent);
+      agent.setSessionId('sess-b');
+      await createPreviewSessionCache(agent);
+      const id = await getCurrentPreviewSessionId(project, agent);
+      expect(id).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Moves all preview session store logic out of `plugin-agent` and into this library so the VS Code extension and the CLI share the same storage layer (per review feedback on salesforcecli/plugin-agent#400)
- Adds `createPreviewSessionCache`, `validatePreviewSession`, `removePreviewSessionCache`, `getCachedPreviewSessionIds`, `getCurrentPreviewSessionId`, `listCachedPreviewSessions` to `src/utils.ts`
- Introduces `SessionType`, `PreviewSessionMeta`, `CachedPreviewSessionInfo`, `CachedPreviewSessionEntry` types
- Atomic write (temp file + `rename`) for the sessions index to reduce race conditions on concurrent `start` calls
- All new functions exported from `src/index.ts`

## Test plan

- [x] 19 new tests added in `test/utils.test.ts` covering create, validate, remove, list, index ordering, removal from index, and directory-scan fallback
- [x] All 132 unit tests pass (`yarn test:only`)
- [x] Lint clean (`yarn lint`)

@W-22203667@

🤖 Generated with [Claude Code](https://claude.com/claude-code)