### PR TITLE
W-22203672: add optional agentJson to ScriptAgentOptions to skip compilation

### DIFF
--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -100,6 +100,12 @@ export class ScriptAgent extends AgentBase {
       });
     }
     this.metaContent = fs.readFileSync(bundleMetaPath, 'utf-8');
+
+    if (options.agentJson) {
+      this.agentJson = options.agentJson;
+      this.name = options.agentJson.globalConfiguration.label || options.aabName;
+    }
+
     this.preview = {
       start: (mockMode?: 'Mock' | 'Live Test', apexDebugging?: boolean): Promise<AgentPreviewStartResponse> =>
         this.startPreview(mockMode, apexDebugging),

--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -103,7 +103,7 @@ export class ScriptAgent extends AgentBase {
 
     if (options.agentJson) {
       this.agentJson = options.agentJson;
-      this.name = options.agentJson.globalConfiguration.label || options.aabName;
+      this.name = options.agentJson.globalConfiguration?.label?.trim() || options.aabName;
     }
 
     this.preview = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export type ScriptAgentOptions = {
   project: SfProject;
   // name of the AAB, e.g. 'myBundle' - the project will be searched to find the AAB directory
   aabName: string;
+  // pre-compiled AgentJSON; when provided, skips the compile step during preview
+  agentJson?: AgentJson;
 };
 export type ProductionAgentOptions = {
   connection: Connection;


### PR DESCRIPTION
## Summary
@W-22203672@

- Add optional `agentJson?: AgentJson` field to `ScriptAgentOptions` so callers can supply a pre-compiled AgentJSON, bypassing the compile step in `startPreview()`
- `ScriptAgent` constructor pre-populates `this.agentJson` and `this.name` when the option is provided

## Test plan
- [ ] Existing unit tests pass (`yarn test`)
- [ ] `plugin-agent` PR exercises the flag end-to-end with a real file

🤖 Generated with [Claude Code](https://claude.com/claude-code)