### PR TITLE
W-22813532: feat: thread contextVariables through ScriptAgent.preview.start

### DIFF
--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -23,6 +23,7 @@ import {
   type AgentPreviewEndResponse,
   AgentPreviewInterface,
   type AgentPreviewSendResponse,
+  type AgentPreviewStartOptions,
   type AgentPreviewStartResponse,
   AgentScriptContent,
   type CompileAgentScriptResponse,
@@ -106,8 +107,16 @@ export class ScriptAgent extends AgentBase {
     }
 
     this.preview = {
-      start: (mockMode?: 'Mock' | 'Live Test', apexDebugging?: boolean): Promise<AgentPreviewStartResponse> =>
-        this.startPreview(mockMode, apexDebugging),
+      start: (
+        mockModeOrOptions?: 'Mock' | 'Live Test' | AgentPreviewStartOptions,
+        apexDebugging?: boolean,
+        startOptions?: AgentPreviewStartOptions
+      ): Promise<AgentPreviewStartResponse> => {
+        if (typeof mockModeOrOptions === 'object' && mockModeOrOptions !== null) {
+          return this.startPreview(undefined, undefined, mockModeOrOptions);
+        }
+        return this.startPreview(mockModeOrOptions, apexDebugging, startOptions);
+      },
       send: (message: string): Promise<AgentPreviewSendResponse> => this.sendMessage(message),
       getAllTraces: (): Promise<PlannerResponse[]> => this.getAllTracesFromDisc(),
       end: (): Promise<AgentPreviewEndResponse> => this.endSession(),
@@ -449,7 +458,8 @@ export class ScriptAgent extends AgentBase {
 
   private async startPreview(
     mockMode?: 'Mock' | 'Live Test',
-    apexDebugging?: boolean
+    apexDebugging?: boolean,
+    options?: AgentPreviewStartOptions
   ): Promise<AgentPreviewStartResponse> {
     if (!this.agentJson) {
       void Lifecycle.getInstance().emit('agents:compiling', {});
@@ -492,7 +502,7 @@ export class ScriptAgent extends AgentBase {
       instanceConfig: {
         endpoint: this.options.connection.instanceUrl,
       },
-      variables: [],
+      variables: options?.contextVariables ?? [],
       parameters: {},
       streamingCapabilities: {
         chunkTypes: ['Text', 'LightningChunk'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ export {
   type AgentPreviewMessageLinks,
   type AgentPreviewMessage,
   type AgentPreviewError,
+  type AgentPreviewStartOptions,
+  type ContextVariable,
   AgentSource,
   type ScriptAgentType,
   type ProductionAgentType,
@@ -173,18 +175,8 @@ export {
   type TestResult,
   type ResultFormat,
 } from './evalFormatter';
-export {
-  isYamlTestSpec,
-  parseTestSpec,
-  translateTestSpec,
-  translateTestCase,
-} from './yamlSpecTranslator';
-export {
-  resolveAgent,
-  executeBatches,
-  buildResultSummary,
-  type AgentEvalRunResult,
-} from './agentEvalRunner';
+export { isYamlTestSpec, parseTestSpec, translateTestSpec, translateTestCase } from './yamlSpecTranslator';
+export { resolveAgent, executeBatches, buildResultSummary, type AgentEvalRunResult } from './agentEvalRunner';
 export { AgentDataLibrary } from './agentDataLibrary';
 export {
   type DataLibrarySummary,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,16 @@ export type AgentPreviewInterface = {
   setApexDebugging: (apexDebugging: boolean) => void;
 };
 
+export type ContextVariable = {
+  name: string;
+  type: 'Object' | 'Json' | 'Boolean' | 'Date' | 'DateTime' | 'Money' | 'Number' | 'Text' | 'Ref' | 'List';
+  value: string;
+};
+
+export type AgentPreviewStartOptions = {
+  contextVariables?: ContextVariable[];
+};
+
 /**
  * Session metadata type
  */
@@ -501,12 +511,12 @@ export type MetadataMetric = { name: string };
 export type MetadataExpectation = {
   // topic/action/outcome matching
   name:
-  | 'topic_sequence_match'
-  | 'topic_assertion'
-  | 'action_sequence_match'
-  | 'actions_assertion'
-  | 'bot_response_rating'
-  | 'output_validation';
+    | 'topic_sequence_match'
+    | 'topic_assertion'
+    | 'action_sequence_match'
+    | 'actions_assertion'
+    | 'bot_response_rating'
+    | 'output_validation';
   expectedValue: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export type AgentPreviewInterface = {
 
 export type ContextVariable = {
   name: string;
-  type: 'Object' | 'Json' | 'Boolean' | 'Date' | 'DateTime' | 'Money' | 'Number' | 'Text' | 'Ref' | 'List';
+  type: 'Object' | 'Boolean' | 'DateTime' | 'Money' | 'Number' | 'Text' | 'Ref' | 'List';
   value: string;
 };
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -686,6 +686,188 @@ describe('Agents', () => {
     });
   });
 
+  describe('ScriptAgent.preview.start contextVariables', () => {
+    let sfProject: SfProject;
+    let requestStub: sinon.SinonStub;
+    const previewSessionResponse = {
+      sessionId: 'test-session-id',
+      _links: {},
+      messages: [],
+    };
+    const minimalAgentJson = {
+      schemaVersion: '1.0',
+      globalConfiguration: {
+        developerName: 'myAgent',
+        label: 'My Agent',
+        agentType: 'AgentforceServiceAgent',
+        defaultAgentUser: 'test@example.com',
+        description: '',
+        enableEnhancedEventLogs: false,
+        templateName: '',
+        defaultOutboundRouting: '',
+        contextVariables: [],
+      },
+      agentVersion: {
+        developerName: 'v1',
+        plannerType: '',
+        systemMessages: [],
+        modalityParameters: {
+          voice: {
+            inboundModel: null,
+            inboundFillerWordsDetection: null,
+            outboundVoice: null,
+            outboundModel: null,
+            outboundSpeed: null,
+            outboundStyleExaggeration: null,
+          },
+          language: {
+            defaultLocale: 'en_US',
+            additionalLocales: [],
+            allAdditionalLocales: false,
+          },
+        },
+        additionalParameters: false,
+        company: '',
+        role: '',
+        stateVariables: [],
+        initialNode: '',
+        nodes: [],
+        knowledgeDefinitions: null,
+      },
+    };
+
+    beforeEach(async () => {
+      sfProject = SfProject.getInstance();
+      // @ts-expect-error Not the full package def
+      $$.SANDBOX.stub(sfProject, 'getDefaultPackage').returns({ path: 'force-app' });
+      $$.SANDBOX.stub(sfProject, 'getPackageDirectories').returns([
+        { fullPath: 'force-app', path: 'force-app', package: '', versionNumber: '', name: 'force-app' },
+      ]);
+
+      const aabDirectory = join('force-app', 'main', 'default', 'aiAuthoringBundles', 'myAgent');
+      await fs.mkdir(aabDirectory, { recursive: true });
+      await fs.writeFile(
+        join(aabDirectory, 'myAgent.agent'),
+        'system:\n  instructions: "You are an AI Agent."\n  developer_name: "myAgent"\n  agent_label: "My Agent"'
+      );
+      await fs.writeFile(
+        join(aabDirectory, 'myAgent.bundle-meta.xml'),
+        '<?xml version="1.0" encoding="UTF-8"?>\n<AiAuthoringBundle xmlns="http://soap.sforce.com/2006/04/metadata">\n    <bundleType>AGENT</bundleType>\n    <target>v1</target>\n</AiAuthoringBundle>'
+      );
+
+      $$.SANDBOX.stub(connection, 'refreshAuth').resolves();
+      $$.SANDBOX.stub(connection, 'getConnectionOptions').returns({
+        accessToken: 'test_access_token',
+        instanceUrl: connection.instanceUrl,
+      });
+
+      $$.SANDBOX.stub(connection, 'query')
+        .withArgs(sinon.match(/SELECT Id FROM USER WHERE username/))
+        .resolves({ done: true, records: [{ Id: '005xx0000000000xxx' }], totalSize: 1 } as never);
+
+      requestStub = $$.SANDBOX.stub(connection, 'request');
+      requestStub.withArgs(sinon.match({ url: `${connection.instanceUrl}/agentforce/bootstrap/nameduser` })).resolves({
+        // eslint-disable-next-line camelcase
+        access_token:
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoidGVzdCJ9.4Adcj0vVzk6B5R-9X8kBR1R0N0FhT3ZSY0J5Z1Z4Y2c',
+      });
+      requestStub
+        .withArgs(sinon.match({ url: sinon.match(/v1\.1\/preview\/sessions/) }))
+        .resolves(previewSessionResponse);
+    });
+
+    afterEach(async () => {
+      await fs.rm(join('force-app'), { recursive: true, force: true });
+    });
+
+    const getStartRequestBody = (): Record<string, unknown> => {
+      const startCall = requestStub
+        .getCalls()
+        .find((c) => (c.args[0] as { url: string }).url.endsWith('/v1.1/preview/sessions'));
+      if (!startCall) throw new Error('preview/sessions request not captured');
+      return JSON.parse((startCall.args[0] as { body: string }).body) as Record<string, unknown>;
+    };
+
+    it('posts variables: [] when called without options (regression)', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property — bypass compile
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start();
+
+      expect(getStartRequestBody().variables).to.deep.equal([]);
+    });
+
+    it('posts {name, type, value} entries when options provided', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start({
+        contextVariables: [{ name: '$Context.RoutableId', type: 'Text', value: '0MwXX0000000000000' }],
+      });
+
+      expect(getStartRequestBody().variables).to.deep.equal([
+        { name: '$Context.RoutableId', type: 'Text', value: '0MwXX0000000000000' },
+      ]);
+    });
+
+    it('preserves $Context. prefix names verbatim', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start({
+        contextVariables: [
+          { name: '$Context.RoutableId', type: 'Text', value: 'a' },
+          { name: '$Context.Region', type: 'Text', value: 'NZ' },
+        ],
+      });
+
+      const variables = getStartRequestBody().variables as Array<{ name: string }>;
+      expect(variables.map((v) => v.name)).to.deep.equal(['$Context.RoutableId', '$Context.Region']);
+    });
+
+    it('preserves bare names (e.g., OpenAgent) verbatim', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start({
+        contextVariables: [{ name: 'OpenAgent', type: 'Text', value: 'general_faq' }],
+      });
+
+      const variables = getStartRequestBody().variables as Array<{ name: string }>;
+      expect(variables.map((v) => v.name)).to.deep.equal(['OpenAgent']);
+    });
+
+    it('accepts single-options call shape: start({contextVariables})', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start({
+        contextVariables: [{ name: 'OpenAgent', type: 'Text', value: 'x' }],
+      });
+
+      expect((getStartRequestBody().variables as unknown[]).length).to.equal(1);
+    });
+
+    it('accepts positional + options: start("Mock", false, {contextVariables})', async () => {
+      const agent = new ScriptAgent({ connection, project: sfProject, aabName: 'myAgent' });
+      // @ts-expect-error private property
+      agent.agentJson = minimalAgentJson;
+
+      await agent.preview.start('Mock', false, {
+        contextVariables: [{ name: '$Context.A', type: 'Text', value: '1' }],
+      });
+
+      const body = getStartRequestBody();
+      expect(body.enableSimulationMode).to.equal(true);
+      expect(body.variables).to.deep.equal([{ name: '$Context.A', type: 'Text', value: '1' }]);
+    });
+  });
+
   it('create save agent', async () => {
     process.env.SF_MOCK_DIR = join('test', 'mocks', 'createAgent-Save');
     const sfProject = SfProject.getInstance();

--- a/test/nuts/agent.nut.ts
+++ b/test/nuts/agent.nut.ts
@@ -419,6 +419,32 @@ describe('agent NUTs', () => {
         });
       });
 
+      it('should reflect supplied contextVariables in the live preview session trace', async () => {
+        const agent = await Agent.init({ connection, project, aabName: bundleApiName });
+        agent.preview.setMockMode('Live Test');
+
+        const overrideValue = '0MwXX0000000000000';
+        await agent.preview.start({
+          contextVariables: [{ name: '$Context.RoutableId', type: 'Text', value: overrideValue }],
+        });
+
+        // Send a message so the planner emits at least one trace
+        await agent.preview.send('hello');
+
+        const traces = await agent.preview.getAllTraces();
+        expect(traces).to.be.an('array');
+        expect(traces.length).to.be.greaterThan(0, 'expected at least one trace from the planner');
+
+        // Walk every step of every trace looking for the override echoed back as session state.
+        // Shape varies by step type, so we stringify and substring-match.
+        const allStepsJson = traces
+          .flatMap((t) => (t as { steps?: unknown[] })?.steps ?? [])
+          .map((s) => JSON.stringify(s))
+          .join('\n');
+
+        expect(allStepsJson).to.contain(overrideValue, 'expected override value to appear in at least one trace step');
+      });
+
       it('should end the preview session', async () => {
         const agent = await Agent.init({ connection, project, aabName: bundleApiName });
         const previewSession = await agent.preview.start();


### PR DESCRIPTION
### What does this PR do?

  Threads caller-supplied `contextVariables` from `agent.preview.start()` into the SFAP request body's `variables` field for
  `ScriptAgent`. Adds a typed `AgentPreviewStartOptions` parameter that accepts `{name, type, value}` entries.

  Behaviour:

  - `start()` and `start('Mock', false)` continue to work — `variables: []` body unchanged
  - `start({ contextVariables: [...] })` populates the wire field
  - `start('Mock', false, { contextVariables: [...] })` also supported
  - Both server-accepted name shapes are passed through verbatim: `$Context.<Name>` and bare `<developerName>`

  Tests: 6 ScriptAgent integration tests, 1 NUT.

  > **Note on diff noise:** `src/index.ts` and the `MetadataExpectation` block in `src/types.ts` show formatter-only churn. `main` is
  currently prettier-dirty for those lines, and the husky `pretty-quick --staged` hook reformatted them on commit — reverting would
  re-introduce a style violation that the next staged change re-fixes.

  ### What issues does this PR fix or reference?
[@W-22813532@](https://gus.lightning.force.com/lightning/_classic//a07EE00002bR4ZmYAK)