### PR TITLE
refactor: resolve ConnectionManager via per-Connection WeakMap @W-22389160@

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -37,7 +37,7 @@ import { MaybeMock } from './maybe-mock';
 import { decodeHtmlEntities, findLocalAgents } from './utils';
 import { ScriptAgent } from './agents/scriptAgent';
 import { ProductionAgent } from './agents/productionAgent';
-import { ConnectionManager } from './connectionManager';
+import { managerFor } from './connectionManager';
 
 /** Instance type returned from Agent.init(); has setSessionId, getHistoryDir, preview, etc. */
 export type AgentInstance = ScriptAgent | ProductionAgent;
@@ -100,15 +100,16 @@ export class Agent {
   public static async init(
     options: ProductionAgentOptions | ScriptAgentOptions
   ): Promise<ScriptAgent | ProductionAgent> {
-    // ConnectionManager isolates JWT (for SFAP) and standard (for org) connections so
-    // the caller's connection is never mutated by JWT upgrades or auto-refresh.
-    const connectionManager = await ConnectionManager.create(options.connection);
+    // Pre-warm the per-Connection ConnectionManager cache so the JWT bootstrap and
+    // standard-connection setup happen here instead of on the first SFAP/SOQL call.
+    // Subsequent managerFor(options.connection) lookups inside the agent are cache hits.
+    await managerFor(options.connection);
 
     // Type guard: check if it's ScriptAgentOptions by looking for 'aabName'
     if ('aabName' in options) {
-      return new ScriptAgent(options, connectionManager);
+      return new ScriptAgent(options);
     } else {
-      const agent = new ProductionAgent(options, connectionManager);
+      const agent = new ProductionAgent(options);
       await agent.getBotMetadata();
       return agent;
     }
@@ -230,10 +231,8 @@ export class Agent {
   ): Promise<AgentCreateResponse> {
     const url = '/connect/ai-assist/create-agent';
 
-    // Create ConnectionManager to get JWT connection for SFAP API calls
-    const connectionManager = await ConnectionManager.create(connection);
-    const jwtConnection = connectionManager.getJwtConnection();
-    const maybeMock = new MaybeMock(jwtConnection);
+    const connectionManager = await managerFor(connection);
+    const maybeMock = new MaybeMock(connectionManager.getJwtConnection());
 
     // When previewing agent creation just return the response.
     if (!config.saveAgent) {
@@ -312,10 +311,8 @@ export class Agent {
    * @returns the agent job spec
    */
   public static async createSpec(connection: Connection, config: AgentJobSpecCreateConfig): Promise<AgentJobSpec> {
-    // Create ConnectionManager to get JWT connection for SFAP API calls
-    const connectionManager = await ConnectionManager.create(connection);
-    const jwtConnection = connectionManager.getJwtConnection();
-    const maybeMock = new MaybeMock(jwtConnection);
+    const connectionManager = await managerFor(connection);
+    const maybeMock = new MaybeMock(connectionManager.getJwtConnection());
     verifyAgentSpecConfig(config);
 
     const url = '/connect/ai-assist/draft-agent-topics';

--- a/src/agents/agentBase.ts
+++ b/src/agents/agentBase.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path';
 import { Connection, SfError } from '@salesforce/core';
 import { AgentPreviewInterface, type AgentPreviewSendResponse, type PlannerResponse, PreviewMetadata } from '../types';
 import { getHistoryDir, SessionHistoryBuffer, TranscriptEntry } from '../utils';
-import { ConnectionManager } from '../connectionManager';
+import { managerFor } from '../connectionManager';
 
 /**
  * Abstract base class for agent preview functionality.
@@ -30,19 +30,12 @@ export abstract class AgentBase {
    */
   public name: string | undefined;
   /**
-   * The standard org connection used for SOQL queries, tooling API calls, and metadata
-   * operations. This is distinct from the JWT-upgraded connection used for SFAP API
-   * calls (held internally by the connection manager).
+   * The Connection passed in by the caller. Used as the lookup key into the ConnectionManager
+   * cache (see managerFor()) — never used directly for SFAP or org API calls. Subclasses go
+   * through getJwtConnection() / getStandardConnection() so that JWT and standard connections
+   * remain isolated.
    */
   protected readonly connection: Connection;
-  /**
-   * Holds isolated JWT and standard connections. When a ConnectionManager is supplied
-   * by Agent.init() / Agent.create() / Agent.createSpec(), the agent gets fully
-   * isolated connections (the caller's connection is not mutated). When undefined
-   * (consumers instantiating an agent directly), the supplied connection is used as
-   * both the JWT and standard connection — preserving the pre-isolation behavior.
-   */
-  protected readonly connectionManager: ConnectionManager | undefined;
   protected sessionId: string | undefined;
   protected historyDir: string | undefined;
   protected historyBuffer: SessionHistoryBuffer | undefined;
@@ -51,25 +44,20 @@ export abstract class AgentBase {
   protected planIds = new Set<string>();
   public abstract preview: AgentPreviewInterface;
 
-  protected constructor(connection: Connection, connectionManager?: ConnectionManager) {
-    this.connectionManager = connectionManager;
-    this.connection = connectionManager ? connectionManager.getStandardConnection() : connection;
+  protected constructor(connection: Connection) {
+    this.connection = connection;
   }
 
   /**
    * Refreshes the access token on the standard connection.
    *
-   * Retained for backward compatibility. With the connection manager in place the
-   * caller's original Connection object is no longer mutated by agent operations,
-   * so this method only refreshes the internal standard connection.
+   * Retained for backward compatibility. The caller's original Connection is never mutated
+   * by agent operations, so this only refreshes the internal standard connection owned by
+   * the ConnectionManager.
    */
   public async restoreConnection(): Promise<void> {
-    if (this.connectionManager) {
-      await this.connectionManager.refreshStandardConnection();
-      return;
-    }
-    delete this.connection.accessToken;
-    await this.connection.refreshAuth();
+    const manager = await managerFor(this.connection);
+    await manager.refreshStandardConnection();
   }
 
   public setSessionId(sessionId: string): void {
@@ -107,11 +95,22 @@ export abstract class AgentBase {
 
   /**
    * Returns the connection to use for SFAP API calls (api.salesforce.com/einstein/ai-agent).
-   * When a ConnectionManager is in use this is the JWT-upgraded connection; otherwise it
-   * is the connection supplied at construction time.
+   * Always the JWT-upgraded connection from the ConnectionManager — never the caller's
+   * original Connection.
    */
-  protected getJwtConnection(): Connection {
-    return this.connectionManager ? this.connectionManager.getJwtConnection() : this.connection;
+  protected async getJwtConnection(): Promise<Connection> {
+    const manager = await managerFor(this.connection);
+    return manager.getJwtConnection();
+  }
+
+  /**
+   * Returns the standard org connection for SOQL queries, tooling API, and metadata
+   * operations. Always the manager's isolated standard connection — never the caller's
+   * original Connection — to keep JWT and org auth fully separate.
+   */
+  protected async getStandardConnection(): Promise<Connection> {
+    const manager = await managerFor(this.connection);
+    return manager.getStandardConnection();
   }
 
   /**

--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -41,7 +41,6 @@ import {
   SessionHistoryBuffer,
 } from '../utils';
 import { createTraceFlag, findTraceFlag, getDebugLog } from '../apexUtils';
-import { ConnectionManager } from '../connectionManager';
 import { AgentBase } from './agentBase';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agents');
@@ -53,8 +52,8 @@ export class ProductionAgent extends AgentBase {
   private apiName: string | undefined;
   private readonly apiBase: string;
 
-  public constructor(private options: ProductionAgentOptions, connectionManager?: ConnectionManager) {
-    super(options.connection, connectionManager);
+  public constructor(private options: ProductionAgentOptions) {
+    super(options.connection);
     this.apiBase = 'https://api.salesforce.com/einstein/ai-agent/v1';
     if (!options.apiNameOrId) {
       throw messages.createError('missingAgentNameOrId');
@@ -83,7 +82,8 @@ export class ProductionAgent extends AgentBase {
         'Id, IsDeleted, DeveloperName, MasterLabel, CreatedDate, CreatedById, LastModifiedDate, LastModifiedById, SystemModstamp, BotUserId, Description, Type, AgentType, AgentTemplate';
       const botVersionFields =
         'Id, Status, IsDeleted, BotDefinitionId, DeveloperName, CreatedDate, CreatedById, LastModifiedDate, LastModifiedById, SystemModstamp, VersionNumber, CopilotPrimaryLanguage, ToneType, CopilotSecondaryLanguages';
-      this.botMetadata = await this.connection.singleRecordQuery<BotMetadata>(
+      const standardConn = await this.getStandardConnection();
+      this.botMetadata = await standardConn.singleRecordQuery<BotMetadata>(
         `SELECT ${botDefinitionFields}, (SELECT ${botVersionFields} FROM BotVersions WHERE IsDeleted = false ORDER BY VersionNumber) FROM BotDefinition WHERE ${whereClause} LIMIT 1`
       );
       this.id = this.botMetadata.Id;
@@ -209,9 +209,10 @@ export class ProductionAgent extends AgentBase {
   protected async handleApexDebuggingSetup(): Promise<void> {
     const botMetadata = await this.getBotMetadata();
     if (botMetadata.BotUserId) {
-      const traceFlag = await findTraceFlag(this.connection, botMetadata.BotUserId);
+      const standardConn = await this.getStandardConnection();
+      const traceFlag = await findTraceFlag(standardConn, botMetadata.BotUserId);
       if (!traceFlag) {
-        await createTraceFlag(this.connection, botMetadata.BotUserId);
+        await createTraceFlag(standardConn, botMetadata.BotUserId);
       }
     }
   }
@@ -265,7 +266,7 @@ export class ProductionAgent extends AgentBase {
       };
       await logTurnToHistory(userEntry, ++this.turnCounter, this.historyDir, this.historyBuffer);
 
-      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(this.getJwtConnection(), {
+      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(await this.getJwtConnection(), {
         method: 'POST',
         url,
         body: JSON.stringify(body),
@@ -297,7 +298,7 @@ export class ProductionAgent extends AgentBase {
       await this.historyBuffer.flush();
 
       if (this.apexDebugging && this.canApexDebug()) {
-        const apexLog = await getDebugLog(this.connection, start, Date.now());
+        const apexLog = await getDebugLog(await this.getStandardConnection(), start, Date.now());
         if (apexLog) {
           response.apexDebugLog = apexLog;
         }
@@ -323,7 +324,7 @@ export class ProductionAgent extends AgentBase {
     }
 
     const url = `/connect/bot-versions/${botVersionMetadata.Id}/activation`;
-    const maybeMock = new MaybeMock(this.getJwtConnection());
+    const maybeMock = new MaybeMock(await this.getJwtConnection());
     const response = await maybeMock.request<BotActivationResponse>('POST', url, { status: desiredState });
     if (response.success) {
       const versionToUpdate = this.botMetadata!.BotVersions.records.find(
@@ -361,7 +362,7 @@ export class ProductionAgent extends AgentBase {
     };
 
     try {
-      const response = await requestWithEndpointFallback<AgentPreviewStartResponse>(this.getJwtConnection(), {
+      const response = await requestWithEndpointFallback<AgentPreviewStartResponse>(await this.getJwtConnection(), {
         method: 'POST',
         url,
         body: JSON.stringify(body),
@@ -423,7 +424,7 @@ export class ProductionAgent extends AgentBase {
     const url = `${this.apiBase}/sessions/${this.sessionId}`;
     try {
       // https://developer.salesforce.com/docs/einstein/genai/guide/agent-api-examples.html#end-session
-      const response = await requestWithEndpointFallback<AgentPreviewEndResponse>(this.getJwtConnection(), {
+      const response = await requestWithEndpointFallback<AgentPreviewEndResponse>(await this.getJwtConnection(), {
         method: 'DELETE',
         url,
         headers: {

--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -49,7 +49,6 @@ import {
 import { getDebugLog } from '../apexUtils';
 import { generateAgentScript } from '../templates/agentScriptTemplate';
 import { applyStringReplacementsToAgent } from '../stringReplacements';
-import { ConnectionManager } from '../connectionManager';
 import { ScriptAgentPublisher } from './scriptAgentPublisher';
 import { AgentBase } from './agentBase';
 
@@ -64,9 +63,8 @@ export class ScriptAgent extends AgentBase {
   private readonly aabDirectory: string;
   private readonly metaContent: string;
   private readonly agentFilePath: string;
-  public constructor(private options: ScriptAgentOptions, connectionManager?: ConnectionManager) {
-    super(options.connection, connectionManager);
-    this.options = options;
+  public constructor(private options: ScriptAgentOptions) {
+    super(options.connection);
     this.apiBase = 'https://api.salesforce.com/einstein/ai-agent';
 
     // Find the AAB directory using the project
@@ -170,7 +168,7 @@ export class ScriptAgent extends AgentBase {
   }
 
   public async getTrace(planId: string): Promise<PlannerResponse> {
-    return requestWithEndpointFallback<PlannerResponse>(this.getJwtConnection(), {
+    return requestWithEndpointFallback<PlannerResponse>(await this.getJwtConnection(), {
       method: 'GET',
       url: `${this.apiBase}/v1.1/preview/sessions/${this.sessionId!}/plans/${planId}`,
       headers: {
@@ -206,7 +204,7 @@ export class ScriptAgent extends AgentBase {
 
     try {
       const response = await requestWithEndpointFallback<CompileAgentScriptResponse>(
-        this.getJwtConnection(),
+        await this.getJwtConnection(),
         {
           method: 'POST',
           url,
@@ -275,8 +273,7 @@ export class ScriptAgent extends AgentBase {
       this.options.connection,
       this.options.project,
       this.agentJson!,
-      skipMetadataRetrieve,
-      this.connectionManager
+      skipMetadataRetrieve
     );
     return publisher.publishAgentJson();
   }
@@ -397,7 +394,7 @@ export class ScriptAgent extends AgentBase {
         this.historyBuffer
       );
 
-      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(this.getJwtConnection(), {
+      const response = await requestWithEndpointFallback<AgentPreviewSendResponse>(await this.getJwtConnection(), {
         method: 'POST',
         url,
         body: JSON.stringify(body),
@@ -434,7 +431,7 @@ export class ScriptAgent extends AgentBase {
       await this.historyBuffer.flush();
 
       if (this.apexDebugging && this.canApexDebug()) {
-        const apexLog = await getDebugLog(this.connection, start, Date.now());
+        const apexLog = await getDebugLog(await this.getStandardConnection(), start, Date.now());
         if (apexLog) {
           response.apexDebugLog = apexLog;
         }
@@ -472,9 +469,10 @@ export class ScriptAgent extends AgentBase {
     }
 
     // send bypassUser=false when the compiledAgent.globalConfiguration.defaultAgentUser is INVALID
+    const standardConn = await this.getStandardConnection();
     let bypassUser =
       (
-        await this.connection.query<{ Id: string }>(
+        await standardConn.query<{ Id: string }>(
           `SELECT Id FROM USER WHERE username='${this.agentJson.globalConfiguration.defaultAgentUser}'`
         )
       ).totalSize === 1;
@@ -511,7 +509,7 @@ export class ScriptAgent extends AgentBase {
       let response: AgentPreviewStartResponse;
       try {
         response = await requestWithEndpointFallback<AgentPreviewStartResponse>(
-          this.getJwtConnection(),
+          await this.getJwtConnection(),
           {
             method: 'POST',
             url: `${this.apiBase}/v1.1/preview/sessions`,

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -23,7 +23,7 @@ import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-ret
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
 import { findAuthoringBundle } from '../utils';
-import { ConnectionManager } from '../connectionManager';
+import { managerFor } from '../connectionManager';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agentPublisher');
@@ -40,8 +40,7 @@ const getLogger = (): Logger => {
  * Service class responsible for publishing agents to Salesforce orgs
  */
 export class ScriptAgentPublisher {
-  private readonly maybeMock: MaybeMock;
-  private readonly standardConnection: Connection;
+  private readonly connection: Connection;
   private project: SfProject;
   private readonly agentJson: AgentJson;
   private readonly developerName: string;
@@ -57,25 +56,19 @@ export class ScriptAgentPublisher {
   /**
    * Creates a new AgentPublisher instance.
    *
-   * @param connection The standard org Connection used for SOQL queries, metadata retrieve,
-   * and deploy. When a ConnectionManager is supplied, its standard connection is used
-   * instead so the caller's Connection is not mutated.
+   * @param connection The caller-supplied Connection. Used as the lookup key into the
+   * ConnectionManager cache (managerFor()); never used directly for SFAP or org API calls.
    * @param project The Salesforce project
    * @param agentJson The compiled AgentJson to publish
    * @param skipMetadataRetrieve Whether to skip retrieving the agent metadata from the org
-   * @param connectionManager Optional ConnectionManager that provides isolated JWT and standard
-   * connections. When omitted, `connection` is used for both SFAP and org calls.
    */
   public constructor(
     connection: Connection,
     project: SfProject,
     agentJson: AgentJson,
-    skipMetadataRetrieve: boolean = false,
-    connectionManager?: ConnectionManager
+    skipMetadataRetrieve: boolean = false
   ) {
-    this.standardConnection = connectionManager ? connectionManager.getStandardConnection() : connection;
-    const jwtConnection = connectionManager ? connectionManager.getJwtConnection() : connection;
-    this.maybeMock = new MaybeMock(jwtConnection);
+    this.connection = connection;
     this.project = project;
     this.agentJson = agentJson;
     this.skipRetrieve = skipMetadataRetrieve;
@@ -96,10 +89,12 @@ export class ScriptAgentPublisher {
   public async publishAgentJson(): Promise<PublishAgent> {
     getLogger().debug('Publishing Agent');
 
+    const manager = await managerFor(this.connection);
+
     const body = {
       agentDefinition: this.agentJson,
       instanceConfig: {
-        endpoint: this.standardConnection.instanceUrl,
+        endpoint: manager.getStandardConnection().instanceUrl,
       },
     };
 
@@ -107,7 +102,8 @@ export class ScriptAgentPublisher {
     // if we've found a botId in the org, then this agent has already been published before => ai-agent/v1.1/authoring/agents/<id>/versions
     // if we didn't find an Id in the org, then we're publishing for the first time         => ai-agent/v1.1/authoring/agents
     const url = botId ? `${this.API_URL}/${botId}/versions` : this.API_URL;
-    const response = await this.maybeMock.request<PublishAgentJsonResponse>('POST', url, body, this.API_HEADERS);
+    const maybeMock = new MaybeMock(manager.getJwtConnection());
+    const response = await maybeMock.request<PublishAgentJsonResponse>('POST', url, body, this.API_HEADERS);
 
     if (response.botId && response.botVersionId) {
       // we've published the AgentJson, now we need to:
@@ -171,6 +167,7 @@ export class ScriptAgentPublisher {
    * @param botVersionName The bot version name
    */
   private async retrieveAgentMetadata(botVersionName: string): Promise<void> {
+    const standardConn = (await managerFor(this.connection)).getStandardConnection();
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     const genAiPluginAndFunctions = this.agentJson.agentVersion.nodes.flatMap((n) => [
@@ -188,12 +185,12 @@ export class ScriptAgentPublisher {
         directoryPaths: [defaultPackagePath],
       },
       org: {
-        username: this.standardConnection.getUsername()!,
+        username: standardConn.getUsername()!,
         exclude: [],
       },
     });
     const retrieve = await cs.retrieve({
-      usernameOrConnection: this.standardConnection,
+      usernameOrConnection: standardConn,
       merge: true,
       format: 'source',
       output: path.resolve(this.project.getPath(), defaultPackagePath),
@@ -239,8 +236,9 @@ export class ScriptAgentPublisher {
     await writeFile(this.bundleMetaPath, xmlBuilder.build(authoringBundle));
 
     // 2. attempt to deploy the authoring bundle to the org
+    const standardConn = (await managerFor(this.connection)).getStandardConnection();
     const deploy = await ComponentSet.fromSource(this.bundleDir).deploy({
-      usernameOrConnection: this.standardConnection,
+      usernameOrConnection: standardConn,
     });
     const deployResult = await deploy.pollStatus();
 
@@ -270,7 +268,8 @@ export class ScriptAgentPublisher {
    */
   private async getPublishedBotId(agentApiName: string): Promise<string | undefined> {
     try {
-      const queryResult = await this.standardConnection.singleRecordQuery<{ Id: string }>(
+      const standardConn = (await managerFor(this.connection)).getStandardConnection();
+      const queryResult = await standardConn.singleRecordQuery<{ Id: string }>(
         `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentApiName}'`
       );
       getLogger().debug(`Agent with developer name ${agentApiName} and id ${queryResult.Id} is already published.`);
@@ -289,7 +288,8 @@ export class ScriptAgentPublisher {
    */
   private async getVersionDeveloperName(botVersionId: string): Promise<string> {
     try {
-      const queryResult = await this.standardConnection.singleRecordQuery<{ DeveloperName: string }>(
+      const standardConn = (await managerFor(this.connection)).getStandardConnection();
+      const queryResult = await standardConn.singleRecordQuery<{ DeveloperName: string }>(
         `SELECT DeveloperName FROM BotVersion WHERE Id='${botVersionId}'`
       );
       getLogger().debug(`Bot version with id ${botVersionId} is ${queryResult.DeveloperName}.`);

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -273,3 +273,48 @@ export class ConnectionManager {
     await this.standardConnection.refreshAuth();
   }
 }
+
+// Per-Connection cache of ConnectionManager instances. Keyed by Connection object identity
+// so callers never have to pass a manager around — any code that holds the caller's
+// Connection can resolve its associated manager via managerFor(connection).
+//
+// Caching the *promise* (not the resolved manager) deduplicates concurrent first-time
+// callers to a single JWT bootstrap. Using a WeakMap means entries are reclaimed when
+// the caller drops the Connection, so long-running processes (extensions, language
+// servers) don't accumulate stale managers.
+const managerCache = new WeakMap<Connection, Promise<ConnectionManager>>();
+
+/**
+ * Returns the ConnectionManager associated with the supplied Connection, creating one on
+ * the first call. Subsequent calls with the same Connection return the cached manager.
+ *
+ * Different Connection objects — even for the same username — get distinct managers,
+ * which is the desired behavior: the caller's connection identity is the unit of trust.
+ *
+ * @param connection The caller-supplied Connection used as the cache key
+ * @returns A promise resolving to the manager for this connection
+ */
+export const managerFor = async (connection: Connection): Promise<ConnectionManager> => {
+  let entry = managerCache.get(connection);
+  if (!entry) {
+    entry = ConnectionManager.create(connection).catch((err) => {
+      // Evict the failed bootstrap so a subsequent call can retry rather than re-throwing
+      // the cached error indefinitely.
+      managerCache.delete(connection);
+      throw err;
+    });
+    managerCache.set(connection, entry);
+  }
+  return entry;
+};
+
+/**
+ * Test-only helper: pre-populate the cache so tests can substitute a fake manager
+ * without exercising the real JWT bootstrap. Callers in production code should use
+ * managerFor() instead.
+ *
+ * @internal
+ */
+export const setManagerForTesting = (connection: Connection, manager: ConnectionManager): void => {
+  managerCache.set(connection, Promise.resolve(manager));
+};

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -23,7 +23,7 @@ import { ComponentSetBuilder, ComponentSet, MetadataApiRetrieve } from '@salesfo
 import { type AgentJson } from '../src';
 import * as utils from '../src/utils';
 import { ScriptAgentPublisher } from '../src/agents/scriptAgentPublisher';
-import { ConnectionManager } from '../src/connectionManager';
+import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
 import { testAgentJson } from './testData';
 
 describe('AgentPublisher', () => {
@@ -82,8 +82,11 @@ describe('AgentPublisher', () => {
     // restore the connection sandbox so that it doesn't override the builtin mocking (MaybeMock)
     $$.SANDBOXES.CONNECTION.restore();
 
-    // Create mock ConnectionManager
+    // Create mock ConnectionManager and seed the per-Connection cache so production
+    // code paths that call managerFor(connection) get the mock instead of doing a real
+    // JWT bootstrap.
     connectionManager = createMockConnectionManager(connection);
+    setManagerForTesting(connection, connectionManager);
 
     sfProject = SfProject.getInstance();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
@@ -107,7 +110,7 @@ describe('AgentPublisher', () => {
     it('should validate developer name and bundle directory during construction', async () => {
       await createTestBundleStructure();
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
       expect(publisher['developerName']).to.equal('test_agent');
       expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
     });
@@ -121,9 +124,7 @@ describe('AgentPublisher', () => {
         },
       };
 
-      expect(
-        () => new ScriptAgentPublisher(connection, sfProject, agentJsonNoBundle, false, connectionManager)
-      ).to.throw(SfError);
+      expect(() => new ScriptAgentPublisher(connection, sfProject, agentJsonNoBundle, false)).to.throw(SfError);
     });
   });
 
@@ -143,7 +144,7 @@ describe('AgentPublisher', () => {
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
 
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -173,7 +174,7 @@ describe('AgentPublisher', () => {
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
 
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, true, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, true);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -205,7 +206,7 @@ describe('AgentPublisher', () => {
         .resolves({ DeveloperName: 'v1' });
 
       // Note: constructor called WITHOUT the 4th arg (defaults to false)
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -228,7 +229,7 @@ describe('AgentPublisher', () => {
     it('should publish new version of an existing agent when there is a bot in the org for the given developer name', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgentVersion-Success');
 
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -259,7 +260,7 @@ describe('AgentPublisher', () => {
     it('should handle API errors during publishing', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishAgentJson-Error');
 
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // Mock useNamedUserJwt to return the connection without making HTTP calls
       $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
@@ -287,7 +288,7 @@ describe('AgentPublisher', () => {
       const originalAccessToken = connection.accessToken;
       const refreshStub = $$.SANDBOX.stub(connection, 'refreshAuth').resolves();
 
-      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       $$.SANDBOX.stub(publisher as any, 'retrieveAgentMetadata').resolves();
@@ -307,7 +308,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       const expectedBotId = '0Xx1234567890ABC';
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves({ Id: expectedBotId });
@@ -325,7 +326,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(new Error('No records found'));
 
@@ -344,7 +345,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       const expectedVersionName = 'v1';
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves({ DeveloperName: expectedVersionName });
@@ -362,7 +363,7 @@ describe('AgentPublisher', () => {
       // Create minimal publisher instance by mocking validateDeveloperName
       const validateStub = createValidateDeveloperNameStub();
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(new Error('No records found'));
 
@@ -391,7 +392,7 @@ describe('AgentPublisher', () => {
         '/nonexistent/path/test_agent.bundle-meta.xml'
       );
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const deployAuthoringBundle = (publisher as any).deployAuthoringBundle.bind(publisher);
@@ -415,7 +416,7 @@ describe('AgentPublisher', () => {
       const bundleMetaPath = join(bundleDir, `${developerName}.bundle-meta.xml`);
 
       const validateStub = createValidateDeveloperNameStub(developerName, bundleDir, bundleMetaPath);
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // The standard connection is already set up in connectionManager via createMockConnectionManager
 
@@ -470,7 +471,7 @@ describe('AgentPublisher', () => {
       $$.SANDBOX.stub(compSet, 'retrieve').resolves(mdApiRetrieve);
       const buildStub = $$.SANDBOX.stub(ComponentSetBuilder, 'build').resolves(compSet);
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const retrieveAgentMetadata = (publisher as any).retrieveAgentMetadata.bind(publisher);
@@ -504,7 +505,7 @@ describe('AgentPublisher', () => {
       $$.SANDBOX.stub(compSet, 'retrieve').resolves(mdApiRetrieve);
       $$.SANDBOX.stub(ComponentSetBuilder, 'build').resolves(compSet);
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const retrieveAgentMetadata = (publisher as any).retrieveAgentMetadata.bind(publisher);
@@ -607,7 +608,7 @@ describe('AgentPublisher', () => {
       };
 
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonWithNodes, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonWithNodes, false);
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();
@@ -684,13 +685,7 @@ describe('AgentPublisher', () => {
       };
 
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(
-        connection,
-        sfProject,
-        agentJsonWithNodesNoTools,
-        false,
-        connectionManager
-      );
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonWithNodesNoTools, false);
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();
@@ -738,7 +733,7 @@ describe('AgentPublisher', () => {
     it('should not include GenAiPlugin and GenAiFunction entries when nodes array is empty', async () => {
       // Use the default agentJson which has empty nodes array
       const validateStub = createValidateDeveloperNameStub();
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false, connectionManager);
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
 
       // Setup successful metadata retrieval mock
       const compSet = new ComponentSet();

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -25,7 +25,7 @@ import type { AgentCreateConfig, DraftAgentTopics, ExtendedAgentJobSpec } from '
 import { AgentSource, COMPILATION_API_EXIT_CODES } from '../src/types';
 import { ScriptAgent } from '../src';
 import { ScriptAgentPublisher } from '../src/agents/scriptAgentPublisher';
-import { ConnectionManager } from '../src/connectionManager';
+import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
 
 function createMockConnectionManager(conn: Connection): ConnectionManager {
   return {
@@ -57,9 +57,7 @@ describe('Agents', () => {
     // restore the connection sandbox so that it doesn't override the builtin mocking (MaybeMock)
     $$.SANDBOXES.CONNECTION.restore();
     connectionManager = createMockConnectionManager(connection);
-
-    // Stub ConnectionManager.create to return the mock connectionManager
-    $$.SANDBOX.stub(ConnectionManager, 'create').resolves(connectionManager);
+    setManagerForTesting(connection, connectionManager);
   });
 
   afterEach(() => {
@@ -151,7 +149,7 @@ describe('Agents', () => {
       });
       requestStub.withArgs(sinon.match.has('url', sinon.match(/authoring\/scripts/))).rejects(err404);
 
-      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' });
       try {
         await agent.compile();
         expect.fail('Expected compile() to throw');
@@ -170,7 +168,7 @@ describe('Agents', () => {
       });
       requestStub.withArgs(sinon.match.has('url', sinon.match(/authoring\/scripts/))).rejects(err500);
 
-      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' });
       try {
         await agent.compile();
         expect.fail('Expected compile() to throw');
@@ -264,7 +262,7 @@ describe('Agents', () => {
         entityId: 'test-entity-id',
       } as never);
 
-      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' });
       // Replacements are applied during publish flow
       await agent.publish();
 
@@ -365,7 +363,7 @@ describe('Agents', () => {
         dslVersion: '0.0.3.rc29',
       });
 
-      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' }, connectionManager);
+      const agent = new ScriptAgent({ connection, project: sfProject!, aabName: 'myAgent' });
       // compile() never applies replacements (only publish does)
       const compileResult = await agent.compile();
 

--- a/test/connectionManager.test.ts
+++ b/test/connectionManager.test.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { AuthInfo, Connection, SfError } from '@salesforce/core';
-import { ConnectionManager } from '../src/connectionManager';
+import { ConnectionManager, managerFor, setManagerForTesting } from '../src/connectionManager';
 import * as utils from '../src/utils';
 
 // Build a minimally valid JWT (header.payload.signature) for tests.
@@ -203,6 +203,76 @@ describe('ConnectionManager', () => {
       expect(refreshAuthStub.calledOnce).to.be.true;
       expect(jwtRefreshStub.called).to.be.false;
       expect(standardConn.accessToken).to.be.undefined;
+    });
+  });
+
+  describe('managerFor', () => {
+    it('returns the same manager for repeat calls with the same Connection', async () => {
+      const fake = {} as ConnectionManager;
+      setManagerForTesting(callerConnection, fake);
+
+      const a = await managerFor(callerConnection);
+      const b = await managerFor(callerConnection);
+
+      expect(a).to.equal(fake);
+      expect(b).to.equal(fake);
+    });
+
+    it('returns distinct managers for different Connection objects', async () => {
+      const otherConn = await testOrg.getConnection();
+      const m1 = {} as ConnectionManager;
+      const m2 = {} as ConnectionManager;
+      setManagerForTesting(callerConnection, m1);
+      setManagerForTesting(otherConn, m2);
+
+      expect(await managerFor(callerConnection)).to.equal(m1);
+      expect(await managerFor(otherConn)).to.equal(m2);
+    });
+
+    it('deduplicates concurrent first-time callers to a single bootstrap', async () => {
+      const otherConn = await testOrg.getConnection();
+      // No seeded manager — let the real ConnectionManager.create run, but stub its
+      // dependencies so we can count bootstraps.
+      const stub = $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      const [a, b] = await Promise.all([managerFor(otherConn), managerFor(otherConn)]);
+
+      expect(a).to.equal(b);
+      expect(stub.callCount).to.equal(1);
+    });
+
+    it('evicts the cache entry when bootstrap fails so a retry can succeed', async () => {
+      const otherConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(otherConn, 'getUsername')
+        .onFirstCall()
+        .returns(undefined)
+        .onSecondCall()
+        .returns('u@example.com');
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').callsFake(async (conn: Connection) => {
+        conn.accessToken = makeJwt(validPayload);
+        return conn;
+      });
+      const seedConn = await testOrg.getConnection();
+      $$.SANDBOX.stub(AuthInfo, 'create').resolves({} as AuthInfo);
+      $$.SANDBOX.stub(Connection, 'create').resolves(seedConn);
+
+      // First call fails with MissingUsername.
+      try {
+        await managerFor(otherConn);
+        expect.fail('expected first managerFor call to throw');
+      } catch (err) {
+        expect((err as SfError).name).to.equal('MissingUsername');
+      }
+
+      // Second call should retry and succeed because the failed entry was evicted.
+      const manager = await managerFor(otherConn);
+      expect(manager).to.be.instanceOf(ConnectionManager);
     });
   });
 });

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -17,7 +17,7 @@ import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
 import { ProductionAgent } from '../src/agents/productionAgent';
-import { ConnectionManager } from '../src/connectionManager';
+import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
 import type { BotMetadata } from '../src/types';
 
 Messages.importMessagesDirectory(__dirname);
@@ -55,6 +55,7 @@ describe('ProductionAgent', () => {
     $$.SANDBOXES.CONNECTION.restore();
 
     connectionManager = createMockConnectionManager(connection);
+    setManagerForTesting(connection, connectionManager);
 
     sfProject = SfProject.getInstance();
     // @ts-expect-error Not the full package def
@@ -123,10 +124,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.getBotVersionMetadata();
 
       expect(version.VersionNumber).to.equal(2);
@@ -190,10 +188,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.getBotVersionMetadata(1);
 
       expect(version.VersionNumber).to.equal(1);
@@ -241,10 +236,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.getBotVersionMetadata(99);
@@ -278,10 +270,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.getBotVersionMetadata();
@@ -315,10 +304,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.getBotVersionMetadata(1);
@@ -387,10 +373,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.activate(1);
 
       expect(version.VersionNumber).to.equal(1);
@@ -453,10 +436,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.activate();
 
       expect(version.VersionNumber).to.equal(2);
@@ -503,10 +483,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.activate(1);
 
       expect(version.Status).to.equal('Active');
@@ -553,10 +530,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.activate(1);
@@ -607,10 +581,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.activate(99);
@@ -644,10 +615,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.activate();
@@ -716,10 +684,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
       const version = await agent.getLatestBotVersionMetadata();
 
       expect(version.VersionNumber).to.equal(2);
@@ -750,10 +715,7 @@ describe('ProductionAgent', () => {
 
       $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(mockBotMetadata);
 
-      const agent = new ProductionAgent(
-        { connection, project: sfProject, apiNameOrId: 'TestAgent' },
-        connectionManager
-      );
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
 
       try {
         await agent.getLatestBotVersionMetadata();


### PR DESCRIPTION
## Summary

Follow-up to #285. Drops the optional `connectionManager` constructor argument from `AgentBase`, `ScriptAgent`, `ProductionAgent`, and `ScriptAgentPublisher` — all four now have the **exact** main-branch constructor signatures.

Internally, every site that needs a JWT or standard connection looks up the `ConnectionManager` by `Connection` object identity via a new exported `managerFor(connection)` helper backed by a module-private `WeakMap<Connection, Promise<ConnectionManager>>`.

### Why a WeakMap keyed by Connection identity

- **Caching the *promise*** (not the resolved manager) deduplicates concurrent first-time callers to a single JWT bootstrap.
- **WeakMap keys** mean stale managers are GC'd with their `Connection` — no leaks in long-running processes (extensions, language servers).
- **Object identity** as the key means same-username/different-org connections (sandbox vs prod) get distinct managers automatically — no composite key needed.
- **Failed bootstraps evict the cache entry** so a retry can succeed instead of caching the error forever.

### Public-surface impact

`AgentBase` exposes new `protected async getJwtConnection()` and `protected async getStandardConnection()` helpers so subclasses never need to know the manager exists. `ScriptAgentPublisher` constructs `MaybeMock` lazily inside `publishAgentJson()` now that the JWT lookup is async.

`git diff main` shows the constructor signatures of `AgentBase`, `ScriptAgent`, `ProductionAgent`, and `ScriptAgentPublisher` are unchanged from `main`.

### Tests

Tests use a new internal `setManagerForTesting(connection, manager)` helper to seed the cache with a stub instead of stubbing `ConnectionManager.create`. Adds four `managerFor` tests covering:

- same connection → same manager
- different connections → different managers
- concurrent dedup (single bootstrap)
- cache eviction on bootstrap failure (retry succeeds)

## Test plan

- [x] \`yarn lint\` — 0 errors (warnings are pre-existing on \`main\`)
- [x] \`yarn compile\` — clean
- [x] \`yarn test\` — 304 passing, 1 pending (pre-existing skip unrelated to this work)
- [x] \`git diff main\` — \`AgentBase\` / \`ScriptAgent\` / \`ProductionAgent\` / \`ScriptAgentPublisher\` constructors match \`main\` exactly
- [ ] Re-run NUTs against a real org

🤖 Generated with [Claude Code](https://claude.com/claude-code)