### PR TITLE
fix: poll on all terminal states for AgentforceStudioTester @W-22143479@ @W-22143478@

### DIFF
--- a/src/agentforceStudioTester.ts
+++ b/src/agentforceStudioTester.ts
@@ -20,6 +20,7 @@ import { MaybeMock } from './maybe-mock';
 import { decodeHtmlEntities } from './utils';
 import {
   type AgentforceStudioTestStartResponse,
+  type AgentforceStudioTestStatus,
   type AgentforceStudioTestStatusResponse,
   type AgentforceStudioTestResultsResponse,
 } from './types.js';
@@ -129,7 +130,8 @@ export class AgentforceStudioTester {
             passingTestCases,
           });
 
-          if (resultsResponse.status.toLowerCase() === 'success') {
+          const terminalStatuses: AgentforceStudioTestStatus[] = ['SUCCESS', 'FAILED', 'TERMINATED'];
+          if (terminalStatuses.includes(resultsResponse.status as AgentforceStudioTestStatus)) {
             return { payload: resultsResponse, completed: true };
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export type ScriptAgentOptions = {
   project: SfProject;
   // name of the AAB, e.g. 'myBundle' - the project will be searched to find the AAB directory
   aabName: string;
+  // pre-compiled AgentJSON; when provided, skips the compile step during preview
+  agentJson?: AgentJson;
 };
 export type ProductionAgentOptions = {
   connection: Connection;


### PR DESCRIPTION
## What does this PR do?

Fixes `AgentforceStudioTester.poll()` to complete on all terminal states (`SUCCESS`, `FAILED`, `TERMINATED`) instead of only `SUCCESS`.

Previously, a test run that ended in `FAILED` or `TERMINATED` would never resolve the poller, causing it to spin until the client timeout fired — resulting in the caller receiving no results.

## What issues does this PR fix or reference?

@W-22143479@ @W-22143478@