### PR TITLE
refactor: keep ConnectionManager internal, preserve public API @W-22389160@

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,15 +17,7 @@
 import { inspect } from 'node:util';
 import * as path from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
-import {
-  Connection,
-  generateApiName,
-  Lifecycle,
-  Logger,
-  Messages,
-  SfError,
-  SfProject,
-} from '@salesforce/core';
+import { Connection, generateApiName, Lifecycle, Logger, Messages, SfError, SfProject } from '@salesforce/core';
 import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
 import {
@@ -108,16 +100,15 @@ export class Agent {
   public static async init(
     options: ProductionAgentOptions | ScriptAgentOptions
   ): Promise<ScriptAgent | ProductionAgent> {
-    // Create ConnectionManager which handles JWT and standard connections
+    // ConnectionManager isolates JWT (for SFAP) and standard (for org) connections so
+    // the caller's connection is never mutated by JWT upgrades or auto-refresh.
     const connectionManager = await ConnectionManager.create(options.connection);
 
     // Type guard: check if it's ScriptAgentOptions by looking for 'aabName'
     if ('aabName' in options) {
-      // TypeScript now knows this is ScriptAgentOptions
-      return new ScriptAgent({ ...options, connectionManager });
+      return new ScriptAgent(options, connectionManager);
     } else {
-      // TypeScript now knows this is ProductionAgentOptions
-      const agent = new ProductionAgent({ ...options, connectionManager });
+      const agent = new ProductionAgent(options, connectionManager);
       await agent.getBotMetadata();
       return agent;
     }

--- a/src/agents/agentBase.ts
+++ b/src/agents/agentBase.ts
@@ -15,7 +15,7 @@
  */
 import { readFile, readdir, cp, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { SfError } from '@salesforce/core';
+import { Connection, SfError } from '@salesforce/core';
 import { AgentPreviewInterface, type AgentPreviewSendResponse, type PlannerResponse, PreviewMetadata } from '../types';
 import { getHistoryDir, SessionHistoryBuffer, TranscriptEntry } from '../utils';
 import { ConnectionManager } from '../connectionManager';
@@ -29,6 +29,20 @@ export abstract class AgentBase {
    * The display name of the agent (user-friendly name, not API name)
    */
   public name: string | undefined;
+  /**
+   * The standard org connection used for SOQL queries, tooling API calls, and metadata
+   * operations. This is distinct from the JWT-upgraded connection used for SFAP API
+   * calls (held internally by the connection manager).
+   */
+  protected readonly connection: Connection;
+  /**
+   * Holds isolated JWT and standard connections. When a ConnectionManager is supplied
+   * by Agent.init() / Agent.create() / Agent.createSpec(), the agent gets fully
+   * isolated connections (the caller's connection is not mutated). When undefined
+   * (consumers instantiating an agent directly), the supplied connection is used as
+   * both the JWT and standard connection — preserving the pre-isolation behavior.
+   */
+  protected readonly connectionManager: ConnectionManager | undefined;
   protected sessionId: string | undefined;
   protected historyDir: string | undefined;
   protected historyBuffer: SessionHistoryBuffer | undefined;
@@ -37,14 +51,25 @@ export abstract class AgentBase {
   protected planIds = new Set<string>();
   public abstract preview: AgentPreviewInterface;
 
-  protected constructor(protected readonly connectionManager: ConnectionManager) {}
+  protected constructor(connection: Connection, connectionManager?: ConnectionManager) {
+    this.connectionManager = connectionManager;
+    this.connection = connectionManager ? connectionManager.getStandardConnection() : connection;
+  }
 
   /**
-   * Restore the connection by refreshing the standard (non-JWT) connection.
+   * Refreshes the access token on the standard connection.
    *
+   * Retained for backward compatibility. With the connection manager in place the
+   * caller's original Connection object is no longer mutated by agent operations,
+   * so this method only refreshes the internal standard connection.
    */
   public async restoreConnection(): Promise<void> {
-    await this.connectionManager.refreshStandardConnection();
+    if (this.connectionManager) {
+      await this.connectionManager.refreshStandardConnection();
+      return;
+    }
+    delete this.connection.accessToken;
+    await this.connection.refreshAuth();
   }
 
   public setSessionId(sessionId: string): void {
@@ -78,6 +103,15 @@ export abstract class AgentBase {
     if (history.metadata?.planIds) {
       history.metadata.planIds.forEach((planId) => this.planIds.add(planId));
     }
+  }
+
+  /**
+   * Returns the connection to use for SFAP API calls (api.salesforce.com/einstein/ai-agent).
+   * When a ConnectionManager is in use this is the JWT-upgraded connection; otherwise it
+   * is the connection supplied at construction time.
+   */
+  protected getJwtConnection(): Connection {
+    return this.connectionManager ? this.connectionManager.getJwtConnection() : this.connection;
   }
 
   /**

--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -41,6 +41,7 @@ import {
   SessionHistoryBuffer,
 } from '../utils';
 import { createTraceFlag, findTraceFlag, getDebugLog } from '../apexUtils';
+import { ConnectionManager } from '../connectionManager';
 import { AgentBase } from './agentBase';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agents');
@@ -52,16 +53,8 @@ export class ProductionAgent extends AgentBase {
   private apiName: string | undefined;
   private readonly apiBase: string;
 
-  public constructor(options: ProductionAgentOptions) {
-    // ConnectionManager should be provided by Agent.init(), but fallback to creating one if needed
-    const connectionManager = options.connectionManager;
-    if (!connectionManager) {
-      throw SfError.create({
-        name: 'MissingConnectionManager',
-        message: 'ConnectionManager is required. Use Agent.init() to create ProductionAgent instances.',
-      });
-    }
-    super(connectionManager);
+  public constructor(private options: ProductionAgentOptions, connectionManager?: ConnectionManager) {
+    super(options.connection, connectionManager);
     this.apiBase = 'https://api.salesforce.com/einstein/ai-agent/v1';
     if (!options.apiNameOrId) {
       throw messages.createError('missingAgentNameOrId');
@@ -90,8 +83,7 @@ export class ProductionAgent extends AgentBase {
         'Id, IsDeleted, DeveloperName, MasterLabel, CreatedDate, CreatedById, LastModifiedDate, LastModifiedById, SystemModstamp, BotUserId, Description, Type, AgentType, AgentTemplate';
       const botVersionFields =
         'Id, Status, IsDeleted, BotDefinitionId, DeveloperName, CreatedDate, CreatedById, LastModifiedDate, LastModifiedById, SystemModstamp, VersionNumber, CopilotPrimaryLanguage, ToneType, CopilotSecondaryLanguages';
-      const standardConn = this.connectionManager.getStandardConnection();
-      this.botMetadata = await standardConn.singleRecordQuery<BotMetadata>(
+      this.botMetadata = await this.connection.singleRecordQuery<BotMetadata>(
         `SELECT ${botDefinitionFields}, (SELECT ${botVersionFields} FROM BotVersions WHERE IsDeleted = false ORDER BY VersionNumber) FROM BotDefinition WHERE ${whereClause} LIMIT 1`
       );
       this.id = this.botMetadata.Id;
@@ -217,10 +209,9 @@ export class ProductionAgent extends AgentBase {
   protected async handleApexDebuggingSetup(): Promise<void> {
     const botMetadata = await this.getBotMetadata();
     if (botMetadata.BotUserId) {
-      const standardConn = this.connectionManager.getStandardConnection();
-      const traceFlag = await findTraceFlag(standardConn, botMetadata.BotUserId);
+      const traceFlag = await findTraceFlag(this.connection, botMetadata.BotUserId);
       if (!traceFlag) {
-        await createTraceFlag(standardConn, botMetadata.BotUserId);
+        await createTraceFlag(this.connection, botMetadata.BotUserId);
       }
     }
   }
@@ -274,17 +265,14 @@ export class ProductionAgent extends AgentBase {
       };
       await logTurnToHistory(userEntry, ++this.turnCounter, this.historyDir, this.historyBuffer);
 
-      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(
-        this.connectionManager.getJwtConnection(),
-        {
-          method: 'POST',
-          url,
-          body: JSON.stringify(body),
-          headers: {
-            'x-client-name': 'afdx',
-          },
-        }
-      );
+      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(this.getJwtConnection(), {
+        method: 'POST',
+        url,
+        body: JSON.stringify(body),
+        headers: {
+          'x-client-name': 'afdx',
+        },
+      });
 
       const planId = response.messages.at(0)!.planId;
       this.planIds.add(planId);
@@ -309,8 +297,7 @@ export class ProductionAgent extends AgentBase {
       await this.historyBuffer.flush();
 
       if (this.apexDebugging && this.canApexDebug()) {
-        const standardConn = this.connectionManager.getStandardConnection();
-        const apexLog = await getDebugLog(standardConn, start, Date.now());
+        const apexLog = await getDebugLog(this.connection, start, Date.now());
         if (apexLog) {
           response.apexDebugLog = apexLog;
         }
@@ -336,7 +323,7 @@ export class ProductionAgent extends AgentBase {
     }
 
     const url = `/connect/bot-versions/${botVersionMetadata.Id}/activation`;
-    const maybeMock = new MaybeMock(this.connectionManager.getJwtConnection());
+    const maybeMock = new MaybeMock(this.getJwtConnection());
     const response = await maybeMock.request<BotActivationResponse>('POST', url, { status: desiredState });
     if (response.success) {
       const versionToUpdate = this.botMetadata!.BotVersions.records.find(
@@ -365,7 +352,7 @@ export class ProductionAgent extends AgentBase {
     const body = {
       externalSessionKey: randomUUID(),
       instanceConfig: {
-        endpoint: this.connectionManager.getStandardConnection().instanceUrl,
+        endpoint: this.options.connection.instanceUrl,
       },
       streamingCapabilities: {
         chunkTypes: ['Text'],
@@ -374,17 +361,14 @@ export class ProductionAgent extends AgentBase {
     };
 
     try {
-      const response = await requestWithEndpointFallback<AgentPreviewStartResponse>(
-        this.connectionManager.getJwtConnection(),
-        {
-          method: 'POST',
-          url,
-          body: JSON.stringify(body),
-          headers: {
-            'x-client-name': 'afdx',
-          },
-        }
-      );
+      const response = await requestWithEndpointFallback<AgentPreviewStartResponse>(this.getJwtConnection(), {
+        method: 'POST',
+        url,
+        body: JSON.stringify(body),
+        headers: {
+          'x-client-name': 'afdx',
+        },
+      });
       this.sessionId = response.sessionId;
 
       const agentId = this.id!;
@@ -439,16 +423,13 @@ export class ProductionAgent extends AgentBase {
     const url = `${this.apiBase}/sessions/${this.sessionId}`;
     try {
       // https://developer.salesforce.com/docs/einstein/genai/guide/agent-api-examples.html#end-session
-      const response = await requestWithEndpointFallback<AgentPreviewEndResponse>(
-        this.connectionManager.getJwtConnection(),
-        {
-          method: 'DELETE',
-          url,
-          headers: {
-            'x-session-end-reason': reason,
-          },
-        }
-      );
+      const response = await requestWithEndpointFallback<AgentPreviewEndResponse>(this.getJwtConnection(), {
+        method: 'DELETE',
+        url,
+        headers: {
+          'x-session-end-reason': reason,
+        },
+      });
 
       // Write end entry and flush buffer
       if (this.historyDir && this.historyBuffer) {

--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -49,6 +49,7 @@ import {
 import { getDebugLog } from '../apexUtils';
 import { generateAgentScript } from '../templates/agentScriptTemplate';
 import { applyStringReplacementsToAgent } from '../stringReplacements';
+import { ConnectionManager } from '../connectionManager';
 import { ScriptAgentPublisher } from './scriptAgentPublisher';
 import { AgentBase } from './agentBase';
 
@@ -63,16 +64,8 @@ export class ScriptAgent extends AgentBase {
   private readonly aabDirectory: string;
   private readonly metaContent: string;
   private readonly agentFilePath: string;
-  public constructor(private options: ScriptAgentOptions) {
-    // ConnectionManager should be provided by Agent.init(), but fallback to creating one if needed
-    const connectionManager = options.connectionManager;
-    if (!connectionManager) {
-      throw SfError.create({
-        name: 'MissingConnectionManager',
-        message: 'ConnectionManager is required. Use Agent.init() to create ScriptAgent instances.',
-      });
-    }
-    super(connectionManager);
+  public constructor(private options: ScriptAgentOptions, connectionManager?: ConnectionManager) {
+    super(options.connection, connectionManager);
     this.options = options;
     this.apiBase = 'https://api.salesforce.com/einstein/ai-agent';
 
@@ -177,7 +170,7 @@ export class ScriptAgent extends AgentBase {
   }
 
   public async getTrace(planId: string): Promise<PlannerResponse> {
-    return requestWithEndpointFallback<PlannerResponse>(this.connectionManager.getJwtConnection(), {
+    return requestWithEndpointFallback<PlannerResponse>(this.getJwtConnection(), {
       method: 'GET',
       url: `${this.apiBase}/v1.1/preview/sessions/${this.sessionId!}/plans/${planId}`,
       headers: {
@@ -213,7 +206,7 @@ export class ScriptAgent extends AgentBase {
 
     try {
       const response = await requestWithEndpointFallback<CompileAgentScriptResponse>(
-        this.connectionManager.getJwtConnection(),
+        this.getJwtConnection(),
         {
           method: 'POST',
           url,
@@ -279,10 +272,11 @@ export class ScriptAgent extends AgentBase {
     }
 
     const publisher = new ScriptAgentPublisher(
-      this.connectionManager,
+      this.options.connection,
       this.options.project,
       this.agentJson!,
-      skipMetadataRetrieve
+      skipMetadataRetrieve,
+      this.connectionManager
     );
     return publisher.publishAgentJson();
   }
@@ -403,17 +397,14 @@ export class ScriptAgent extends AgentBase {
         this.historyBuffer
       );
 
-      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(
-        this.connectionManager.getJwtConnection(),
-        {
-          method: 'POST',
-          url,
-          body: JSON.stringify(body),
-          headers: {
-            'x-client-name': 'afdx',
-          },
-        }
-      );
+      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(this.getJwtConnection(), {
+        method: 'POST',
+        url,
+        body: JSON.stringify(body),
+        headers: {
+          'x-client-name': 'afdx',
+        },
+      });
 
       const planId = response.messages.at(0)!.planId;
       this.planIds.add(planId);
@@ -443,9 +434,7 @@ export class ScriptAgent extends AgentBase {
       await this.historyBuffer.flush();
 
       if (this.apexDebugging && this.canApexDebug()) {
-        // Use standard connection for tooling API query to avoid JWT token clobbering
-        const standardConn = this.connectionManager.getStandardConnection();
-        const apexLog = await getDebugLog(standardConn, start, Date.now());
+        const apexLog = await getDebugLog(this.connection, start, Date.now());
         if (apexLog) {
           response.apexDebugLog = apexLog;
         }
@@ -456,7 +445,6 @@ export class ScriptAgent extends AgentBase {
       throw SfError.wrap(err);
     }
   }
-
 
   private setMockMode(mockMode: 'Mock' | 'Live Test'): void {
     this.mockMode = mockMode;
@@ -484,11 +472,9 @@ export class ScriptAgent extends AgentBase {
     }
 
     // send bypassUser=false when the compiledAgent.globalConfiguration.defaultAgentUser is INVALID
-    // Use standard connection for SOQL query to avoid JWT token clobbering
-    const standardConn = this.connectionManager.getStandardConnection();
     let bypassUser =
       (
-        await standardConn.query<{ Id: string }>(
+        await this.connection.query<{ Id: string }>(
           `SELECT Id FROM USER WHERE username='${this.agentJson.globalConfiguration.defaultAgentUser}'`
         )
       ).totalSize === 1;
@@ -523,9 +509,9 @@ export class ScriptAgent extends AgentBase {
       void Lifecycle.getInstance().emit('agents:simulation-starting', {});
 
       let response: AgentPreviewStartResponse;
-        try {
+      try {
         response = await requestWithEndpointFallback<AgentPreviewStartResponse>(
-          this.connectionManager.getJwtConnection(),
+          this.getJwtConnection(),
           {
             method: 'POST',
             url: `${this.apiBase}/v1.1/preview/sessions`,

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -18,7 +18,7 @@ import * as path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
-import { Logger, Messages, SfError, SfProject } from '@salesforce/core';
+import { Connection, Logger, Messages, SfError, SfProject } from '@salesforce/core';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
@@ -41,7 +41,7 @@ const getLogger = (): Logger => {
  */
 export class ScriptAgentPublisher {
   private readonly maybeMock: MaybeMock;
-  private readonly connectionManager: ConnectionManager;
+  private readonly standardConnection: Connection;
   private project: SfProject;
   private readonly agentJson: AgentJson;
   private readonly developerName: string;
@@ -55,21 +55,27 @@ export class ScriptAgentPublisher {
   };
 
   /**
-   * Creates a new AgentPublisher instance
+   * Creates a new AgentPublisher instance.
    *
-   * @param connectionManager The ConnectionManager for making SFAP and org requests
+   * @param connection The standard org Connection used for SOQL queries, metadata retrieve,
+   * and deploy. When a ConnectionManager is supplied, its standard connection is used
+   * instead so the caller's Connection is not mutated.
    * @param project The Salesforce project
-   * @param agentJson
+   * @param agentJson The compiled AgentJson to publish
    * @param skipMetadataRetrieve Whether to skip retrieving the agent metadata from the org
+   * @param connectionManager Optional ConnectionManager that provides isolated JWT and standard
+   * connections. When omitted, `connection` is used for both SFAP and org calls.
    */
   public constructor(
-    connectionManager: ConnectionManager,
+    connection: Connection,
     project: SfProject,
     agentJson: AgentJson,
-    skipMetadataRetrieve: boolean = false
+    skipMetadataRetrieve: boolean = false,
+    connectionManager?: ConnectionManager
   ) {
-    this.connectionManager = connectionManager;
-    this.maybeMock = new MaybeMock(connectionManager.getJwtConnection());
+    this.standardConnection = connectionManager ? connectionManager.getStandardConnection() : connection;
+    const jwtConnection = connectionManager ? connectionManager.getJwtConnection() : connection;
+    this.maybeMock = new MaybeMock(jwtConnection);
     this.project = project;
     this.agentJson = agentJson;
     this.skipRetrieve = skipMetadataRetrieve;
@@ -93,7 +99,7 @@ export class ScriptAgentPublisher {
     const body = {
       agentDefinition: this.agentJson,
       instanceConfig: {
-        endpoint: this.connectionManager.getStandardConnection().instanceUrl,
+        endpoint: this.standardConnection.instanceUrl,
       },
     };
 
@@ -122,7 +128,6 @@ export class ScriptAgentPublisher {
       });
     }
   }
-
 
   /**
    * Validates and extracts the developer name from the agent configuration,
@@ -166,8 +171,6 @@ export class ScriptAgentPublisher {
    * @param botVersionName The bot version name
    */
   private async retrieveAgentMetadata(botVersionName: string): Promise<void> {
-    const standardConnection = this.connectionManager.getStandardConnection();
-
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     const genAiPluginAndFunctions = this.agentJson.agentVersion.nodes.flatMap((n) => [
@@ -185,12 +188,12 @@ export class ScriptAgentPublisher {
         directoryPaths: [defaultPackagePath],
       },
       org: {
-        username: standardConnection.getUsername()!,
+        username: this.standardConnection.getUsername()!,
         exclude: [],
       },
     });
     const retrieve = await cs.retrieve({
-      usernameOrConnection: standardConnection,
+      usernameOrConnection: this.standardConnection,
       merge: true,
       format: 'source',
       output: path.resolve(this.project.getPath(), defaultPackagePath),
@@ -234,11 +237,10 @@ export class ScriptAgentPublisher {
       suppressEmptyNode: false,
     });
     await writeFile(this.bundleMetaPath, xmlBuilder.build(authoringBundle));
-    const standardConnection = this.connectionManager.getStandardConnection();
 
     // 2. attempt to deploy the authoring bundle to the org
     const deploy = await ComponentSet.fromSource(this.bundleDir).deploy({
-      usernameOrConnection: standardConnection,
+      usernameOrConnection: this.standardConnection,
     });
     const deployResult = await deploy.pollStatus();
 
@@ -268,9 +270,7 @@ export class ScriptAgentPublisher {
    */
   private async getPublishedBotId(agentApiName: string): Promise<string | undefined> {
     try {
-      // Use standard connection for SOQL query to avoid JWT token clobbering
-      const standardConn = this.connectionManager.getStandardConnection();
-      const queryResult = await standardConn.singleRecordQuery<{ Id: string }>(
+      const queryResult = await this.standardConnection.singleRecordQuery<{ Id: string }>(
         `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentApiName}'`
       );
       getLogger().debug(`Agent with developer name ${agentApiName} and id ${queryResult.Id} is already published.`);
@@ -289,9 +289,7 @@ export class ScriptAgentPublisher {
    */
   private async getVersionDeveloperName(botVersionId: string): Promise<string> {
     try {
-      // Use standard connection for SOQL query to avoid JWT token clobbering
-      const standardConn = this.connectionManager.getStandardConnection();
-      const queryResult = await standardConn.singleRecordQuery<{ DeveloperName: string }>(
+      const queryResult = await this.standardConnection.singleRecordQuery<{ DeveloperName: string }>(
         `SELECT DeveloperName FROM BotVersion WHERE Id='${botVersionId}'`
       );
       getLogger().debug(`Bot version with id ${botVersionId} is ${queryResult.DeveloperName}.`);

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -20,7 +20,7 @@ import { useNamedUserJwt } from './utils';
 /**
  * Result of JWT validation
  */
-export interface JwtValidationResult {
+export type JwtValidationResult = {
   isValid: boolean;
   hasRequiredFields: boolean;
   missingFields: string[];
@@ -31,7 +31,7 @@ export interface JwtValidationResult {
   issuer?: string;
   appId?: string;
   scopes?: string[];
-}
+};
 
 /**
  * Manages JWT and standard connections for agent operations.
@@ -70,14 +70,14 @@ export class ConnectionManager {
   /**
    * Creates a new ConnectionManager instance.
    *
-   * This method:
-   * 1. Creates a standard org connection
-   * 2. Creates and validates a JWT connection for SFAP
-   * 3. Installs a guard to prevent JWT corruption
+   * Builds two separate Connection objects derived from the username on the supplied
+   * connection: a standard connection for org-instance operations (SOQL, tooling,
+   * metadata) and a JWT-upgraded connection for SFAP API calls. The supplied
+   * connection is read-only — it is never mutated.
    *
-   * @param connection - The base connection to use
+   * @param connection - The connection whose username is used to derive the new connections
    * @returns A new ConnectionManager instance
-   * @throws {SfError} If JWT creation or validation fails
+   * @throws {SfError} If JWT creation or validation fails, or if the connection has no username
    */
   public static async create(connection: Connection): Promise<ConnectionManager> {
     const logger = Logger.childFromRoot('ConnectionManager');
@@ -92,53 +92,59 @@ export class ConnectionManager {
 
     logger.debug(`Creating ConnectionManager for user: ${username}`);
 
-    // Create standard connection for org operations
-    const standardConn = await this.createStandardConnection(username);
-    logger.debug('Standard connection created');
+    // Build two fresh, independent connections — one for org operations, one for SFAP JWT.
+    // Building from username (not from the caller's connection object) guarantees the
+    // caller's connection is not mutated by the JWT upgrade.
+    const standardConn = await this.createConnectionFromUsername(username);
+    const jwtSeed = await this.createConnectionFromUsername(username);
+    logger.debug('Standard and JWT seed connections created');
 
-    // Create and validate JWT connection for SFAP
-    const jwtConn = await this.createAndValidateJwtConnection(connection, logger);
+    const jwtConn = await this.createAndValidateJwtConnection(jwtSeed, logger);
     logger.debug('JWT connection created and validated');
 
     return new ConnectionManager(jwtConn, standardConn);
   }
 
   /**
-   * Creates a fresh standard connection for org-instance operations.
+   * Creates a fresh Connection from a username. Used for both the standard and JWT
+   * connections so the caller's original Connection object is never mutated.
    */
-  private static async createStandardConnection(username: string): Promise<Connection> {
+  private static async createConnectionFromUsername(username: string): Promise<Connection> {
     const authInfo = await AuthInfo.create({ username });
     return Connection.create({ authInfo });
   }
 
   /**
-   * Creates and validates a JWT connection for SFAP operations.
+   * Upgrades a connection to a JWT connection for SFAP operations and validates the result.
+   * The connection passed in is mutated (its accessToken is replaced with the JWT) — callers
+   * must pass a fresh, isolated Connection rather than a connection they care about.
    */
-  private static async createAndValidateJwtConnection(
-    connection: Connection,
-    logger: Logger
-  ): Promise<Connection> {
-    // Upgrade to JWT (useNamedUserJwt creates a new connection internally)
+  private static async createAndValidateJwtConnection(connection: Connection, logger: Logger): Promise<Connection> {
     const upgraded = await useNamedUserJwt(connection);
     logger.debug('Connection upgraded to JWT');
 
-    // Validate JWT immediately after creation
     const validation = this.validateJwt(upgraded.accessToken ?? undefined);
 
     if (!validation.isValid) {
       logger.error('JWT validation failed:', validation);
+      const actions = ['Ensure your Connected App has the correct scopes: chatbot_api, sfap_api, web'];
+      if (validation.missingFields.length > 0) {
+        actions.push(`JWT missing required fields: ${validation.missingFields.join(', ')}`);
+      }
+      if (validation.isExpired) {
+        actions.push('JWT is expired - ensure system time is correct');
+      }
       throw SfError.create({
         name: 'InvalidJwtToken',
         message: 'Failed to create valid JWT for SFAP access',
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        data: { validation: JSON.parse(JSON.stringify(validation)) },
-        actions: [
-          'Ensure your Connected App has the correct scopes: chatbot_api, sfap_api, web',
-          validation.missingFields.length > 0
-            ? `JWT missing required fields: ${validation.missingFields.join(', ')}`
-            : '',
-          validation.isExpired ? 'JWT is expired - ensure system time is correct' : '',
-        ].filter(Boolean),
+        data: {
+          validation: {
+            ...validation,
+            expiresAt: validation.expiresAt?.toISOString(),
+            issuedAt: validation.issuedAt?.toISOString(),
+          },
+        },
+        actions,
       });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@ import { Connection, Logger, SfProject } from '@salesforce/core';
 import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import { type ApexLog } from '@salesforce/types/tooling';
 import { metric } from './utils';
-import { ConnectionManager } from './connectionManager';
 
 // ====================================================
 //     Compilation API exit codes
@@ -63,7 +62,7 @@ export type PreviewMetadata = {
 };
 
 export type BaseAgentConfig = {
-  connectionManager: ConnectionManager;
+  connection: Connection;
   logger?: Logger;
 };
 
@@ -82,15 +81,11 @@ export type ScriptAgentOptions = {
   aabName: string;
   // pre-compiled AgentJSON; when provided, skips the compile step during preview
   agentJson?: AgentJson;
-  // Internal use only - ConnectionManager created by Agent.init()
-  connectionManager?: ConnectionManager;
 };
 export type ProductionAgentOptions = {
   connection: Connection;
   project: SfProject;
   apiNameOrId: string;
-  // Internal use only - ConnectionManager created by Agent.init()
-  connectionManager?: ConnectionManager;
 };
 
 /**

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -107,7 +107,7 @@ describe('AgentPublisher', () => {
     it('should validate developer name and bundle directory during construction', async () => {
       await createTestBundleStructure();
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
       expect(publisher['developerName']).to.equal('test_agent');
       expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
     });
@@ -121,7 +121,9 @@ describe('AgentPublisher', () => {
         },
       };
 
-      expect(() => new ScriptAgentPublisher(connectionManager, sfProject, agentJsonNoBundle)).to.throw(SfError);
+      expect(
+        () => new ScriptAgentPublisher(connection, sfProject, agentJsonNoBundle, false, connectionManager)
+      ).to.throw(SfError);
     });
   });
 
@@ -141,7 +143,7 @@ describe('AgentPublisher', () => {
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
 
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -171,7 +173,7 @@ describe('AgentPublisher', () => {
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
 
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson, true);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, true, connectionManager);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -203,7 +205,7 @@ describe('AgentPublisher', () => {
         .resolves({ DeveloperName: 'v1' });
 
       // Note: constructor called WITHOUT the 4th arg (defaults to false)
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -226,7 +228,7 @@ describe('AgentPublisher', () => {
     it('should publish new version of an existing agent when there is a bot in the org for the given developer name', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgentVersion-Success');
 
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -257,7 +259,7 @@ describe('AgentPublisher', () => {
     it('should handle API errors during publishing', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishAgentJson-Error');
 
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -274,9 +276,7 @@ describe('AgentPublisher', () => {
       }
     });
 
-    // TODO: These tests checked for refreshAuth behavior that no longer exists with ConnectionManager
-    // ConnectionManager handles connection lifecycle internally
-    it.skip('should call refreshAuth in finally block when connection has a refresh token', async () => {
+    it('should not mutate the caller-supplied connection during publish', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
         .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
@@ -284,15 +284,10 @@ describe('AgentPublisher', () => {
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
 
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
-
-      $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
-
-      // Stub getAuthInfoFields to return a refresh token
-      $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({
-        refreshToken: 'some-refresh-token',
-      });
+      const originalAccessToken = connection.accessToken;
       const refreshStub = $$.SANDBOX.stub(connection, 'refreshAuth').resolves();
+
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       $$.SANDBOX.stub(publisher as any, 'retrieveAgentMetadata').resolves();
@@ -301,34 +296,9 @@ describe('AgentPublisher', () => {
 
       await publisher.publishAgentJson();
 
-      expect(refreshStub.calledOnce).to.be.true;
-    });
-
-    it.skip('should skip refreshAuth in finally block when connection has no refresh token (ECA auth)', async () => {
-      process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
-      $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
-        .throws(new Error('No records found'))
-        .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
-        .resolves({ DeveloperName: 'v1' });
-
-      publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
-
-      $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
-
-      // Stub getAuthInfoFields to return NO refresh token (ECA auth)
-      $$.SANDBOX.stub(connection, 'getAuthInfoFields').returns({});
-      const refreshStub = $$.SANDBOX.stub(connection, 'refreshAuth').resolves();
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      $$.SANDBOX.stub(publisher as any, 'retrieveAgentMetadata').resolves();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      $$.SANDBOX.stub(publisher as any, 'deployAuthoringBundle').resolves();
-
-      await publisher.publishAgentJson();
-
-      // refreshAuth should NOT be called when there's no refresh token
+      // The caller's connection should be untouched: no refresh, no token swap.
       expect(refreshStub.called).to.be.false;
+      expect(connection.accessToken).to.equal(originalAccessToken);
     });
   });
 
@@ -337,7 +307,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       const expectedBotId = '0Xx1234567890ABC';
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves({ Id: expectedBotId });
@@ -355,7 +325,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(new Error('No records found'));
 
@@ -374,7 +344,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       const expectedVersionName = 'v1';
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves({ DeveloperName: expectedVersionName });
@@ -392,7 +362,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(new Error('No records found'));
 
@@ -421,7 +391,7 @@ describe('AgentPublisher', () => {
         '/nonexistent/path/test_agent.bundle-meta.xml'
       );
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const deployAuthoringBundle = (publisher as any).deployAuthoringBundle.bind(publisher);
@@ -445,7 +415,7 @@ describe('AgentPublisher', () => {
       const bundleMetaPath = join(bundleDir, `${developerName}.bundle-meta.xml`);
 
       const validateStub = createValidateDeveloperNameStub(developerName, bundleDir, bundleMetaPath);
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // The standard connection is already set up in connectionManager via createMockConnectionManager
 
@@ -500,7 +470,7 @@ describe('AgentPublisher', () => {
       $$.SANDBOX.stub(compSet, 'retrieve').resolves(mdApiRetrieve);
       const buildStub = $$.SANDBOX.stub(ComponentSetBuilder, 'build').resolves(compSet);
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const retrieveAgentMetadata = (publisher as any).retrieveAgentMetadata.bind(publisher);
@@ -534,7 +504,7 @@ describe('AgentPublisher', () => {
       $$.SANDBOX.stub(compSet, 'retrieve').resolves(mdApiRetrieve);
       $$.SANDBOX.stub(ComponentSetBuilder, 'build').resolves(compSet);
 
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const retrieveAgentMetadata = (publisher as any).retrieveAgentMetadata.bind(publisher);
@@ -637,7 +607,7 @@ describe('AgentPublisher', () => {
       };
 
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJsonWithNodes);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonWithNodes, false, connectionManager);
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();
@@ -714,7 +684,13 @@ describe('AgentPublisher', () => {
       };
 
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJsonWithNodesNoTools);
+      const publisher = new ScriptAgentPublisher(
+        connection,
+        sfProject,
+        agentJsonWithNodesNoTools,
+        false,
+        connectionManager
+      );
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();
@@ -762,7 +738,7 @@ describe('AgentPublisher', () => {
     it('should not include GenAiPlugin and GenAiFunction entries when nodes array is empty', async () => {
       // Use the default agentJson which has empty nodes array
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(connectionManager, sfProject, agentJson);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -151,7 +151,7 @@ describe('Agents', () => {
       });
       requestStub.withArgs(sinon.match.has('url', sinon.match(/authoring\/scripts/))).rejects(err404);
 
-      const agent = new ScriptAgent({ connection, connectionManager, project: sfProject!, aabName: 'myAgent' });
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
       try {
         await agent.compile();
         expect.fail('Expected compile() to throw');
@@ -170,7 +170,7 @@ describe('Agents', () => {
       });
       requestStub.withArgs(sinon.match.has('url', sinon.match(/authoring\/scripts/))).rejects(err500);
 
-      const agent = new ScriptAgent({ connection, connectionManager, project: sfProject!, aabName: 'myAgent' });
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
       try {
         await agent.compile();
         expect.fail('Expected compile() to throw');
@@ -264,7 +264,7 @@ describe('Agents', () => {
         entityId: 'test-entity-id',
       } as never);
 
-      const agent = new ScriptAgent({ connection, connectionManager, project: sfProject!, aabName: 'myAgent' });
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
       // Replacements are applied during publish flow
       await agent.publish();
 
@@ -365,7 +365,7 @@ describe('Agents', () => {
         dslVersion: '0.0.3.rc29',
       });
 
-      const agent = new ScriptAgent({ connection, connectionManager, project: sfProject!, aabName: 'myAgent' });
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
       // compile() never applies replacements (only publish does)
       const compileResult = await agent.compile();
 
@@ -517,13 +517,11 @@ describe('Agents', () => {
         dslVersion: '0.0.3.rc29',
       });
       // Bootstrap endpoint for compile - return valid JWT format token
-      requestStub
-        .withArgs(sinon.match({ url: `${connection.instanceUrl}/agentforce/bootstrap/nameduser` }))
-        .resolves({
-          // eslint-disable-next-line camelcase
-          access_token:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoidGVzdCJ9.4Adcj0vVzk6B5R-9X8kBR1R0N0FhT3ZSY0J5Z1Z4Y2c',
-        });
+      requestStub.withArgs(sinon.match({ url: `${connection.instanceUrl}/agentforce/bootstrap/nameduser` })).resolves({
+        // eslint-disable-next-line camelcase
+        access_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoidGVzdCJ9.4Adcj0vVzk6B5R-9X8kBR1R0N0FhT3ZSY0J5Z1Z4Y2c',
+      });
       // Publish endpoint should return error response
       requestStub.withArgs(sinon.match({ url: sinon.match(/ai-agent\/v1\.1\/authoring\/agents/) })).resolves({
         isSuccess: false,
@@ -619,13 +617,11 @@ describe('Agents', () => {
       // 1. Return valid JWT for nameduser endpoint
       // 2. Reject for all other requests with internal error
       const requestStub = $$.SANDBOX.stub(connection, 'request');
-      requestStub
-        .withArgs(sinon.match({ url: `${connection.instanceUrl}/agentforce/bootstrap/nameduser` }))
-        .resolves({
-          // eslint-disable-next-line camelcase
-          access_token:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoidGVzdCJ9.4Adcj0vVzk6B5R-9X8kBR1R0N0FhT3ZSY0J5Z1Z4Y2c',
-        });
+      requestStub.withArgs(sinon.match({ url: `${connection.instanceUrl}/agentforce/bootstrap/nameduser` })).resolves({
+        // eslint-disable-next-line camelcase
+        access_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoidGVzdCJ9.4Adcj0vVzk6B5R-9X8kBR1R0N0FhT3ZSY0J5Z1Z4Y2c',
+      });
       requestStub.rejects(internalError);
 
       $$.SANDBOX.stub(connection, 'query')

--- a/test/connectionManager.test.ts
+++ b/test/connectionManager.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { AuthInfo, Connection, SfError } from '@salesforce/core';
+import { ConnectionManager } from '../src/connectionManager';
+import * as utils from '../src/utils';
+
+// Build a minimally valid JWT (header.payload.signature) for tests.
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64 = (obj: unknown): string => Buffer.from(JSON.stringify(obj)).toString('base64').replace(/=+$/, '');
+  return `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64(payload)}.signature`;
+}
+
+const validPayload = {
+  sub: 'user@example.com',
+  iss: 'https://login.salesforce.com',
+  // eslint-disable-next-line camelcase
+  sfdc_app_id: 'app-123',
+  scope: 'chatbot_api sfap_api web',
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  iat: Math.floor(Date.now() / 1000),
+};
+
+describe('ConnectionManager', () => {
+  const $$ = new TestContext();
+  let testOrg: MockTestOrgData;
+  let callerConnection: Connection;
+
+  beforeEach(async () => {
+    testOrg = new MockTestOrgData();
+    callerConnection = await testOrg.getConnection();
+    callerConnection.instanceUrl = 'https://test.my.salesforce.com';
+    callerConnection.accessToken = 'caller-original-token';
+    $$.SANDBOXES.CONNECTION.restore();
+  });
+
+  describe('create', () => {
+    it('throws when the supplied connection has no username', async () => {
+      $$.SANDBOX.stub(callerConnection, 'getUsername').returns(undefined);
+
+      try {
+        await ConnectionManager.create(callerConnection);
+        expect.fail('expected create to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('MissingUsername');
+      }
+    });
+
+    it('does not mutate the caller-supplied connection', async () => {
+      // Stub useNamedUserJwt so it operates only on the seed Connection that ConnectionManager creates.
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      // Stub AuthInfo.create / Connection.create so the manager can build fresh connections from the username.
+      const seedConn = await testOrg.getConnection();
+      seedConn.accessToken = 'seed-token';
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      await ConnectionManager.create(callerConnection);
+
+      expect(callerConnection.accessToken).to.equal('caller-original-token');
+    });
+
+    it('returns a manager whose JWT and standard connections are distinct objects', async () => {
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const standardConn = await testOrg.getConnection();
+      const jwtConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      const createStub = $$.SANDBOX.stub(Connection, 'create');
+      createStub.onFirstCall().resolves(standardConn);
+      createStub.onSecondCall().resolves(jwtConn);
+
+      const manager = await ConnectionManager.create(callerConnection);
+
+      expect(manager.getStandardConnection()).to.equal(standardConn);
+      expect(manager.getJwtConnection()).to.equal(jwtConn);
+      expect(manager.getStandardConnection()).to.not.equal(manager.getJwtConnection());
+      expect(manager.getJwtConnection().accessToken).to.equal(makeJwt(validPayload));
+    });
+
+    it('throws InvalidJwtToken when the upgraded token is malformed', async () => {
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = 'not-a-jwt';
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      try {
+        await ConnectionManager.create(callerConnection);
+        expect.fail('expected create to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('InvalidJwtToken');
+      }
+    });
+
+    it('throws InvalidJwtToken when the upgraded token is expired', async () => {
+      const expiredPayload = { ...validPayload, exp: Math.floor(Date.now() / 1000) - 60 };
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(expiredPayload);
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      try {
+        await ConnectionManager.create(callerConnection);
+        expect.fail('expected create to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('InvalidJwtToken');
+        const actions = (err as SfError).actions ?? [];
+        expect(actions.some((a) => a.includes('expired'))).to.be.true;
+      }
+    });
+  });
+
+  describe('inspectJwt', () => {
+    it('reports a valid JWT with parsed claims', async () => {
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      const manager = await ConnectionManager.create(callerConnection);
+      const result = manager.inspectJwt();
+
+      expect(result.isValid).to.be.true;
+      expect(result.hasRequiredFields).to.be.true;
+      expect(result.isExpired).to.be.false;
+      expect(result.subject).to.equal(validPayload.sub);
+      expect(result.issuer).to.equal(validPayload.iss);
+      expect(result.appId).to.equal(validPayload.sfdc_app_id);
+      expect(result.scopes).to.deep.equal(['chatbot_api', 'sfap_api', 'web']);
+    });
+
+    it('reports an invalid result when the connection has no access token', async () => {
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      const manager = await ConnectionManager.create(callerConnection);
+      // Simulate a token getting cleared somehow.
+      manager.getJwtConnection().accessToken = undefined;
+      const result = manager.inspectJwt();
+
+      expect(result.isValid).to.be.false;
+      expect(result.missingFields).to.include('token');
+    });
+  });
+
+  describe('refreshStandardConnection', () => {
+    it('clears and refreshes only the standard connection', async () => {
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const standardConn = await testOrg.getConnection();
+      standardConn.accessToken = 'standard-token';
+      const jwtConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      const createStub = $$.SANDBOX.stub(Connection, 'create');
+      createStub.onFirstCall().resolves(standardConn);
+      createStub.onSecondCall().resolves(jwtConn);
+
+      const refreshAuthStub = $$.SANDBOX.stub(standardConn, 'refreshAuth').resolves();
+      const jwtRefreshStub = $$.SANDBOX.stub(jwtConn, 'refreshAuth').resolves();
+
+      const manager = await ConnectionManager.create(callerConnection);
+      await manager.refreshStandardConnection();
+
+      expect(refreshAuthStub.calledOnce).to.be.true;
+      expect(jwtRefreshStub.called).to.be.false;
+      expect(standardConn.accessToken).to.be.undefined;
+    });
+  });
+});

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -123,7 +123,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.getBotVersionMetadata();
 
       expect(version.VersionNumber).to.equal(2);
@@ -187,7 +190,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.getBotVersionMetadata(1);
 
       expect(version.VersionNumber).to.equal(1);
@@ -235,7 +241,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.getBotVersionMetadata(99);
@@ -269,7 +278,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.getBotVersionMetadata();
@@ -303,7 +315,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.getBotVersionMetadata(1);
@@ -372,7 +387,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.activate(1);
 
       expect(version.VersionNumber).to.equal(1);
@@ -435,7 +453,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.activate();
 
       expect(version.VersionNumber).to.equal(2);
@@ -482,7 +503,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.activate(1);
 
       expect(version.Status).to.equal('Active');
@@ -529,7 +553,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.activate(1);
@@ -580,7 +607,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.activate(99);
@@ -614,7 +644,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.activate();
@@ -683,7 +716,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
       const version = await agent.getLatestBotVersionMetadata();
 
       expect(version.VersionNumber).to.equal(2);
@@ -714,7 +750,10 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent({ connection, connectionManager, project: sfProject, apiNameOrId: 'TestAgent' });
+      const agent = new ProductionAgent(
+        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
+        connectionManager
+      );
 
       try {
         await agent.getLatestBotVersionMetadata();

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -985,32 +985,6 @@ describe('JWT Token Protection', () => {
       expect(requestStub.calledOnce).to.be.true;
     });
 
-    // TODO: Re-enable when JWT guard is implemented to prevent token clobbering
-    it.skip('should disable auto-refresh on JWT connection', async () => {
-      $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
-        accessToken: 'original-token',
-        instanceUrl: connection.instanceUrl,
-      });
-
-      $$.SANDBOX.stub(connection, 'request').resolves({
-        // eslint-disable-next-line camelcase
-        access_token: 'jwt.token.here',
-      });
-
-      await useNamedUserJwt(connection);
-
-      // Attempting to refresh should throw an error
-      try {
-        await connection.refreshAuth();
-        expect.fail('Expected refreshAuth to throw an error');
-      } catch (error) {
-        expect(error).to.be.instanceOf(SfError);
-        expect((error as SfError).name).to.equal('JwtConnectionMisuse');
-        expect((error as SfError).message).to.include('JWT connection');
-        expect((error as SfError).message).to.include('SFAP API calls');
-      }
-    });
-
     it('should throw error if JWT response is missing access_token', async () => {
       $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
         accessToken: 'original-token',
@@ -1090,39 +1064,6 @@ describe('JWT Token Protection', () => {
       await useNamedUserJwt(connection);
 
       expect(refreshStub.called).to.be.false;
-    });
-  });
-
-  // TODO: Re-enable when JWT guard is implemented to prevent token clobbering
-  describe.skip('JWT Guard Integration', () => {
-    it('should prevent token clobbering scenario', async () => {
-      // Simulate the bug scenario that we fixed
-      $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
-        accessToken: 'original-token',
-        instanceUrl: connection.instanceUrl,
-      });
-
-      $$.SANDBOX.stub(connection, 'request').resolves({
-        // eslint-disable-next-line camelcase
-        access_token: 'jwt.valid.token',
-      });
-
-      // Step 1: Upgrade to JWT
-      await useNamedUserJwt(connection);
-      expect(connection.accessToken).to.equal('jwt.valid.token');
-
-      // Step 2: Simulate a 401 that would trigger auto-refresh
-      // With our fix, this should throw instead of silently clobbering
-      try {
-        await connection.refreshAuth();
-        expect.fail('Expected refreshAuth to throw');
-      } catch (error) {
-        expect(error).to.be.instanceOf(SfError);
-        expect((error as SfError).name).to.equal('JwtConnectionMisuse');
-      }
-
-      // Step 3: Verify JWT is still intact
-      expect(connection.accessToken).to.equal('jwt.valid.token');
     });
   });
 });


### PR DESCRIPTION
## Summary

Refactor of #278 that keeps the connection-isolation fix but eliminates the breaking changes to the public API.

- `ConnectionManager` is internal — never exported, never appears in any public type (`BaseAgentConfig`, `ScriptAgentOptions`, `ProductionAgentOptions` revert to their `main`-branch shape).
- `ConnectionManager.create()` builds two fresh `Connection` objects from the username via `AuthInfo.create()` instead of mutating the caller's `Connection`. The supplied connection is read-only.
- `AgentBase` keeps its `protected readonly connection: Connection` property and `restoreConnection()` signature. JWT access goes through a new `protected getJwtConnection()` helper.
- `ScriptAgent`, `ProductionAgent`, and `ScriptAgentPublisher` constructors accept an optional internal-only `connectionManager` as a second positional parameter; direct instantiation (e.g., `new ProductionAgent({ connection, ... })`) continues to work as on `main`.

The library-internal clobbering scenario remains fixed: `getStandardConnection()` returns a fresh connection that never holds a JWT, so SOQL/tooling auto-refresh cannot overwrite the JWT used for SFAP requests.

## Test plan

- [x] `yarn lint` — 0 errors (warnings are pre-existing on `main`)
- [x] `yarn compile` — clean
- [x] `yarn test` — 300 passing, 1 pending (pre-existing skip unrelated to this work)
- [x] New `test/connectionManager.test.ts` — 8 tests covering: missing-username error, **no-mutation guarantee**, distinct JWT/standard connection objects, malformed token, expired token, `inspectJwt` claim parsing, `refreshStandardConnection` only touches the standard side
- [x] Replace the four `it.skip` tests from #278: the two in `test/utils.test.ts` tested an unimplemented JWT guard and are deleted (the new architecture doesn't need a guard); the two in `test/agentPublisher.test.ts` tested the old `try/finally` `refreshAuth` and are replaced by a new test asserting the no-mutation contract during publish
- [x] `git diff main -- src/types.ts src/index.ts` — empty (public type surface matches `main`)
- [ ] Re-run NUTs against a real org

🤖 Generated with [Claude Code](https://claude.com/claude-code)