### PR TITLE
feat: add NGT (Agentforce Studio) create surface @W-22513615@

### DIFF
--- a/messages/agentTest.md
+++ b/messages/agentTest.md
@@ -9,3 +9,35 @@ Must provide an org connection to get agent test data based on an AiEvaluationDe
 # missingTestSpecData
 
 The agent test is missing the required data to provide a test spec.
+
+# ngtMissingTestCases
+
+NGT test spec must define at least one test case under `testCases:`.
+
+# ngtTestCaseMissingInputs
+
+NGT test case %s must define at least one entry under `inputs:`.
+
+# ngtTestCaseMissingScorers
+
+NGT test case %s must define at least one scorer under `scorers:`.
+
+# ngtScorerMissingExpected
+
+NGT scorer '%s' on test case %s requires an `expected:` value.
+
+# ngtTaskResolutionRequiresConversationHistory
+
+NGT scorer 'task_resolution' on test case %s requires conversationHistory on at least one input.
+
+# ngtMultiAgentMissingHandoff
+
+Test case %s targets a multi-agent subject and must include an `agent_handoff_match` scorer with an `expected:` value.
+
+# ngtConversationHistoryIndexAllOrNothing
+
+NGT conversationHistory on test case %s, input %s mixes turns with and without `index:`. Either set `index:` on every turn or none.
+
+# ngtLooksLikeLegacySpec
+
+This YAML looks like a legacy AiEvaluationDefinition spec (uses top-level `utterance:` / `expectedTopic:` / `customEvaluations:`). Use `--test-runner testing-center` for legacy authoring, or hand-edit the deployed XML for `<scorer scorerType="Custom">` blocks on NGT.

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -25,10 +25,18 @@ import {
   AvailableDefinition,
   AgentTestConfig,
   AiEvaluationDefinition,
+  AiTestCase,
+  AiTestCaseScorer,
+  AiTestingDefinition,
+  AiConversationTurnXml,
   TestSpec,
   MetadataExpectation,
+  NgtTestSpec,
+  NgtTestCase,
+  NgtTestCaseInput,
 } from './types.js';
-import { metric, sanitizeFilename } from './utils';
+import { isNgtScorerName, NgtScorerCatalog, NgtScorerName } from './ngtScorerCatalog';
+import { metric, sanitizeFilename, TestRunnerType } from './utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agentTest');
@@ -99,40 +107,66 @@ export class AgentTest {
   }
 
   /**
-   * Creates and deploys an AiEvaluationDefinition from a specification file.
+   * Creates and deploys a test definition from a specification file.
+   *
+   * Two metadata types are supported, selected via `options.testRunner`:
+   * `'testing-center'` (default) — legacy `AiEvaluationDefinition`. Filename `<apiName>.aiEvaluationDefinition-meta.xml`.
+   * `'agentforce-studio'` — new `AiTestingDefinition` (NGT). Filename `<apiName>.aiTestingDefinition-meta.xml`. 
+   *    Requires Metadata API v66.0 or later on the target org; the server gates this and the lib does not preflight.
    *
    * @param connection - Connection to the org where the agent test will be created.
-   * @param apiName - The API name of the AiEvaluationDefinition to create
-   * @param specFilePath - The path to the specification file to create the definition from
-   * @param options - Configuration options for creating the definition
-   * @param options.outputDir - The directory where the AiEvaluationDefinition file will be written
-   * @param options.preview - If true, writes the AiEvaluationDefinition file to <api-name>-preview-<timestamp>.xml in the current working directory and does not deploy it
+   * @param apiName - The API name of the test definition to create.
+   * @param specFilePath - The path to the YAML specification file.
+   * @param options - Configuration options for creating the definition.
+   * @param options.outputDir - The directory where the metadata file will be written.
+   * @param options.preview - If true, writes the metadata file to `<apiName>-preview-<timestamp>.xml` in the current working directory and does not deploy.
+   * @param options.testRunner - Which test runner to author for. Defaults to `'testing-center'`.
    *
    * @returns Promise containing:
-   * - path: The filesystem path to the created AiEvaluationDefinition file
-   * - contents: The AiEvaluationDefinition contents as a string
-   * - deployResult: The deployment result (if not in preview mode)
+   * - path: The filesystem path to the created metadata file.
+   * - contents: The metadata XML as a string.
+   * - deployResult: The deployment result (if not in preview mode).
    *
-   * @throws {SfError} When deployment fails
+   * @throws {SfError} When validation or deployment fails.
    */
   public static async create(
     connection: Connection,
     apiName: string,
     specFilePath: string,
-    options: { outputDir: string; preview?: boolean }
+    options: { outputDir: string; preview?: boolean; testRunner?: TestRunnerType }
   ): Promise<{ path: string; contents: string; deployResult?: DeployResult }> {
-    const agentTestSpec = parse(await readFile(specFilePath, 'utf-8')) as TestSpec;
     const lifecycle = Lifecycle.getInstance();
-    await lifecycle.emit(AgentTestCreateLifecycleStages.CreatingLocalMetadata, {});
     const preview = options.preview ?? false;
-    // outputDir is overridden if preview is true
+    const testRunner: TestRunnerType = options.testRunner ?? 'testing-center';
     const outputDir = preview ? process.cwd() : options.outputDir;
-    const filename = preview
-      ? `${apiName}-preview-${new Date().toISOString()}.xml`
-      : `${apiName}.aiEvaluationDefinition-meta.xml`;
-    const definitionPath = join(outputDir, sanitizeFilename(filename));
 
-    const xml = buildMetadataXml(convertToMetadata(agentTestSpec));
+    const rawSpec = await readFile(specFilePath, 'utf-8');
+
+    let xml: string;
+    let definitionPath: string;
+
+    if (testRunner === 'agentforce-studio') {
+      const ngtSpec = parse(rawSpec) as NgtTestSpec;
+      const isMultiAgent = await fetchIsMultiAgent(connection, ngtSpec.subjectName);
+      validateNgtSpec(ngtSpec, { isMultiAgent });
+      await lifecycle.emit(AgentTestCreateLifecycleStages.CreatingLocalMetadata, {});
+
+      const filename = preview
+        ? `${apiName}-preview-${new Date().toISOString()}.xml`
+        : `${apiName}.aiTestingDefinition-meta.xml`;
+      definitionPath = join(outputDir, sanitizeFilename(filename));
+      xml = buildTestingMetadataXml(convertToTestingMetadata(ngtSpec));
+    } else {
+      const agentTestSpec = parse(rawSpec) as TestSpec;
+      await lifecycle.emit(AgentTestCreateLifecycleStages.CreatingLocalMetadata, {});
+
+      const filename = preview
+        ? `${apiName}-preview-${new Date().toISOString()}.xml`
+        : `${apiName}.aiEvaluationDefinition-meta.xml`;
+      definitionPath = join(outputDir, sanitizeFilename(filename));
+      xml = buildMetadataXml(convertToMetadata(agentTestSpec));
+    }
+
     await mkdir(outputDir, { recursive: true });
     await writeFile(definitionPath, xml);
 
@@ -435,5 +469,164 @@ const buildMetadataXml = (data: AiEvaluationDefinition): string => {
 
   const xml = builder.build(aiEvalXml);
 
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${xml}`;
+};
+
+/**
+ * Validate an NGT test spec before conversion.
+ *
+ * Throws on the first failure encountered so authors get one clear actionable
+ * error at a time. Emits a Lifecycle warning (does not throw) for unknown
+ * scorer names — Core's MD validator catches those at deploy time.
+ */
+export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean }): void => {
+  if (!spec.testCases || spec.testCases.length === 0) {
+    throw ngtError('ngtMissingTestCases');
+  }
+
+  spec.testCases.forEach((testCase, tcIdx) => {
+    if (!testCase.inputs || testCase.inputs.length === 0) {
+      throw ngtError('ngtTestCaseMissingInputs', [tcIdx + 1]);
+    }
+    if (!testCase.scorers || testCase.scorers.length === 0) {
+      throw ngtError('ngtTestCaseMissingScorers', [tcIdx + 1]);
+    }
+
+    testCase.scorers.forEach((scorer) => {
+      if (!isNgtScorerName(scorer.name)) {
+        const unknownName = String(scorer.name);
+        void Lifecycle.getInstance().emitWarning(
+          `Unknown NGT scorer name '${unknownName}'. The deploy will be validated by the server.`
+        );
+        return;
+      }
+      const entry = NgtScorerCatalog[scorer.name];
+      if (entry.needsExpected && (scorer.expected === undefined || scorer.expected === '')) {
+        throw ngtError('ngtScorerMissingExpected', [scorer.name, tcIdx + 1]);
+      }
+    });
+
+    const hasTaskResolution = testCase.scorers.some((s) => s.name === 'task_resolution');
+    if (hasTaskResolution) {
+      const anyHistory = testCase.inputs.some(
+        (input) => Array.isArray(input.conversationHistory) && input.conversationHistory.length > 0
+      );
+      if (!anyHistory) {
+        throw ngtError('ngtTaskResolutionRequiresConversationHistory', [tcIdx + 1]);
+      }
+    }
+
+    if (ctx.isMultiAgent) {
+      const hasHandoff = testCase.scorers.some(
+        (s) => s.name === 'agent_handoff_match' && s.expected !== undefined && s.expected !== ''
+      );
+      if (!hasHandoff) {
+        throw ngtError('ngtMultiAgentMissingHandoff', [tcIdx + 1]);
+      }
+    }
+
+    testCase.inputs.forEach((input, inputIdx) => {
+      const turns = input.conversationHistory;
+      if (!turns || turns.length === 0) return;
+      const withIndex = turns.filter((t) => t.index !== undefined).length;
+      if (withIndex !== 0 && withIndex !== turns.length) {
+        throw ngtError('ngtConversationHistoryIndexAllOrNothing', [tcIdx + 1, inputIdx + 1]);
+      }
+    });
+  });
+};
+
+const ngtError = (key: string, tokens: Array<string | number> = []): SfError => {
+  const message = messages.getMessage(key, tokens);
+  return new SfError(message, key);
+};
+
+/** Reads `BotDefinition.IsMultiAgent` for the named subject. Conservative default `false` on read failure. */
+const fetchIsMultiAgent = async (connection: Connection, subjectName: string): Promise<boolean> => {
+  try {
+    // @ts-expect-error jsForce types don't model BotDefinition
+    const data = (await connection.metadata.read('BotDefinition', subjectName)) as { IsMultiAgent?: boolean } | undefined;
+    return Boolean(data?.IsMultiAgent);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Convert a validated `NgtTestSpec` to the `AiTestingDefinition` shape ready for XML serialization.
+ *
+ * Multi-input fan-out: when a test case has N inputs, emit N `<testCase>` elements sharing the
+ * same scorer set. The `<number>` field increments globally across the whole document.
+ *
+ * Must be called after `validateNgtSpec`.
+ */
+export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition => {
+  const testCases: AiTestCase[] = [];
+  let counter = 1;
+  for (const tc of spec.testCases) {
+    const sharedScorers = tc.scorers.map(toScorerXml);
+    for (const input of tc.inputs) {
+      testCases.push({
+        number: counter++,
+        inputs: toInputsXml(input),
+        scorer: sharedScorers,
+      });
+    }
+  }
+  return {
+    ...(spec.description && { description: spec.description }),
+    name: spec.name,
+    subjectName: spec.subjectName,
+    subjectType: spec.subjectType,
+    ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
+    testCase: testCases,
+  };
+};
+
+const toScorerXml = (scorer: NgtTestCase['scorers'][number]): AiTestCaseScorer => {
+  const name = scorer.name as NgtScorerName;
+  // Quality scorers (needsExpected:false) and unknown names omit expectedValue.
+  const known = isNgtScorerName(name) ? NgtScorerCatalog[name] : undefined;
+  const includeExpected = scorer.expected !== undefined && (known?.needsExpected ?? true);
+  return includeExpected ? { name, expectedValue: scorer.expected as string } : { name };
+};
+
+const toInputsXml = (input: NgtTestCaseInput): AiTestCase['inputs'] => {
+  const inputs: { utterance: string; contextVariable?: Array<{ variableName: string; variableValue: string }>; conversationHistory?: AiConversationTurnXml[] } = {
+    utterance: input.utterance,
+  };
+  if (input.contextVariables && input.contextVariables.length > 0) {
+    inputs.contextVariable = input.contextVariables.map((cv) => ({
+      variableName: cv.name,
+      variableValue: cv.value,
+    }));
+  }
+  if (input.conversationHistory && input.conversationHistory.length > 0) {
+    inputs.conversationHistory = input.conversationHistory.map((turn, i) =>
+      turn.role === 'agent'
+        ? { role: turn.role, message: turn.message, topic: turn.topic, index: turn.index ?? i }
+        : { role: turn.role, message: turn.message, index: turn.index ?? i }
+    );
+  }
+  return inputs;
+};
+
+/** Serialize an `AiTestingDefinition` to source-format XML. Mirrors `buildMetadataXml`. */
+export const buildTestingMetadataXml = (data: AiTestingDefinition): string => {
+  const wrapped = {
+    AiTestingDefinition: {
+      $xmlns: 'http://soap.sforce.com/2006/04/metadata',
+      ...data,
+    },
+  };
+
+  const builder = new XMLBuilder({
+    format: true,
+    attributeNamePrefix: '$',
+    indentBy: '    ',
+    ignoreAttributes: false,
+  });
+
+  const xml = builder.build(wrapped);
   return `<?xml version="1.0" encoding="UTF-8"?>\n${xml}`;
 };

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -111,8 +111,8 @@ export class AgentTest {
    *
    * Two metadata types are supported, selected via `options.testRunner`:
    * `'testing-center'` (default) — legacy `AiEvaluationDefinition`. Filename `<apiName>.aiEvaluationDefinition-meta.xml`.
-   * `'agentforce-studio'` — new `AiTestingDefinition` (NGT). Filename `<apiName>.aiTestingDefinition-meta.xml`. 
-   *    Requires Metadata API v66.0 or later on the target org; the server gates this and the lib does not preflight.
+   * `'agentforce-studio'` — new `AiTestingDefinition` (NGT). Filename `<apiName>.aiTestingDefinition-meta.xml`.
+   * Requires Metadata API v66.0 or later on the target org; the server gates this and the lib does not preflight.
    *
    * @param connection - Connection to the org where the agent test will be created.
    * @param apiName - The API name of the test definition to create.

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,19 @@ export {
   type MetadataCustomEvaluation,
   type AiEvaluationDefinition,
 
+  // NGT (Agentforce Studio) Authoring + Metadata Types
+  type NgtTestSpec,
+  type NgtTestCase,
+  type NgtTestCaseInput,
+  type NgtTestCaseScorer,
+  type NgtContextVar,
+  type NgtConversationTurn,
+  type AiTestingDefinition,
+  type AiTestCase,
+  type AiTestCaseInputXml,
+  type AiTestCaseScorer,
+  type AiConversationTurnXml,
+
   // Agentforce Studio Testing Types
   type AgentforceStudioTestStartResponse,
   type AgentforceStudioTestStatusResponse,
@@ -117,6 +130,14 @@ export { Agent, AgentCreateLifecycleStages, type AgentInstance } from './agent';
 export { AgentTester } from './agentTester';
 export { AgentforceStudioTester, normalizeAgentforceStudioResults } from './agentforceStudioTester';
 export { createAgentTester, type CreateAgentTesterOptions, type CreateAgentTesterResult } from './agentTesterFactory';
+export {
+  type NgtScorerName,
+  type KnownNgtScorerName,
+  type NgtScorerGrade,
+  type NgtScorerEntry,
+  NgtScorerCatalog,
+  isNgtScorerName,
+} from './ngtScorerCatalog';
 export { AgentTest, AgentTestCreateLifecycleStages } from './agentTest';
 export { ProductionAgent } from './agents/productionAgent';
 export { ScriptAgent } from './agents/scriptAgent';

--- a/src/ngtScorerCatalog.ts
+++ b/src/ngtScorerCatalog.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Known scorer names for the NGT (Agentforce Studio) test runner — used for IDE
+ * autocomplete and the per-scorer metadata in {@link NgtScorerCatalog}.
+ *
+ * The `(string & {})` branch keeps this open: arbitrary names from a future Core
+ * release pass type-checks. Validation is non-strict on purpose — `validateNgtSpec`
+ * emits a lifecycle warning for unknown names, and Core's MD validator
+ * (`AITestingOOTBEvaluations.resolveByKeyOrName`) is the authoritative runtime gate.
+ *
+ * Update when Core ships a new OOTB scorer.
+ *
+ * Future direction: when `AiTestingDefinition` lands in `@salesforce/types`
+ * (currently only `AiEvaluationDefinition` is published; see forcedotcom/wsdl
+ * `src/metadata.ts`), the XML types should be swapped for generated ones. The
+ * scorer name list itself isn't enum-typed in the WSDL though, so this catalog
+ * stays the source of truth for the `needsExpected` and `grade` metadata even
+ * after that swap.
+ */
+export type NgtScorerName =
+  | KnownNgtScorerName
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (string & {});
+
+/** The closed set used for catalog lookups and autocomplete. */
+export type KnownNgtScorerName =
+  | 'topic_sequence_match'
+  | 'action_sequence_match'
+  | 'agent_handoff_match'
+  | 'bot_response_rating'
+  | 'response_match'
+  | 'coherence'
+  | 'conciseness'
+  | 'factuality'
+  | 'completeness'
+  | 'task_resolution'
+  | 'output_latency_milliseconds';
+
+/** Grading scheme a scorer reports back. Used for downstream rendering / threshold logic. */
+export type NgtScorerGrade = 'PASS_FAIL' | 'LLM_PASS_FAIL' | 'LLM_0_100' | 'LLM_0_5' | 'NUMERIC';
+
+/** Catalog row describing a single scorer. */
+export type NgtScorerEntry = {
+  needsExpected: boolean;
+  grade: NgtScorerGrade;
+  requiresConversationHistory?: true;
+};
+
+/* eslint-disable camelcase */
+export const NgtScorerCatalog: Readonly<Record<KnownNgtScorerName, NgtScorerEntry>> = {
+  topic_sequence_match: { needsExpected: true, grade: 'PASS_FAIL' },
+  action_sequence_match: { needsExpected: true, grade: 'PASS_FAIL' },
+  agent_handoff_match: { needsExpected: true, grade: 'PASS_FAIL' },
+  bot_response_rating: { needsExpected: true, grade: 'LLM_PASS_FAIL' },
+  response_match: { needsExpected: true, grade: 'LLM_PASS_FAIL' },
+  coherence: { needsExpected: false, grade: 'LLM_0_100' },
+  conciseness: { needsExpected: false, grade: 'LLM_0_100' },
+  factuality: { needsExpected: false, grade: 'LLM_0_100' },
+  completeness: { needsExpected: false, grade: 'LLM_0_100' },
+  task_resolution: { needsExpected: false, grade: 'LLM_0_5', requiresConversationHistory: true },
+  output_latency_milliseconds: { needsExpected: false, grade: 'NUMERIC' },
+} as const;
+/* eslint-enable camelcase */
+
+export const isNgtScorerName = (s: string): s is KnownNgtScorerName =>
+  Object.prototype.hasOwnProperty.call(NgtScorerCatalog, s);

--- a/src/ngtScorerCatalog.ts
+++ b/src/ngtScorerCatalog.ts
@@ -18,7 +18,7 @@
  * Known scorer names for the NGT (Agentforce Studio) test runner — used for IDE
  * autocomplete and the per-scorer metadata in {@link NgtScorerCatalog}.
  *
- * The `(string & {})` branch keeps this open: arbitrary names from a future Core
+ * The `(string & NonNullable<unknown>)` branch keeps this open: arbitrary names from a future Core
  * release pass type-checks. Validation is non-strict on purpose — `validateNgtSpec`
  * emits a lifecycle warning for unknown names, and Core's MD validator
  * (`AITestingOOTBEvaluations.resolveByKeyOrName`) is the authoritative runtime gate.
@@ -34,8 +34,7 @@
  */
 export type NgtScorerName =
   | KnownNgtScorerName
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  | (string & {});
+  | (string & NonNullable<unknown>);
 
 /** The closed set used for catalog lookups and autocomplete. */
 export type KnownNgtScorerName =

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ import { Connection, Logger, SfProject } from '@salesforce/core';
 import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import { type ApexLog } from '@salesforce/types/tooling';
 import { metric } from './utils';
+import type { NgtScorerName } from './ngtScorerCatalog';
 
 // ====================================================
 //     Compilation API exit codes
@@ -500,12 +501,12 @@ export type MetadataMetric = { name: string };
 export type MetadataExpectation = {
   // topic/action/outcome matching
   name:
-    | 'topic_sequence_match'
-    | 'topic_assertion'
-    | 'action_sequence_match'
-    | 'actions_assertion'
-    | 'bot_response_rating'
-    | 'output_validation';
+  | 'topic_sequence_match'
+  | 'topic_assertion'
+  | 'action_sequence_match'
+  | 'actions_assertion'
+  | 'bot_response_rating'
+  | 'output_validation';
   expectedValue: string;
 };
 
@@ -538,6 +539,80 @@ export type AiEvaluationDefinition = {
       utterance: string;
     };
   }>;
+};
+
+// ====================================================
+//    NGT Agent Testing Types (Agentforce Studio)
+// ====================================================
+
+// Authoring (YAML) types for NGT specs.
+
+export type NgtContextVar = {
+  name: string;
+  value: string;
+};
+
+export type NgtConversationTurn =
+  | { role: 'user'; message: string; index?: number }
+  | { role: 'agent'; message: string; topic: string; index?: number };
+
+export type NgtTestCaseInput = {
+  utterance: string;
+  contextVariables?: NgtContextVar[];
+  conversationHistory?: NgtConversationTurn[];
+};
+
+export type NgtTestCaseScorer = {
+  name: NgtScorerName;
+  expected?: string;
+};
+
+export type NgtTestCase = {
+  inputs: NgtTestCaseInput[];
+  scorers: NgtTestCaseScorer[];
+};
+
+export type NgtTestSpec = {
+  name: string;
+  description?: string;
+  subjectType: 'AGENT';
+  subjectName: string;
+  subjectVersion?: string;
+  testCases: NgtTestCase[];
+};
+
+// Metadata (XML) types for AiTestingDefinition.
+
+export type AiConversationTurnXml =
+  | { role: 'user'; message: string; index: number }
+  | { role: 'agent'; message: string; topic: string; index: number };
+
+export type AiTestCaseInputXml = {
+  utterance: string;
+  contextVariable?: Array<{ variableName: string; variableValue: string }>;
+  conversationHistory?: AiConversationTurnXml[];
+};
+
+export type AiTestCaseScorer = {
+  name: NgtScorerName;
+  expectedValue?: string;
+  // 'Custom' reserved for the future, converter never emits it for v1.
+  scorerType?: 'OOTB' | 'Custom';
+};
+
+export type AiTestCase = {
+  number: number;
+  inputs: AiTestCaseInputXml;
+  scorer: AiTestCaseScorer[];
+};
+
+export type AiTestingDefinition = {
+  description?: string;
+  name: string;
+  subjectName: string;
+  subjectType: 'AGENT';
+  subjectVersion?: string;
+  testCase: AiTestCase[];
 };
 
 // ====================================================

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -31,9 +31,9 @@ import type { NgtTestSpec } from '../src/types';
 
 /**
  * Normalize a serialized XML string for comparison:
- *   - normalize line endings to \n
- *   - trim trailing whitespace per line
- *   - drop a final trailing newline
+ * - normalize line endings to \n
+ * - trim trailing whitespace per line
+ * - drop a final trailing newline
  *
  * The XMLBuilder may emit empty self-closing differences depending on options;
  * if the developer's serializer differs in those edge details, the test should
@@ -394,7 +394,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(xml).to.not.include("['Get_Order_Status']");
     });
 
-    it("action_sequence_match with the python-list-string passes through verbatim to <expectedValue>", () => {
+    it('action_sequence_match with the python-list-string passes through verbatim to <expectedValue>', () => {
       // Per plan: NgtTestCaseScorer.expected?: string — the user passes the python-list-string
       // (single-quoted, comma-joined, no spaces) verbatim, matching spec doc §7's wire format.
       const spec: NgtTestSpec = {
@@ -504,14 +504,18 @@ testCases:
       sinon.restore();
     });
 
-    it('preview: true writes <apiName>.aiTestingDefinition-meta.xml without invoking deploy', async () => {
+    it('preview: true writes <apiName>-preview-<timestamp>.xml without invoking deploy', async () => {
       const result = await AgentTest.create(connection, 'MyTest', 'spec.yaml', {
         outputDir: 'tmp',
         preview: true,
         testRunner: 'agentforce-studio',
       } as never); // cast: option type is added in src by the developer.
 
-      expect(result.path).to.match(/MyTest\.aiTestingDefinition-meta\.xml$/);
+      // Preview parity with the legacy path (src/agentTest.ts:131-132): timestamped
+      // filename so previewing in the project root doesn't clobber a real
+      // `<apiName>.aiTestingDefinition-meta.xml` checked in alongside source.
+      expect(result.path).to.match(/MyTest-preview-.+\.xml$/);
+      expect(result.path).to.not.include('aiTestingDefinition');
       expect(componentSetBuildStub.called, 'ComponentSetBuilder.build must NOT be called when preview=true').to.be
         .false;
       expect(writeFileStub.calledOnce).to.be.true;
@@ -559,10 +563,14 @@ testCases:
       expect(mkdirStub.calledOnce).to.be.true;
     });
 
-    // Regression guard: omitting testRunner → legacy behavior, byte-for-byte.
-    // The existing legacy `describe('create', ...)` already covers most of this;
-    // this single concise test pins the filename suffix.
-    it('regression: omitting testRunner writes <apiName>.aiEvaluationDefinition-meta.xml (legacy path unchanged)', async () => {
+    // Regression guard: omitting testRunner must route through the legacy path,
+    // not the NGT path. With preview:true, legacy emits the timestamped preview
+    // filename (`<apiName>-preview-<ISO>.xml`) per src/agentTest.ts:131-132 and
+    // the existing tests at test/agentTest.test.ts:847,888.
+    // The load-bearing assertion is "no aiTestingDefinition in the path" — that's
+    // what proves we didn't accidentally branch into the NGT path. The filename
+    // shape check just documents the legacy preview convention.
+    it('regression: omitting testRunner stays on the legacy path (no NGT routing)', async () => {
       readFileStub.restore();
       const legacyYaml = `name: Legacy
 description: Legacy
@@ -581,8 +589,8 @@ testCases:
         outputDir: 'tmp',
         preview: true,
       });
-      expect(path).to.match(/LegacyTest\.aiEvaluationDefinition-meta\.xml$/);
       expect(path).to.not.include('aiTestingDefinition');
+      expect(path).to.match(/LegacyTest-preview-.+\.xml$/);
     });
   });
 

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -1,0 +1,627 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
+import { AgentTest } from '../src';
+import {
+  validateNgtSpec,
+  convertToTestingMetadata,
+  buildTestingMetadataXml,
+} from '../src/agentTest';
+import type { NgtTestSpec } from '../src/types';
+
+/**
+ * Normalize a serialized XML string for comparison:
+ *   - normalize line endings to \n
+ *   - trim trailing whitespace per line
+ *   - drop a final trailing newline
+ *
+ * The XMLBuilder may emit empty self-closing differences depending on options;
+ * if the developer's serializer differs in those edge details, the test should
+ * fail loud rather than silently — that's why we don't strip blank lines.
+ */
+const normalizeXml = (xml: string): string =>
+  xml.replace(/\r\n/g, '\n').split('\n').map((l) => l.replace(/\s+$/, '')).join('\n').replace(/\n+$/, '');
+
+describe('AgentTest NGT (Agentforce Studio) create surface', () => {
+  const $$ = new TestContext();
+  let testOrg: MockTestOrgData;
+  let connection: Connection;
+
+  beforeEach(async () => {
+    $$.inProject(true);
+    testOrg = new MockTestOrgData();
+    process.env.SF_MOCK_DIR = 'test/mocks';
+    connection = await testOrg.getConnection();
+    connection.instanceUrl = 'https://mydomain.salesforce.com';
+    // restore the connection sandbox so that it doesn't override the builtin mocking (MaybeMock)
+    $$.SANDBOXES.CONNECTION.restore();
+  });
+
+  afterEach(() => {
+    delete process.env.SF_MOCK_DIR;
+  });
+
+  // -------------------------------------------------------------------------
+  // validateNgtSpec — pure validator
+  // -------------------------------------------------------------------------
+  describe('validateNgtSpec', () => {
+    /** Smallest legal single-agent spec. Tests mutate copies of this. */
+    const baseSpec = (): NgtTestSpec => ({
+      name: 'Suite',
+      subjectType: 'AGENT',
+      subjectName: 'MyAgent',
+      testCases: [
+        {
+          inputs: [{ utterance: 'hello' }],
+          scorers: [{ name: 'topic_sequence_match', expected: 'GeneralCRM' }],
+        },
+      ],
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('passes for a minimal valid spec (single-agent)', () => {
+      expect(() => validateNgtSpec(baseSpec(), { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('throws ngtMissingTestCases when testCases is empty', () => {
+      const spec = baseSpec();
+      spec.testCases = [];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtMissingTestCases');
+      }
+    });
+
+    it('throws ngtTestCaseMissingInputs when a test case has empty inputs[]', () => {
+      const spec = baseSpec();
+      spec.testCases[0].inputs = [];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtTestCaseMissingInputs');
+      }
+    });
+
+    it('throws ngtTestCaseMissingScorers when a test case has empty scorers[]', () => {
+      const spec = baseSpec();
+      spec.testCases[0].scorers = [];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtTestCaseMissingScorers');
+      }
+    });
+
+    it('throws ngtScorerMissingExpected when a needsExpected scorer omits expected', () => {
+      const spec = baseSpec();
+      // bot_response_rating is needsExpected:true (LLM_PASS_FAIL)
+      spec.testCases[0].scorers = [{ name: 'bot_response_rating' }];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtScorerMissingExpected');
+        // Message must mention which scorer triggered the failure (per plan: "needs the scorer name").
+        expect((err as SfError).message).to.include('bot_response_rating');
+      }
+    });
+
+    it('passes when a needsExpected scorer has expected', () => {
+      const spec = baseSpec();
+      spec.testCases[0].scorers = [
+        { name: 'bot_response_rating', expected: 'a friendly greeting' },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('passes when a quality scorer (needsExpected:false) omits expected', () => {
+      const spec = baseSpec();
+      // coherence is needsExpected:false (LLM_0_100)
+      spec.testCases[0].scorers = [
+        { name: 'topic_sequence_match', expected: 'GeneralCRM' },
+        { name: 'coherence' },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('emits a Lifecycle warn event for an unknown scorer name (does not throw)', async () => {
+      const lifecycleSpy = sinon.spy(Lifecycle.prototype, 'emitWarning');
+      const spec = baseSpec();
+      // Cast through unknown to bypass static typing; this models a hand-edited YAML.
+      (spec.testCases[0].scorers as unknown as Array<{ name: string; expected?: string }>).push({
+        name: 'made_up_scorer',
+        expected: 'whatever',
+      });
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+      expect(lifecycleSpy.called).to.be.true;
+      const allWarnArgs = lifecycleSpy.getCalls().flatMap((c) => c.args.map(String));
+      expect(allWarnArgs.some((a) => a.includes('made_up_scorer'))).to.be.true;
+    });
+
+    it('throws ngtTaskResolutionRequiresConversationHistory when task_resolution lacks conversationHistory', () => {
+      const spec = baseSpec();
+      spec.testCases[0].scorers = [{ name: 'task_resolution' }];
+      // No conversationHistory on any input — should fail.
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtTaskResolutionRequiresConversationHistory');
+      }
+    });
+
+    it('passes when task_resolution is paired with conversationHistory on at least one input', () => {
+      const spec = baseSpec();
+      spec.testCases[0].inputs = [
+        {
+          utterance: 'follow up',
+          conversationHistory: [
+            { role: 'user', message: 'first turn' },
+            { role: 'agent', message: 'sure', topic: 'GeneralCRM' },
+          ],
+        },
+      ];
+      spec.testCases[0].scorers = [{ name: 'task_resolution' }];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('throws ngtMultiAgentMissingHandoff when isMultiAgent:true and a test case omits agent_handoff_match', () => {
+      const spec = baseSpec();
+      // Only topic_sequence_match in default — no agent_handoff_match.
+      try {
+        validateNgtSpec(spec, { isMultiAgent: true });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtMultiAgentMissingHandoff');
+      }
+    });
+
+    it('passes when isMultiAgent:true and every test case has agent_handoff_match with expected', () => {
+      const spec = baseSpec();
+      spec.testCases[0].scorers = [
+        { name: 'topic_sequence_match', expected: 'GeneralCRM' },
+        { name: 'agent_handoff_match', expected: 'CheckoutAgent' },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: true })).to.not.throw();
+    });
+
+    it('throws ngtConversationHistoryIndexAllOrNothing when one input mixes indexed and unindexed turns', () => {
+      const spec = baseSpec();
+      spec.testCases[0].inputs = [
+        {
+          utterance: 'mixed indices',
+          conversationHistory: [
+            { role: 'user', message: 'first', index: 0 },
+            { role: 'agent', message: 'second', topic: 'GeneralCRM' }, // no index
+            { role: 'user', message: 'third', index: 2 },
+          ],
+        },
+      ];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtConversationHistoryIndexAllOrNothing');
+      }
+    });
+
+    it('passes when every conversation turn has an index OR none do (the all-or-nothing rule, satisfied)', () => {
+      const allSet = baseSpec();
+      allSet.testCases[0].inputs = [
+        {
+          utterance: 'all indexed',
+          conversationHistory: [
+            { role: 'user', message: 'a', index: 5 },
+            { role: 'agent', message: 'b', topic: 'GeneralCRM', index: 6 },
+          ],
+        },
+      ];
+      expect(() => validateNgtSpec(allSet, { isMultiAgent: false })).to.not.throw();
+
+      const noneSet = baseSpec();
+      noneSet.testCases[0].inputs = [
+        {
+          utterance: 'none indexed',
+          conversationHistory: [
+            { role: 'user', message: 'a' },
+            { role: 'agent', message: 'b', topic: 'GeneralCRM' },
+          ],
+        },
+      ];
+      expect(() => validateNgtSpec(noneSet, { isMultiAgent: false })).to.not.throw();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // convertToTestingMetadata — pure converter (and buildTestingMetadataXml)
+  // -------------------------------------------------------------------------
+  describe('convertToTestingMetadata + buildTestingMetadataXml', () => {
+    // Spec doc §7 "ReturnsCheckoutSuite" verbatim — the canonical example from the
+    // spec author. Exact-XML compare proves the converter produces what the spec
+    // doc draws. Drift between this fixture and the spec doc means we re-transcribe;
+    // never adjust the converter to match a stale fixture. See top of fixture file
+    // for the one cleanup applied (spec §7 has duplicate "case 6" entries).
+    it('matches the expected XML fixture for the ReturnsCheckoutSuite spec (spec doc §7)', async () => {
+      const yamlPath = join(__dirname, 'fixtures', 'ngt-spec-returns-checkout.yaml');
+      const xmlPath = join(__dirname, 'fixtures', 'ngt-xml-returns-checkout.xml');
+
+      const { parse } = await import('yaml');
+      const spec = parse(await fs.readFile(yamlPath, 'utf-8')) as NgtTestSpec;
+
+      const def = convertToTestingMetadata(spec);
+      const actual = buildTestingMetadataXml(def);
+      const expected = await fs.readFile(xmlPath, 'utf-8');
+
+      expect(normalizeXml(actual)).to.equal(normalizeXml(expected));
+    });
+
+    it('multi-input fan-out: one inputs[] with 3 entries → 3 <testCase> elements, shared scorers, globally numbered', () => {
+      const spec: NgtTestSpec = {
+        name: 'OrderStatusOnly',
+        subjectType: 'AGENT',
+        subjectName: 'Returns',
+        testCases: [
+          {
+            inputs: [
+              { utterance: "What's the status of order #12345?" },
+              { utterance: 'Where is my order 12345' },
+              { utterance: 'Tell me about order #12345' },
+            ],
+            scorers: [
+              { name: 'topic_sequence_match', expected: 'order_status' },
+              { name: 'action_sequence_match', expected: 'Get_Order_Status' },
+            ],
+          },
+        ],
+      };
+
+      const def = convertToTestingMetadata(spec);
+      expect(def.testCase).to.have.length(3);
+      expect(def.testCase.map((tc) => tc.number)).to.deep.equal([1, 2, 3]);
+      // All three share the same scorer set verbatim.
+      def.testCase.forEach((tc) => {
+        expect(tc.scorer.map((s) => s.name)).to.deep.equal([
+          'topic_sequence_match',
+          'action_sequence_match',
+        ]);
+        expect(tc.scorer.map((s) => s.expectedValue)).to.deep.equal([
+          'order_status',
+          'Get_Order_Status',
+        ]);
+      });
+      // Utterances are distributed 1-per-testCase in input order.
+      expect(def.testCase.map((tc) => tc.inputs.utterance)).to.deep.equal([
+        "What's the status of order #12345?",
+        'Where is my order 12345',
+        'Tell me about order #12345',
+      ]);
+    });
+
+    it('quality scorer (needsExpected:false) emits <scorer> without <expectedValue>', () => {
+      const spec: NgtTestSpec = {
+        name: 'Q',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [{ utterance: 'hi' }],
+            scorers: [{ name: 'coherence' }],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      const scorer = def.testCase[0].scorer[0];
+      expect(scorer.name).to.equal('coherence');
+      expect(scorer.expectedValue).to.be.undefined;
+
+      // Cross-check: the serialized XML must not have an <expectedValue> for coherence.
+      const xml = buildTestingMetadataXml(def);
+      // Find the scorer block and assert no expectedValue inside it.
+      const coherenceBlock = xml.match(/<scorer>\s*<name>coherence<\/name>[\s\S]*?<\/scorer>/);
+      expect(coherenceBlock, 'coherence scorer block').to.not.be.null;
+      expect(coherenceBlock![0]).to.not.include('<expectedValue>');
+    });
+
+    it('assertion scorer (needsExpected:true) emits <scorer> with <expectedValue>', () => {
+      const spec: NgtTestSpec = {
+        name: 'A',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [{ utterance: 'hi' }],
+            scorers: [{ name: 'topic_sequence_match', expected: 'Greeting' }],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      const scorer = def.testCase[0].scorer[0];
+      expect(scorer.name).to.equal('topic_sequence_match');
+      expect(scorer.expectedValue).to.equal('Greeting');
+    });
+
+    it('action_sequence_match with a single value emits the bare value in <expectedValue>', () => {
+      const spec: NgtTestSpec = {
+        name: 'A',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [{ utterance: 'hi' }],
+            scorers: [{ name: 'action_sequence_match', expected: 'Get_Order_Status' }],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      expect(def.testCase[0].scorer[0].expectedValue).to.equal('Get_Order_Status');
+      const xml = buildTestingMetadataXml(def);
+      expect(xml).to.include('<expectedValue>Get_Order_Status</expectedValue>');
+      // Specifically must NOT be wrapped in [ ... ] or quoted.
+      expect(xml).to.not.include("['Get_Order_Status']");
+    });
+
+    it("action_sequence_match with the python-list-string passes through verbatim to <expectedValue>", () => {
+      // Per plan: NgtTestCaseScorer.expected?: string — the user passes the python-list-string
+      // (single-quoted, comma-joined, no spaces) verbatim, matching spec doc §7's wire format.
+      const spec: NgtTestSpec = {
+        name: 'A',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [{ utterance: 'hi' }],
+            scorers: [
+              { name: 'action_sequence_match', expected: "['Verify_Customer','Get_Order_Status']" },
+            ],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      expect(def.testCase[0].scorer[0].expectedValue).to.equal(
+        "['Verify_Customer','Get_Order_Status']"
+      );
+      const xml = buildTestingMetadataXml(def);
+      // XMLBuilder encodes ' as &apos;.
+      expect(xml).to.include('[&apos;Verify_Customer&apos;,&apos;Get_Order_Status&apos;]');
+    });
+
+    it('auto-assigns conversationHistory.index 0..n-1 when none are set', () => {
+      const spec: NgtTestSpec = {
+        name: 'A',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [
+              {
+                utterance: 'follow-up',
+                conversationHistory: [
+                  { role: 'user', message: 'a' },
+                  { role: 'agent', message: 'b', topic: 'GeneralCRM' },
+                  { role: 'user', message: 'c' },
+                ],
+              },
+            ],
+            scorers: [{ name: 'task_resolution' }],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      const turns = def.testCase[0].inputs.conversationHistory!;
+      expect(turns.map((t) => t.index)).to.deep.equal([0, 1, 2]);
+    });
+
+    it('preserves conversationHistory.index verbatim when every turn has one', () => {
+      const spec: NgtTestSpec = {
+        name: 'A',
+        subjectType: 'AGENT',
+        subjectName: 'A',
+        testCases: [
+          {
+            inputs: [
+              {
+                utterance: 'follow-up',
+                conversationHistory: [
+                  { role: 'user', message: 'a', index: 7 },
+                  { role: 'agent', message: 'b', topic: 'GeneralCRM', index: 8 },
+                ],
+              },
+            ],
+            scorers: [{ name: 'task_resolution' }],
+          },
+        ],
+      };
+      const def = convertToTestingMetadata(spec);
+      const turns = def.testCase[0].inputs.conversationHistory!;
+      expect(turns.map((t) => t.index)).to.deep.equal([7, 8]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AgentTest.create() with testRunner: 'agentforce-studio'
+  // -------------------------------------------------------------------------
+  describe("AgentTest.create with testRunner: 'agentforce-studio'", () => {
+    let writeFileStub: sinon.SinonStub;
+    let readFileStub: sinon.SinonStub;
+    let mkdirStub: sinon.SinonStub;
+    let componentSetBuildStub: sinon.SinonStub;
+
+    const yamlSpec = `name: SimpleSuite
+description: NGT minimal
+subjectType: AGENT
+subjectName: MyAgent
+testCases:
+  - inputs:
+      - utterance: hello
+    scorers:
+      - name: topic_sequence_match
+        expected: Greeting
+      - name: conciseness
+`;
+
+    beforeEach(() => {
+      writeFileStub = sinon.stub(fs, 'writeFile').resolves();
+      mkdirStub = sinon.stub(fs, 'mkdir').resolves();
+      readFileStub = sinon.stub(fs, 'readFile').resolves(yamlSpec);
+      componentSetBuildStub = sinon.stub(ComponentSetBuilder, 'build');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('preview: true writes <apiName>.aiTestingDefinition-meta.xml without invoking deploy', async () => {
+      const result = await AgentTest.create(connection, 'MyTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: true,
+        testRunner: 'agentforce-studio',
+      } as never); // cast: option type is added in src by the developer.
+
+      expect(result.path).to.match(/MyTest\.aiTestingDefinition-meta\.xml$/);
+      expect(componentSetBuildStub.called, 'ComponentSetBuilder.build must NOT be called when preview=true').to.be
+        .false;
+      expect(writeFileStub.calledOnce).to.be.true;
+    });
+
+    it("preview output's XML root is <AiTestingDefinition xmlns=...> (NGT root, not legacy)", async () => {
+      const { contents } = await AgentTest.create(connection, 'MyTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: true,
+        testRunner: 'agentforce-studio',
+      } as never);
+
+      expect(contents).to.include('<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">');
+      expect(contents).to.not.include('<AiEvaluationDefinition');
+    });
+
+    it('non-preview path queries BotDefinition.IsMultiAgent and proceeds to deploy on a single-agent subject', async () => {
+      // Mock connection.metadata.read for the multi-agent gate.
+      // jsforce types don't model BotDefinition; the lib uses the same pattern as for AiEvaluationDefinition.
+      const metadataReadStub = sinon
+        .stub(connection.metadata, 'read')
+        .resolves({ IsMultiAgent: false } as never);
+
+      // Stub a successful deploy.
+      const mockDeploy = {
+        onUpdate: sinon.stub(),
+        onFinish: sinon.stub(),
+        pollStatus: sinon.stub().resolves({
+          response: { success: true, details: { componentFailures: [] } },
+        }),
+      };
+      const mockComponentSet = { deploy: sinon.stub().resolves(mockDeploy) };
+      componentSetBuildStub.resolves(mockComponentSet as never);
+
+      const result = await AgentTest.create(connection, 'MyTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: false,
+        testRunner: 'agentforce-studio',
+      } as never);
+
+      expect(result.path).to.match(/MyTest\.aiTestingDefinition-meta\.xml$/);
+      expect(metadataReadStub.calledWith('BotDefinition' as never, 'MyAgent' as never)).to.be.true;
+      expect(componentSetBuildStub.calledOnce).to.be.true;
+      expect(mockComponentSet.deploy.calledOnce).to.be.true;
+      expect(mkdirStub.calledOnce).to.be.true;
+    });
+
+    // Regression guard: omitting testRunner → legacy behavior, byte-for-byte.
+    // The existing legacy `describe('create', ...)` already covers most of this;
+    // this single concise test pins the filename suffix.
+    it('regression: omitting testRunner writes <apiName>.aiEvaluationDefinition-meta.xml (legacy path unchanged)', async () => {
+      readFileStub.restore();
+      const legacyYaml = `name: Legacy
+description: Legacy
+subjectType: AGENT
+subjectName: MyAgent
+testCases:
+  - utterance: hi
+    expectedActions:
+      - DoSomething
+    expectedOutcome: did something
+    expectedTopic: General
+`;
+      sinon.stub(fs, 'readFile').resolves(legacyYaml);
+      sinon.stub(AgentTest, 'list').resolves([]);
+      const { path } = await AgentTest.create(connection, 'LegacyTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: true,
+      });
+      expect(path).to.match(/LegacyTest\.aiEvaluationDefinition-meta\.xml$/);
+      expect(path).to.not.include('aiTestingDefinition');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SDR registry resolution: lock in the suffix and catch SDR version drift.
+  // This is a real (not mocked) call to ComponentSetBuilder.
+  // -------------------------------------------------------------------------
+  describe('SDR registry resolution for AiTestingDefinition', () => {
+    let workDir: string;
+
+    beforeEach(async () => {
+      workDir = await fs.mkdtemp(join(tmpdir(), 'agents-ngt-sdr-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(workDir, { recursive: true, force: true });
+    });
+
+    it('ComponentSetBuilder resolves <name>.aiTestingDefinition-meta.xml to type=AiTestingDefinition', async () => {
+      // Source-format file. The XML body just needs to be a parseable, valid-shape AiTestingDefinition;
+      // SDR picks the metadata type from the suffix, not the body.
+      const filename = 'SdrSmoke.aiTestingDefinition-meta.xml';
+      const filePath = join(workDir, filename);
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '    <name>SdrSmoke</name>\n' +
+        '    <subjectName>MyAgent</subjectName>\n' +
+        '    <subjectType>AGENT</subjectType>\n' +
+        '</AiTestingDefinition>\n';
+      await fs.mkdir(workDir, { recursive: true });
+      await fs.writeFile(filePath, xml, 'utf-8');
+
+      const cs = await ComponentSetBuilder.build({ sourcepath: [filePath] });
+
+      expect(cs.size, 'expected exactly one component for the source file').to.equal(1);
+      const components = cs.getSourceComponents().toArray();
+      expect(components).to.have.length(1);
+      expect(components[0].type.name).to.equal('AiTestingDefinition');
+    });
+  });
+});

--- a/test/fixtures/ngt-spec-returns-checkout.yaml
+++ b/test/fixtures/ngt-spec-returns-checkout.yaml
@@ -1,0 +1,85 @@
+# Literal transcription of spec doc §7 "ReturnsCheckoutSuite"
+# Source: NGT YAML Test-Spec Proposal [W-22513509]
+# https://docs.google.com/document/d/13tqS-2EwT-Aqy4bdqYc6wZfXUYLbBkNHYYxjwSn7ZnU
+#
+# Cleanup applied: spec §7 contains two "case 6" entries. The first is a
+# duplicate of case 5 (likely a typo). This fixture keeps only the second
+# (the handoff scorer example). The §7 numbering 1..7 is preserved with
+# the duplicate dropped — so this fixture has 6 cases, not 7.
+#
+# Bug to flag on W-22513509: duplicate "case 6" entries in the spec doc.
+name: ReturnsCheckoutSuite
+description: Validates the Returns / Checkout flow on agent v1.
+subjectType: AGENT
+subjectName: ReturnsAgent
+subjectVersion: v1
+testCases:
+  # 1: assertion scorers - topic + action + LLM-judged outcome.
+  - inputs:
+      - utterance: "Where is my order #12345?"
+    scorers:
+      - name: topic_sequence_match
+        expected: order_status
+      - name: action_sequence_match
+        expected: Get_Order_Status
+      - name: bot_response_rating
+        expected: "Agent looks up the order and returns its status"
+  # 2: assertion + quality + numeric mix.
+  - inputs:
+      - utterance: "Cancel my order"
+    scorers:
+      - name: topic_sequence_match
+        expected: returns
+      - name: bot_response_rating
+        expected: "Agent confirms the cancellation"
+      - name: coherence
+      - name: factuality
+      - name: output_latency_milliseconds
+  # 3: multi-action expected - Python-list-string format.
+  - inputs:
+      - utterance: "Verify identity and look up my order"
+    scorers:
+      - name: action_sequence_match
+        expected: "['Verify_Customer','Get_Order_Status']"
+  # 4: contextVariables + multi-turn conversationHistory + task_resolution.
+  - inputs:
+      - utterance: "Yes, my email is jane@example.com"
+        contextVariables:
+          - name: RoutableId
+            value: "0Mw000000000001"
+        conversationHistory:
+          - role: user
+            message: "I need help with my order"
+          - role: agent
+            topic: identity_verification
+            message: "I can help. What's your email on file?"
+    scorers:
+      - name: topic_sequence_match
+        expected: identity_verification
+      - name: response_match
+        expected: "Agent verifies identity and continues"
+      - name: task_resolution
+  # 5: quality scorers without `expected`.
+  - inputs:
+      - utterance: "Show order details"
+    scorers:
+      - name: factuality
+      - name: completeness
+  # 6: handoff scorer - expected is the target agent's DeveloperName.
+  - inputs:
+      - utterance: "I need a sales rep"
+    scorers:
+      - name: topic_sequence_match
+        expected: handoff
+      - name: agent_handoff_match
+        expected: SDRAgent
+  # 7: multi-input - same scorers evaluate against three phrasings.
+  - inputs:
+      - utterance: "What's the status of order #12345?"
+      - utterance: "Where is my order 12345"
+      - utterance: "Tell me about order #12345"
+    scorers:
+      - name: topic_sequence_match
+        expected: order_status
+      - name: action_sequence_match
+        expected: Get_Order_Status

--- a/test/fixtures/ngt-xml-returns-checkout.xml
+++ b/test/fixtures/ngt-xml-returns-checkout.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Validates the Returns / Checkout flow on agent v1.</description>
+    <name>ReturnsCheckoutSuite</name>
+    <subjectName>ReturnsAgent</subjectName>
+    <subjectType>AGENT</subjectType>
+    <subjectVersion>v1</subjectVersion>
+    <testCase>
+        <number>1</number>
+        <inputs>
+            <utterance>Where is my order #12345?</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>bot_response_rating</name>
+            <expectedValue>Agent looks up the order and returns its status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>2</number>
+        <inputs>
+            <utterance>Cancel my order</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>returns</expectedValue>
+        </scorer>
+        <scorer>
+            <name>bot_response_rating</name>
+            <expectedValue>Agent confirms the cancellation</expectedValue>
+        </scorer>
+        <scorer>
+            <name>coherence</name>
+        </scorer>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>output_latency_milliseconds</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>3</number>
+        <inputs>
+            <utterance>Verify identity and look up my order</utterance>
+        </inputs>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>[&apos;Verify_Customer&apos;,&apos;Get_Order_Status&apos;]</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>4</number>
+        <inputs>
+            <utterance>Yes, my email is jane@example.com</utterance>
+            <contextVariable>
+                <variableName>RoutableId</variableName>
+                <variableValue>0Mw000000000001</variableValue>
+            </contextVariable>
+            <conversationHistory>
+                <role>user</role>
+                <message>I need help with my order</message>
+                <index>0</index>
+            </conversationHistory>
+            <conversationHistory>
+                <role>agent</role>
+                <message>I can help. What&apos;s your email on file?</message>
+                <topic>identity_verification</topic>
+                <index>1</index>
+            </conversationHistory>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>identity_verification</expectedValue>
+        </scorer>
+        <scorer>
+            <name>response_match</name>
+            <expectedValue>Agent verifies identity and continues</expectedValue>
+        </scorer>
+        <scorer>
+            <name>task_resolution</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>5</number>
+        <inputs>
+            <utterance>Show order details</utterance>
+        </inputs>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>completeness</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>6</number>
+        <inputs>
+            <utterance>I need a sales rep</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>handoff</expectedValue>
+        </scorer>
+        <scorer>
+            <name>agent_handoff_match</name>
+            <expectedValue>SDRAgent</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>7</number>
+        <inputs>
+            <utterance>What&apos;s the status of order #12345?</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>8</number>
+        <inputs>
+            <utterance>Where is my order 12345</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>9</number>
+        <inputs>
+            <utterance>Tell me about order #12345</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+</AiTestingDefinition>


### PR DESCRIPTION
### What does this PR do?
Adds an Agentforce Studio (NGT) write path to `AgentTest.create()`, paired with the run-side support shipped in #272. Selected via a new `testRunner: 'agentforce-studio'` option; default (`'testing-center'`) is unchanged.

The design parallels the run-side runner split — one class, branched by runner — mirroring how `AgentTest.list()` already covers both metadata types.

 #### What's added
  - **`src/types.ts`** — `NgtTestSpec` (YAML authoring) and `AiTestingDefinition` (XML) types, additive to existing legacy types.
  - **`src/ngtScorerCatalog.ts`** *(new)* — 11 v1 OOTB scorers with `needsExpected` / `grade` metadata. `NgtScorerName` uses the open `KnownNgtScorerName | (string & {})` pattern; catalog is a hint, Core's `AITestingOOTBEvaluations.resolveByKeyOrName` is the runtime gate.
  - **`src/agentTest.ts`** — `validateNgtSpec` (per spec §3–§9), `convertToTestingMetadata` with multi-input fan-out per spec §3a, `buildTestingMetadataXml`, plus the `create()` runner branch.
  - **`messages/agentTest.md`** — eight new lint-failure message keys.
  - **`test/agentTestNgt.test.ts`** + fixtures *(new)* — 27 tests including a real (unmocked) `ComponentSetBuilder.build()` call that pins the source-format suffix `<name>.aiTestingDefinition-meta.xml` against the SDR registry.

#### Notes
  - Source-format suffix on disk; SDR translates to MDAPI (`aiTestingDefinitions/<name>.aiTestingDefinition`) at deploy time.
  - NGT requires Metadata API v66.0+ on the target org — server gates this; no preflight in the lib.
  - `validateNgtSpec` is stricter than the legacy path, which has no client-side validation. Several rules (multi-agent gating, `task_resolution` ⇒ `conversationHistory`, `index` all-or-nothing) produce server errors that don't map cleanly back to YAML lines.
 
#### Test plan
  - [x] `yarn lint` — 0 errors (1 pre-existing warning on legacy code in `agentTest.ts:306`, unrelated)
  - [x] `yarn compile` — clean
  - [x] `yarn test` — 331 passing, 1 pending (pre-existing skip), 0 failing
  - [x] Backward compat — 19 legacy `agentTest.test.ts` tests pass without modification

The `xNuts-plugin-agent` matrix job is expected to fail on this PR — CLI plumbing (`--test-runner` flag) lands in @W-22513740@

### What issues does this PR fix or reference?
@W-22513615@

  - Soft-blocked by @W-22513509@ (NGT YAML schema sign-off — in progress; spec doc treated as draft-but-load-bearing). Got soft signoff from Mukta Chandorkar and Shaunak Shatmanyu.
  - Blocks @W-22513740@ (CLI consumer, NUT coverage), @W-22513811@ (skill cutover)

  🤖 Written with help from [Claude Code](https://claude.com/claude-code)