### PR TITLE
feat: add AgentDataLibrary for ADL Connect API operations @W-22787736@

### DIFF
--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -256,6 +256,11 @@ export class AgentDataLibrary {
   }
 
   private static async uploadToS3(uploadEntry: FileUploadUrlEntry, filePath: string): Promise<void> {
+    const maxFileSize = 100 * 1024 * 1024; // 100 MB — SearchIndex limit for chunking/vectorization
+    const fileSize = statSync(filePath).size;
+    if (fileSize > maxFileSize) {
+      throw new SfError(`File size (${fileSize} bytes) exceeds maximum of ${maxFileSize} bytes.`, 'FileTooLarge');
+    }
     const fileBuffer = readFileSync(filePath);
     const response = await fetch(uploadEntry.uploadUrl, {
       method: 'PUT',

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
+import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import {
+  type DataLibrarySummary,
+  type DataLibraryDetail,
+  type IndexingStatusResponse,
+  type CreateLibraryInput,
+  type UpdateLibraryInput,
+  type UploadResult,
+  type FileAddResult,
+  type GroundingFileRef,
+} from './dataLibraryTypes.js';
+
+export { type DataLibrarySummary, type DataLibraryDetail, type IndexingStatusResponse, type CreateLibraryInput, type UpdateLibraryInput, type UploadResult, type FileAddResult, type GroundingFileRef } from './dataLibraryTypes.js';
+
+type UploadReadinessResponse = { ready: boolean };
+type FileUploadUrlEntry = { uploadUrl: string; filePath: string; headers: Record<string, string> };
+type FileUploadUrlsResponse = { uploadUrls: FileUploadUrlEntry[] };
+type IndexingResponse = { status: string; filesAccepted?: number };
+
+function baseUrl(connection: Connection, libraryId?: string): string {
+  const base = `/services/data/v${String(connection.version)}/einstein/data-libraries`;
+  return libraryId ? `${base}/${libraryId}` : base;
+}
+
+export class AgentDataLibrary {
+  public static async list(connection: Connection): Promise<{ libraries: DataLibrarySummary[] }> {
+    try {
+      return await connection.request<{ libraries: DataLibrarySummary[] }>({
+        method: 'GET',
+        url: baseUrl(connection),
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async create(connection: Connection, input: CreateLibraryInput): Promise<DataLibraryDetail> {
+    let result: DataLibraryDetail;
+    try {
+      result = await connection.request<DataLibraryDetail>({
+        method: 'POST',
+        url: baseUrl(connection),
+        body: JSON.stringify(input),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_create_failed' });
+      throw wrapped;
+    }
+
+    await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_create_success' });
+
+    if (input.groundingSource.sourceType === 'KNOWLEDGE') {
+      // Trigger indexing — abort after 10s to avoid blocking process exit.
+      // Server starts processing on receipt; we don't need the response.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        await fetch(`${String(connection.instanceUrl)}${baseUrl(connection, result.libraryId)}/indexing`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${String(connection.accessToken)}`,
+            'Content-Type': 'application/json',
+          },
+          signal: controller.signal,
+        });
+      } catch {
+        // best-effort — server processes indexing even if aborted/timeout
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    return result;
+  }
+
+  public static async get(connection: Connection, libraryId: string): Promise<DataLibraryDetail> {
+    try {
+      return await connection.request<DataLibraryDetail>({
+        method: 'GET',
+        url: baseUrl(connection, libraryId),
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_get_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async update(connection: Connection, libraryId: string, input: UpdateLibraryInput): Promise<DataLibraryDetail> {
+    try {
+      return await connection.request<DataLibraryDetail>({
+        method: 'PATCH',
+        url: baseUrl(connection, libraryId),
+        body: JSON.stringify(input),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_update_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async delete(connection: Connection, libraryId: string): Promise<void> {
+    try {
+      await connection.request({
+        method: 'DELETE',
+        url: baseUrl(connection, libraryId),
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_delete_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async status(connection: Connection, libraryId: string): Promise<IndexingStatusResponse> {
+    try {
+      return await connection.request<IndexingStatusResponse>({
+        method: 'GET',
+        url: `${baseUrl(connection, libraryId)}/status`,
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_status_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async listFiles(connection: Connection, libraryId: string): Promise<GroundingFileRef[]> {
+    const detail = await AgentDataLibrary.get(connection, libraryId);
+    return detail.groundingSource?.groundingFileRefs ?? [];
+  }
+
+  public static async deleteFile(connection: Connection, libraryId: string, fileId: string): Promise<void> {
+    try {
+      await connection.request({
+        method: 'DELETE',
+        url: `${baseUrl(connection, libraryId)}/files/${fileId}`,
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_delete_failed' });
+      throw wrapped;
+    }
+  }
+
+  public static async upload(
+    connection: Connection,
+    libraryId: string,
+    filePath: string,
+    options?: { waitMinutes?: number }
+  ): Promise<UploadResult> {
+    const url = baseUrl(connection, libraryId);
+    const fileName = basename(filePath);
+
+    await AgentDataLibrary.checkUploadReadiness(connection, url);
+
+    const uploadEntry = await AgentDataLibrary.getUploadUrl(connection, url, fileName);
+
+    await AgentDataLibrary.uploadToS3(uploadEntry, filePath);
+
+    const fileSize = statSync(filePath).size;
+    await AgentDataLibrary.triggerIndexing(connection, url, uploadEntry.filePath, fileSize);
+
+    if (options?.waitMinutes) {
+      const detail = await AgentDataLibrary.pollForReadiness(connection, url, libraryId, options.waitMinutes);
+      return {
+        libraryId,
+        retrieverId: detail.retrieverId,
+        ragFeatureConfigId: `ARFPC_${libraryId}`,
+        status: 'READY',
+      };
+    }
+
+    return { libraryId, status: 'IN_PROGRESS' };
+  }
+
+  public static async addFile(
+    connection: Connection,
+    libraryId: string,
+    filePath: string
+  ): Promise<FileAddResult> {
+    const url = baseUrl(connection, libraryId);
+    const fileName = basename(filePath);
+
+    const uploadEntry = await AgentDataLibrary.getUploadUrl(connection, url, fileName);
+    await AgentDataLibrary.uploadToS3(uploadEntry, filePath);
+
+    const fileSize = statSync(filePath).size;
+    await connection.request({
+      method: 'POST',
+      url: `${url}/files`,
+      body: JSON.stringify({ uploadedFiles: [{ filePath: uploadEntry.filePath, fileSize }] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_add_success' });
+    return { success: true, fileName, libraryId };
+  }
+
+  // ── Private helpers ───────────────────────────────────────
+
+  private static async checkUploadReadiness(connection: Connection, url: string): Promise<void> {
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      let readiness: UploadReadinessResponse;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        readiness = await connection.request<UploadReadinessResponse>({
+          method: 'GET',
+          url: `${url}/upload-readiness?waitMaxTime=120000`,
+        });
+      } catch (error) {
+        throw SfError.wrap(error);
+      }
+
+      if (readiness.ready) return;
+
+      if (attempt === maxAttempts) {
+        throw new SfError('Library not ready for upload after waiting.', 'UploadNotReady');
+      }
+    }
+  }
+
+  private static async getUploadUrl(connection: Connection, url: string, fileName: string): Promise<FileUploadUrlEntry> {
+    const response = await connection.request<FileUploadUrlsResponse>({
+      method: 'POST',
+      url: `${url}/file-upload-urls`,
+      body: JSON.stringify({ files: [{ fileName }] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return response.uploadUrls[0];
+  }
+
+  private static async uploadToS3(uploadEntry: FileUploadUrlEntry, filePath: string): Promise<void> {
+    const fileBuffer = readFileSync(filePath);
+    const response = await fetch(uploadEntry.uploadUrl, {
+      method: 'PUT',
+      headers: uploadEntry.headers,
+      body: fileBuffer,
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new SfError(`S3 upload failed: HTTP ${response.status}: ${body}`, 'S3UploadFailed');
+    }
+  }
+
+  private static async triggerIndexing(
+    connection: Connection,
+    url: string,
+    s3FilePath: string,
+    fileSize: number
+  ): Promise<IndexingResponse> {
+    return connection.request<IndexingResponse>({
+      method: 'POST',
+      url: `${url}/indexing`,
+      body: JSON.stringify({ uploadedFiles: [{ filePath: s3FilePath, fileSize }] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  private static async pollForReadiness(
+    connection: Connection,
+    url: string,
+    libraryId: string,
+    waitMinutes: number
+  ): Promise<DataLibraryDetail> {
+    const deadline = Date.now() + waitMinutes * 60_000;
+    const pollInterval = 10_000;
+
+    // eslint-disable-next-line no-await-in-loop
+    while (Date.now() < deadline) {
+      // eslint-disable-next-line no-await-in-loop
+      const detail = await connection.request<DataLibraryDetail>({ method: 'GET', url });
+
+      if (detail.retrieverId) return detail;
+      if (detail.status === 'FAILED') {
+        throw new SfError('Library indexing failed.', 'IndexingFailed');
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+
+    throw new SfError(`Indexing did not complete within ${waitMinutes} minutes.`, 'UploadTimeout');
+  }
+}

--- a/src/dataLibraryTypes.ts
+++ b/src/dataLibraryTypes.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type SourceType = 'SFDRIVE' | 'KNOWLEDGE' | 'RETRIEVER';
+
+export type DataLibrarySummary = {
+  libraryId: string;
+  masterLabel: string;
+  developerName: string;
+  description?: string;
+  sourceType: string;
+  status: string;
+};
+
+export type GroundingFileRef = {
+  fileId: string;
+  fileName: string;
+  filePath: string;
+  fileSize: number;
+  createdDate?: string;
+  createdBy?: string;
+};
+
+export type DataLibraryDetail = {
+  libraryId: string;
+  masterLabel: string;
+  developerName: string;
+  description?: string;
+  sourceType: string;
+  status?: string;
+  retrieverId?: string;
+  retrieverLabel?: string;
+  dataSpaceScopeId?: string;
+  groundingSource?: {
+    [key: string]: unknown;
+    groundingSourceType?: string;
+    groundingFileRefs?: GroundingFileRef[];
+  };
+};
+
+export type StageDetail = {
+  name: string;
+  status: string;
+  completedAt?: number;
+  startedAt?: number;
+  error?: string;
+};
+
+export type IndexingStatusResponse = {
+  indexingStatus: {
+    libraryId: string;
+    status: string;
+    currentStage?: string;
+    stageDetails?: StageDetail[];
+    lastUpdatedAt?: number;
+  };
+};
+
+export type GroundingSource = {
+  sourceType: SourceType;
+  indexMode?: string;
+  retrieverId?: string;
+  knowledgeConfig?: {
+    primaryIndexField1?: string;
+    primaryIndexField2?: string;
+    contentFields?: string[];
+    isRestrictToPublicArticle?: boolean;
+  };
+};
+
+export type CreateLibraryInput = {
+  masterLabel: string;
+  developerName: string;
+  description?: string;
+  groundingSource: GroundingSource;
+};
+
+export type UpdateLibraryInput = {
+  masterLabel?: string;
+  description?: string;
+  groundingSource?: {
+    sourceType: string;
+    knowledgeConfig?: {
+      contentFields?: string[];
+      isRestrictToPublicArticle?: boolean;
+    };
+  };
+};
+
+export type UploadResult = {
+  libraryId: string;
+  retrieverId?: string;
+  ragFeatureConfigId?: string;
+  status: string;
+};
+
+export type FileAddResult = {
+  success: boolean;
+  fileName: string;
+  libraryId: string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,3 +185,17 @@ export {
   buildResultSummary,
   type AgentEvalRunResult,
 } from './agentEvalRunner';
+export { AgentDataLibrary } from './agentDataLibrary';
+export {
+  type DataLibrarySummary,
+  type DataLibraryDetail,
+  type IndexingStatusResponse,
+  type CreateLibraryInput,
+  type UpdateLibraryInput,
+  type UploadResult,
+  type FileAddResult,
+  type GroundingFileRef,
+  type GroundingSource,
+  type StageDetail,
+  type SourceType,
+} from './dataLibraryTypes';

--- a/test/agentDataLibrary.test.ts
+++ b/test/agentDataLibrary.test.ts
@@ -16,6 +16,8 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unused-vars */
 
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection } from '@salesforce/core';
@@ -385,7 +387,7 @@ describe('AgentDataLibrary', () => {
 
   describe('upload', () => {
     let fetchStub: sinon.SinonStub;
-    const testFilePath = '/tmp/adl-upload-test.txt';
+    const testFilePath = join(tmpdir(), 'adl-upload-test.txt');
 
     beforeEach(async () => {
       const { writeFileSync } = await import('node:fs');
@@ -536,7 +538,7 @@ describe('AgentDataLibrary', () => {
 
   describe('addFile', () => {
     let fetchStub: sinon.SinonStub;
-    const testFilePath = '/tmp/adl-add-test.txt';
+    const testFilePath = join(tmpdir(), 'adl-add-test.txt');
 
     beforeEach(async () => {
       const { writeFileSync } = await import('node:fs');

--- a/test/agentDataLibrary.test.ts
+++ b/test/agentDataLibrary.test.ts
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unused-vars */
+
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Connection } from '@salesforce/core';
+import { AgentDataLibrary } from '../src/agentDataLibrary';
+import type { CreateLibraryInput, UpdateLibraryInput } from '../src/dataLibraryTypes';
+
+describe('AgentDataLibrary', () => {
+  const $$ = new TestContext();
+  let testOrg: MockTestOrgData;
+  let connection: Connection;
+  let requests: Array<{ method?: string; url?: string; body?: string }>;
+
+  beforeEach(async () => {
+    testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    connection = await testOrg.getConnection();
+    requests = [];
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  function mockRequest(response: any): void {
+    $$.fakeConnectionRequest = (req: any) => {
+      requests.push(req);
+      return Promise.resolve(response);
+    };
+  }
+
+  describe('list', () => {
+    it('should return libraries from the API', async () => {
+      const mockLibraries = [
+        { libraryId: '1JD000001', masterLabel: 'Test', developerName: 'Test', sourceType: 'SFDRIVE', status: 'READY' },
+      ];
+      mockRequest({ libraries: mockLibraries });
+
+      const result = await AgentDataLibrary.list(connection);
+
+      expect(result.libraries).to.deep.equal(mockLibraries);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.include('/einstein/data-libraries');
+    });
+
+    it('should throw on API error', async () => {
+      $$.fakeConnectionRequest = () => Promise.reject(new Error('Network error'));
+
+      try {
+        await AgentDataLibrary.list(connection);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Network error');
+      }
+    });
+  });
+
+  describe('create', () => {
+    it('should create an SFDRIVE library', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'Test',
+        developerName: 'Test',
+        groundingSource: { sourceType: 'SFDRIVE' },
+      };
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'Test', developerName: 'Test', sourceType: 'SFDRIVE' });
+
+      const result = await AgentDataLibrary.create(connection, input);
+
+      expect(result.libraryId).to.equal('1JD000001');
+      expect(requests[0].method).to.equal('POST');
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.sourceType).to.equal('SFDRIVE');
+    });
+
+    it('should auto-trigger indexing for KNOWLEDGE via fetch', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'KB',
+        developerName: 'KB',
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: { primaryIndexField1: 'ArticleNumber', primaryIndexField2: 'Title' },
+        },
+      };
+      mockRequest({ libraryId: '1JD000002', masterLabel: 'KB', developerName: 'KB', sourceType: 'KNOWLEDGE' });
+
+      // stub global fetch for the indexing call
+      const fetchStub = $$.SANDBOX.stub(global, 'fetch');
+      fetchStub.resolves(new Response(JSON.stringify({ status: 'IN_PROGRESS' }), { status: 201 }));
+
+      await AgentDataLibrary.create(connection, input);
+
+      // create goes through connection.request, indexing goes through fetch
+      expect(requests).to.have.lengthOf(1);
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0] as string).to.include('/indexing');
+      expect((fetchStub.firstCall.args[1] as { method: string }).method).to.equal('POST');
+    });
+
+    it('should not trigger indexing for RETRIEVER', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'Ret',
+        developerName: 'Ret',
+        groundingSource: { sourceType: 'RETRIEVER', retrieverId: '1Cx000001' },
+      };
+      mockRequest({ libraryId: '1JD000003', masterLabel: 'Ret', developerName: 'Ret', sourceType: 'RETRIEVER' });
+
+      await AgentDataLibrary.create(connection, input);
+
+      expect(requests).to.have.lengthOf(1);
+    });
+
+    it('should throw when retriever is not active', async () => {
+      $$.fakeConnectionRequest = () => Promise.reject(new Error('INVALID_REQUEST_STATE: The custom retriever is not active. Activate the retriever before adding it to a Data Library.'));
+
+      const input: CreateLibraryInput = {
+        masterLabel: 'Ret',
+        developerName: 'Ret',
+        groundingSource: { sourceType: 'RETRIEVER', retrieverId: '1Cx_INACTIVE' },
+      };
+
+      try {
+        await AgentDataLibrary.create(connection, input);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('not active');
+      }
+    });
+
+    it('should pass indexMode for SFDRIVE', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'Test',
+        developerName: 'Test',
+        groundingSource: { sourceType: 'SFDRIVE', indexMode: 'ENHANCED' },
+      };
+      mockRequest({ libraryId: '1JD000004', masterLabel: 'Test', developerName: 'Test', sourceType: 'SFDRIVE' });
+
+      await AgentDataLibrary.create(connection, input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.indexMode).to.equal('ENHANCED');
+    });
+
+    it('should pass retrieverId for RETRIEVER', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'Ret',
+        developerName: 'Ret',
+        groundingSource: { sourceType: 'RETRIEVER', retrieverId: '0pmSG000000001KAAQ' },
+      };
+      mockRequest({ libraryId: '1JD000005', masterLabel: 'Ret', developerName: 'Ret', sourceType: 'RETRIEVER' });
+
+      await AgentDataLibrary.create(connection, input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.sourceType).to.equal('RETRIEVER');
+      expect(body.groundingSource.retrieverId).to.equal('0pmSG000000001KAAQ');
+    });
+
+    it('should pass full knowledgeConfig for KNOWLEDGE', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'KB Full',
+        developerName: 'KB_Full',
+        description: 'Full knowledge config',
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: {
+            primaryIndexField1: 'ArticleNumber',
+            primaryIndexField2: 'Title',
+            contentFields: ['Answer__c', 'Summary__c'],
+            isRestrictToPublicArticle: true,
+          },
+        },
+      };
+      mockRequest({ libraryId: '1JD000006', masterLabel: 'KB Full', developerName: 'KB_Full', sourceType: 'KNOWLEDGE' });
+
+      await AgentDataLibrary.create(connection, input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.sourceType).to.equal('KNOWLEDGE');
+      expect(body.groundingSource.knowledgeConfig.primaryIndexField1).to.equal('ArticleNumber');
+      expect(body.groundingSource.knowledgeConfig.primaryIndexField2).to.equal('Title');
+      expect(body.groundingSource.knowledgeConfig.contentFields).to.deep.equal(['Answer__c', 'Summary__c']);
+      expect(body.groundingSource.knowledgeConfig.isRestrictToPublicArticle).to.be.true;
+      expect(body.description).to.equal('Full knowledge config');
+    });
+
+    it('should pass description for any source type', async () => {
+      const input: CreateLibraryInput = {
+        masterLabel: 'Test',
+        developerName: 'Test',
+        description: 'My description',
+        groundingSource: { sourceType: 'SFDRIVE' },
+      };
+      mockRequest({ libraryId: '1JD000007', masterLabel: 'Test', developerName: 'Test', sourceType: 'SFDRIVE' });
+
+      await AgentDataLibrary.create(connection, input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.description).to.equal('My description');
+    });
+  });
+
+  describe('get', () => {
+    it('should return library detail', async () => {
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'Test', sourceType: 'SFDRIVE', status: 'READY', retrieverId: '1Cx000001' });
+
+      const result = await AgentDataLibrary.get(connection, '1JD000001');
+
+      expect(result.libraryId).to.equal('1JD000001');
+      expect(result.retrieverId).to.equal('1Cx000001');
+      expect(requests[0].url).to.include('/1JD000001');
+    });
+  });
+
+  describe('update', () => {
+    it('should send PATCH with metadata', async () => {
+      const input: UpdateLibraryInput = { masterLabel: 'Updated', description: 'New desc' };
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'Updated', developerName: 'Test' });
+
+      const result = await AgentDataLibrary.update(connection, '1JD000001', input);
+
+      expect(result.masterLabel).to.equal('Updated');
+      expect(requests[0].method).to.equal('PATCH');
+      const body = JSON.parse(requests[0].body!);
+      expect(body.masterLabel).to.equal('Updated');
+    });
+
+    it('should send knowledgeConfig in groundingSource', async () => {
+      const input: UpdateLibraryInput = {
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: { contentFields: ['Answer__c'], isRestrictToPublicArticle: true },
+        },
+      };
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'KB' });
+
+      await AgentDataLibrary.update(connection, '1JD000001', input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.knowledgeConfig.contentFields).to.deep.equal(['Answer__c']);
+      expect(body.groundingSource.knowledgeConfig.isRestrictToPublicArticle).to.be.true;
+    });
+
+    it('should update only contentFields without restrictToPublicArticle', async () => {
+      const input: UpdateLibraryInput = {
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: { contentFields: ['Answer__c', 'Summary__c'] },
+        },
+      };
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'KB' });
+
+      await AgentDataLibrary.update(connection, '1JD000001', input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.groundingSource.knowledgeConfig.contentFields).to.deep.equal(['Answer__c', 'Summary__c']);
+      expect(body.groundingSource.knowledgeConfig.isRestrictToPublicArticle).to.be.undefined;
+    });
+
+    it('should combine metadata and knowledgeConfig update', async () => {
+      const input: UpdateLibraryInput = {
+        masterLabel: 'Updated KB',
+        description: 'New desc',
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: { contentFields: ['Answer__c'] },
+        },
+      };
+      mockRequest({ libraryId: '1JD000001', masterLabel: 'Updated KB' });
+
+      await AgentDataLibrary.update(connection, '1JD000001', input);
+
+      const body = JSON.parse(requests[0].body!);
+      expect(body.masterLabel).to.equal('Updated KB');
+      expect(body.description).to.equal('New desc');
+      expect(body.groundingSource.knowledgeConfig.contentFields).to.deep.equal(['Answer__c']);
+    });
+
+    it('should throw on update error (e.g. provisioning in progress)', async () => {
+      $$.fakeConnectionRequest = () => Promise.reject(new Error('INVALID_REQUEST_STATE: Cannot update library'));
+
+      try {
+        await AgentDataLibrary.update(connection, '1JD000001', { masterLabel: 'Fail' });
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Cannot update library');
+      }
+    });
+  });
+
+  describe('delete', () => {
+    it('should send DELETE request', async () => {
+      mockRequest({});
+
+      await AgentDataLibrary.delete(connection, '1JD000001');
+
+      expect(requests[0].method).to.equal('DELETE');
+      expect(requests[0].url).to.include('/1JD000001');
+    });
+
+    it('should throw on API error', async () => {
+      $$.fakeConnectionRequest = () => Promise.reject(new Error('Cannot delete'));
+
+      try {
+        await AgentDataLibrary.delete(connection, '1JD000001');
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.include('Cannot delete');
+      }
+    });
+  });
+
+  describe('status', () => {
+    it('should return indexing status', async () => {
+      const mockResult = {
+        indexingStatus: {
+          libraryId: '1JD000001',
+          status: 'IN_PROGRESS',
+          stageDetails: [
+            { name: 'DATA_LAKE_OBJECT', status: 'SUCCESS' },
+            { name: 'SEARCH_INDEX', status: 'IN_PROGRESS' },
+          ],
+        },
+      };
+      mockRequest(mockResult);
+
+      const result = await AgentDataLibrary.status(connection, '1JD000001');
+
+      expect(result.indexingStatus.status).to.equal('IN_PROGRESS');
+      expect(result.indexingStatus.stageDetails).to.have.lengthOf(2);
+      expect(requests[0].url).to.include('/status');
+    });
+  });
+
+  describe('listFiles', () => {
+    it('should extract groundingFileRefs from detail', async () => {
+      mockRequest({
+        libraryId: '1JD000001',
+        groundingSource: {
+          groundingFileRefs: [{ fileId: '1Jc000001', fileName: 'doc.pdf', filePath: 'path/doc.pdf', fileSize: 1024 }],
+        },
+      });
+
+      const files = await AgentDataLibrary.listFiles(connection, '1JD000001');
+
+      expect(files).to.have.lengthOf(1);
+      expect(files[0].fileName).to.equal('doc.pdf');
+    });
+
+    it('should return empty array when no files', async () => {
+      mockRequest({ libraryId: '1JD000001', groundingSource: {} });
+
+      const files = await AgentDataLibrary.listFiles(connection, '1JD000001');
+
+      expect(files).to.have.lengthOf(0);
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should send DELETE to files endpoint', async () => {
+      mockRequest({});
+
+      await AgentDataLibrary.deleteFile(connection, '1JD000001', '1Jc000001');
+
+      expect(requests[0].method).to.equal('DELETE');
+      expect(requests[0].url).to.include('/files/1Jc000001');
+    });
+  });
+
+  describe('upload', () => {
+    let fetchStub: sinon.SinonStub;
+    const testFilePath = '/tmp/adl-upload-test.txt';
+
+    beforeEach(async () => {
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(testFilePath, 'test content for upload');
+      fetchStub = $$.SANDBOX.stub(global, 'fetch');
+      fetchStub.resolves(new Response(null, { status: 200 }));
+    });
+
+    it('should perform full upload flow (readiness → urls → s3 → indexing)', async () => {
+      let callCount = 0;
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        callCount++;
+        if (req.url?.includes('/upload-readiness')) {
+          return Promise.resolve({ ready: true });
+        }
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/upload', filePath: '$adl$/1JD000001/test.txt', headers: { 'Content-Type': 'text/plain' } }],
+          });
+        }
+        if (req.url?.includes('/indexing')) {
+          return Promise.resolve({ status: 'IN_PROGRESS', filesAccepted: 1 });
+        }
+        return Promise.resolve({});
+      };
+
+      const result = await AgentDataLibrary.upload(connection, '1JD000001', testFilePath);
+
+      expect(result.status).to.equal('IN_PROGRESS');
+      expect(result.libraryId).to.equal('1JD000001');
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal('https://s3.example.com/upload');
+      expect(fetchStub.firstCall.args[1].method).to.equal('PUT');
+      expect(fetchStub.firstCall.args[1].headers).to.deep.equal({ 'Content-Type': 'text/plain' });
+
+      const readinessReq = requests.find((r) => r.url?.includes('/upload-readiness'));
+      const urlsReq = requests.find((r) => r.url?.includes('/file-upload-urls'));
+      const indexingReq = requests.find((r) => r.url?.includes('/indexing'));
+      expect(readinessReq).to.exist;
+      expect(urlsReq).to.exist;
+      expect(indexingReq).to.exist;
+
+      const indexBody = JSON.parse(indexingReq!.body!);
+      expect(indexBody.uploadedFiles[0].filePath).to.equal('$adl$/1JD000001/test.txt');
+      expect(indexBody.uploadedFiles[0].fileSize).to.be.a('number');
+    });
+
+    it('should poll and return READY when --wait and retrieverId appears', async () => {
+      let pollCount = 0;
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/upload-readiness')) {
+          return Promise.resolve({ ready: true });
+        }
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/upload', filePath: '$adl$/1JD000001/test.txt', headers: {} }],
+          });
+        }
+        if (req.url?.includes('/indexing')) {
+          return Promise.resolve({ status: 'IN_PROGRESS' });
+        }
+        // GET detail (polling)
+        pollCount++;
+        if (pollCount >= 2) {
+          return Promise.resolve({ libraryId: '1JD000001', retrieverId: '1Cx000001', status: 'READY' });
+        }
+        return Promise.resolve({ libraryId: '1JD000001', status: 'IN_PROGRESS' });
+      };
+
+      const result = await AgentDataLibrary.upload(connection, '1JD000001', testFilePath, { waitMinutes: 1 });
+
+      expect(result.status).to.equal('READY');
+      expect(result.retrieverId).to.equal('1Cx000001');
+      expect(result.ragFeatureConfigId).to.equal('ARFPC_1JD000001');
+    });
+
+    it('should retry upload-readiness up to 3 times', async () => {
+      let readinessAttempts = 0;
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/upload-readiness')) {
+          readinessAttempts++;
+          if (readinessAttempts < 3) {
+            return Promise.resolve({ ready: false });
+          }
+          return Promise.resolve({ ready: true });
+        }
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/upload', filePath: '$adl$/1JD000001/test.txt', headers: {} }],
+          });
+        }
+        if (req.url?.includes('/indexing')) {
+          return Promise.resolve({ status: 'IN_PROGRESS' });
+        }
+        return Promise.resolve({});
+      };
+
+      const result = await AgentDataLibrary.upload(connection, '1JD000001', testFilePath);
+
+      expect(readinessAttempts).to.equal(3);
+      expect(result.status).to.equal('IN_PROGRESS');
+    });
+
+    it('should throw UploadNotReady after 3 failed readiness attempts', async () => {
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/upload-readiness')) {
+          return Promise.resolve({ ready: false });
+        }
+        return Promise.resolve({});
+      };
+
+      try {
+        await AgentDataLibrary.upload(connection, '1JD000001', testFilePath);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.name).to.equal('UploadNotReady');
+      }
+    });
+
+    it('should throw on S3 upload failure', async () => {
+      fetchStub.resolves(new Response('Forbidden', { status: 403 }));
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/upload-readiness')) {
+          return Promise.resolve({ ready: true });
+        }
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/upload', filePath: '$adl$/1JD000001/test.txt', headers: {} }],
+          });
+        }
+        return Promise.resolve({});
+      };
+
+      try {
+        await AgentDataLibrary.upload(connection, '1JD000001', testFilePath);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.name).to.equal('S3UploadFailed');
+        expect(err.message).to.include('403');
+      }
+    });
+  });
+
+  describe('addFile', () => {
+    let fetchStub: sinon.SinonStub;
+    const testFilePath = '/tmp/adl-add-test.txt';
+
+    beforeEach(async () => {
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(testFilePath, 'test content for add');
+      fetchStub = $$.SANDBOX.stub(global, 'fetch');
+      fetchStub.resolves(new Response(null, { status: 200 }));
+    });
+
+    it('should perform add file flow (urls → s3 → /files)', async () => {
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/add', filePath: '$adl$/1JD000001/new.txt', headers: { 'Content-Type': 'text/plain' } }],
+          });
+        }
+        if (req.url?.includes('/files')) {
+          return Promise.resolve({ filesAccepted: 1 });
+        }
+        return Promise.resolve({});
+      };
+
+      const result = await AgentDataLibrary.addFile(connection, '1JD000001', testFilePath);
+
+      expect(result.success).to.be.true;
+      expect(result.fileName).to.equal('adl-add-test.txt');
+      expect(result.libraryId).to.equal('1JD000001');
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal('https://s3.example.com/add');
+
+      const filesReq = requests.find((r) => r.url?.includes('/files') && r.method === 'POST');
+      expect(filesReq).to.exist;
+      const filesBody = JSON.parse(filesReq!.body!);
+      expect(filesBody.uploadedFiles[0].filePath).to.equal('$adl$/1JD000001/new.txt');
+    });
+
+    it('should throw on S3 failure during add', async () => {
+      fetchStub.resolves(new Response('Access Denied', { status: 403 }));
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [{ uploadUrl: 'https://s3.example.com/add', filePath: '$adl$/1JD000001/new.txt', headers: {} }],
+          });
+        }
+        return Promise.resolve({});
+      };
+
+      try {
+        await AgentDataLibrary.addFile(connection, '1JD000001', testFilePath);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.name).to.equal('S3UploadFailed');
+      }
+    });
+  });
+});

--- a/test/nuts/agentDataLibrary.nut.ts
+++ b/test/nuts/agentDataLibrary.nut.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { expect } from 'chai';
+import { Connection, Org } from '@salesforce/core';
+import { AgentDataLibrary } from '../../src/agentDataLibrary';
+
+/* eslint-disable no-console */
+
+// AgentDataLibrary NUT — Tests ADL operations against a real org.
+// Requires a pre-authenticated org with Data Cloud provisioned.
+//
+// Usage:
+//   TARGET_ORG=sdb3 RETRIEVER_ID=1CxSB000000G5Rx0AK yarn test:nuts --grep "AgentDataLibrary"
+
+const targetOrg = process.env.TARGET_ORG;
+const retrieverId = process.env.RETRIEVER_ID;
+
+describe('AgentDataLibrary NUTs — SFDRIVE', function () {
+  this.timeout(15 * 60 * 1000);
+
+  let connection: Connection;
+  let libraryId: string;
+  let testFile: string;
+  let testFile2: string;
+
+  before(async function () {
+    if (!targetOrg) {
+      console.log('Skipping ADL NUTs: set TARGET_ORG env var');
+      this.skip();
+    }
+
+    const org = await Org.create({ aliasOrUsername: targetOrg });
+    connection = org.getConnection();
+
+    testFile = join(tmpdir(), 'adl-agents-nut-test.txt');
+    testFile2 = join(tmpdir(), 'adl-agents-nut-test2.txt');
+    writeFileSync(testFile, 'AgentDataLibrary NUT test document.');
+    writeFileSync(testFile2, 'AgentDataLibrary NUT second document for day-1.');
+  });
+
+  after(async () => {
+    if (libraryId && connection) {
+      try {
+        await AgentDataLibrary.delete(connection, libraryId);
+        console.log(`Cleanup: deleted ${libraryId}`);
+      } catch {
+        console.log(`Cleanup: delete failed for ${libraryId} (may still be provisioning)`);
+      }
+    }
+  });
+
+  it('should list libraries (prerequisite check)', async () => {
+    const result = await AgentDataLibrary.list(connection);
+    expect(result).to.have.property('libraries');
+    console.log(`ADL API accessible — ${result.libraries.length} existing libraries`);
+  });
+
+  it('should create an SFDRIVE library', async () => {
+    const devName = `NUT_Lib_${Date.now()}`;
+    const result = await AgentDataLibrary.create(connection, {
+      masterLabel: devName,
+      developerName: devName,
+      groundingSource: { sourceType: 'SFDRIVE' },
+    });
+
+    expect(result).to.have.property('libraryId');
+    libraryId = result.libraryId;
+    console.log(`Created SFDRIVE library: ${libraryId}`);
+  });
+
+  it('should get library detail', async () => {
+    const result = await AgentDataLibrary.get(connection, libraryId);
+    expect(result.libraryId).to.equal(libraryId);
+    expect(result.sourceType).to.equal('SFDRIVE');
+  });
+
+  it('should get indexing status', async () => {
+    const result = await AgentDataLibrary.status(connection, libraryId);
+    expect(result.indexingStatus.libraryId).to.equal(libraryId);
+    expect(result.indexingStatus).to.have.property('status');
+    expect(result.indexingStatus).to.have.property('stageDetails');
+  });
+
+  it('should upload a file and wait for READY', async function () {
+    this.timeout(10 * 60 * 1000);
+
+    const result = await AgentDataLibrary.upload(connection, libraryId, testFile, { waitMinutes: 10 });
+
+    expect(result.libraryId).to.equal(libraryId);
+    expect(result.status).to.equal('READY');
+    expect(result.retrieverId).to.be.a('string');
+    expect(result.ragFeatureConfigId).to.equal(`ARFPC_${libraryId}`);
+    console.log(`Upload complete — retrieverId: ${result.retrieverId}`);
+  });
+
+  it('should update library metadata', async () => {
+    const result = await AgentDataLibrary.update(connection, libraryId, {
+      masterLabel: 'NUT_Updated',
+      description: 'Updated by AgentDataLibrary NUT',
+    });
+
+    expect(result.masterLabel).to.equal('NUT_Updated');
+  });
+
+  it('should add a second file (day-1)', async function () {
+    this.timeout(3 * 60 * 1000);
+
+    const result = await AgentDataLibrary.addFile(connection, libraryId, testFile2);
+
+    expect(result.success).to.be.true;
+    expect(result.fileName).to.equal('adl-agents-nut-test2.txt');
+  });
+
+  it('should list files in the library', async () => {
+    const files = await AgentDataLibrary.listFiles(connection, libraryId);
+    expect(files.length).to.be.greaterThan(0);
+    console.log(`Files: ${files.map((f) => f.fileName).join(', ')}`);
+  });
+});
+
+describe('AgentDataLibrary NUTs — KNOWLEDGE', function () {
+  this.timeout(5 * 60 * 1000);
+
+  let connection: Connection;
+  let libraryId: string;
+
+  before(async function () {
+    if (!targetOrg) {
+      this.skip();
+    }
+    const org = await Org.create({ aliasOrUsername: targetOrg });
+    connection = org.getConnection();
+  });
+
+  after(async () => {
+    if (libraryId && connection) {
+      try {
+        await AgentDataLibrary.delete(connection, libraryId);
+        console.log(`Cleanup: deleted Knowledge library ${libraryId}`);
+      } catch {
+        console.log(`Cleanup: delete failed for ${libraryId}`);
+      }
+    }
+  });
+
+  it('should create a KNOWLEDGE library with config', async () => {
+    const devName = `NUT_Know_${Date.now()}`;
+    const result = await AgentDataLibrary.create(connection, {
+      masterLabel: devName,
+      developerName: devName,
+      groundingSource: {
+        sourceType: 'KNOWLEDGE',
+        knowledgeConfig: {
+          primaryIndexField1: 'ArticleNumber',
+          primaryIndexField2: 'Title',
+        },
+      },
+    });
+
+    expect(result).to.have.property('libraryId');
+    expect(result.sourceType).to.equal('KNOWLEDGE');
+    libraryId = result.libraryId;
+    console.log(`Created KNOWLEDGE library: ${libraryId}`);
+  });
+
+  it('should get Knowledge library detail', async () => {
+    const result = await AgentDataLibrary.get(connection, libraryId);
+    expect(result.sourceType).to.equal('KNOWLEDGE');
+  });
+
+  it('should get Knowledge indexing status with stages', async () => {
+    const result = await AgentDataLibrary.status(connection, libraryId);
+    expect(result.indexingStatus.libraryId).to.equal(libraryId);
+    expect(result.indexingStatus).to.have.property('stageDetails');
+  });
+
+  it('should update Knowledge metadata (best-effort — may fail if still provisioning)', async () => {
+    try {
+      const result = await AgentDataLibrary.update(connection, libraryId, {
+        masterLabel: 'NUT_Know_Updated',
+        description: 'Updated Knowledge lib',
+      });
+      expect(result.masterLabel).to.equal('NUT_Know_Updated');
+    } catch (err: unknown) {
+      const error = err as { message?: string };
+      if (error.message?.includes('provisioning operation is currently in progress')) {
+        console.log('Update skipped — library still provisioning (expected for freshly created Knowledge)');
+      } else {
+        throw err;
+      }
+    }
+  });
+});
+
+describe('AgentDataLibrary NUTs — RETRIEVER', function () {
+  this.timeout(3 * 60 * 1000);
+
+  let connection: Connection;
+  let libraryId: string;
+
+  before(async function () {
+    if (!targetOrg || !retrieverId) {
+      console.log('Skipping RETRIEVER NUTs: set TARGET_ORG and RETRIEVER_ID env vars');
+      this.skip();
+    }
+    const org = await Org.create({ aliasOrUsername: targetOrg });
+    connection = org.getConnection();
+  });
+
+  after(async () => {
+    if (libraryId && connection) {
+      try {
+        await AgentDataLibrary.delete(connection, libraryId);
+        console.log(`Cleanup: deleted Retriever library ${libraryId}`);
+      } catch {
+        console.log(`Cleanup: delete failed for ${libraryId}`);
+      }
+    }
+  });
+
+  it('should create a RETRIEVER library (immediately READY)', async () => {
+    const devName = `NUT_Ret_${Date.now()}`;
+    const result = await AgentDataLibrary.create(connection, {
+      masterLabel: devName,
+      developerName: devName,
+      groundingSource: { sourceType: 'RETRIEVER', retrieverId },
+    });
+
+    expect(result).to.have.property('libraryId');
+    expect(result.sourceType).to.equal('RETRIEVER');
+    libraryId = result.libraryId;
+    console.log(`Created RETRIEVER library: ${libraryId}`);
+  });
+
+  it('should get Retriever detail with status READY', async () => {
+    const result = await AgentDataLibrary.get(connection, libraryId);
+    expect(result.sourceType).to.equal('RETRIEVER');
+    expect(result.status).to.equal('READY');
+    expect(result.retrieverId).to.equal(retrieverId);
+  });
+
+  it('should update Retriever metadata', async () => {
+    const result = await AgentDataLibrary.update(connection, libraryId, {
+      masterLabel: 'NUT_Ret_Updated',
+      description: 'Updated Retriever',
+    });
+
+    expect(result.masterLabel).to.equal('NUT_Ret_Updated');
+  });
+
+  it('should delete Retriever library', async () => {
+    await AgentDataLibrary.delete(connection, libraryId);
+    libraryId = '';
+  });
+});


### PR DESCRIPTION
Adds AgentDataLibrary class with static methods for all ADL operations:
- list, create, get, update, delete, status
- upload (multi-step: readiness → presigned URL → S3 PUT → indexing → poll)
- addFile (day-1 additions), listFiles, deleteFile

Types exported: DataLibrarySummary, DataLibraryDetail, CreateLibraryInput, UpdateLibraryInput, UploadResult, FileAddResult, GroundingFileRef, etc.

Key behaviors:
- Upload-readiness retries up to 3x (6 min total)
- S3 upload uses fetch() directly with verbatim headers
- KNOWLEDGE auto-triggers /indexing on create (30s timeout, best-effort)
- Polling gates on retrieverId from detail endpoint

Includes 29 unit tests + NUT tests for SFDRIVE, KNOWLEDGE, RETRIEVER.

### What does this PR do?
  Adds AgentDataLibrary class to @salesforce/agents for Agentforce Data Library (ADL) Connect API operations. Supports SFDRIVE, KNOWLEDGE, and RETRIEVER source types with full lifecycle: create, list,
  get, update, delete, status, upload (multi-step S3 flow), file add, file list, and file delete.
  
### What issues does this PR fix or reference?
@W-22787736@