### PR TITLE
W-22816781: fix: multi-file support, list filter, retriever swap

### DIFF
--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -192,10 +192,9 @@ export class AgentDataLibrary {
     const fileNames = paths.map((p) => ({ fileName: basename(p) }));
     const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileNames);
 
-    for (let i = 0; i < paths.length; i++) {
-      // eslint-disable-next-line no-await-in-loop
-      await AgentDataLibrary.uploadToS3(uploadEntries[i], paths[i]);
-    }
+    await Promise.all(
+      paths.map((path, i) => AgentDataLibrary.uploadToS3(uploadEntries[i], path))
+    );
 
     const uploadedFiles = uploadEntries.map((entry, i) => ({
       filePath: entry.filePath,
@@ -231,10 +230,9 @@ export class AgentDataLibrary {
     const fileInfos = paths.map((p) => ({ fileName: basename(p) }));
     const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileInfos);
 
-    for (let i = 0; i < paths.length; i++) {
-      // eslint-disable-next-line no-await-in-loop
-      await AgentDataLibrary.uploadToS3(uploadEntries[i], paths[i]);
-    }
+    await Promise.all(
+      paths.map((path, i) => AgentDataLibrary.uploadToS3(uploadEntries[i], path))
+    );
 
     const uploadedFiles = uploadEntries.map((entry, i) => ({
       filePath: entry.filePath,

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -41,11 +41,18 @@ function baseUrl(connection: Connection, libraryId?: string): string {
 }
 
 export class AgentDataLibrary {
-  public static async list(connection: Connection): Promise<{ libraries: DataLibrarySummary[] }> {
+  public static async list(
+    connection: Connection,
+    options?: { sourceType?: string }
+  ): Promise<{ libraries: DataLibrarySummary[] }> {
     try {
+      let url = baseUrl(connection);
+      if (options?.sourceType) {
+        url += `?sourceType=${options.sourceType.toUpperCase()}`;
+      }
       return await connection.request<{ libraries: DataLibrarySummary[] }>({
         method: 'GET',
-        url: baseUrl(connection),
+        url,
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
@@ -170,20 +177,27 @@ export class AgentDataLibrary {
   public static async upload(
     connection: Connection,
     libraryId: string,
-    filePath: string,
+    filePaths: string | string[],
     options?: { waitMinutes?: number }
   ): Promise<UploadResult> {
     const url = baseUrl(connection, libraryId);
-    const fileName = basename(filePath);
+    const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
 
     await AgentDataLibrary.checkUploadReadiness(connection, url);
 
-    const uploadEntry = await AgentDataLibrary.getUploadUrl(connection, url, fileName);
+    const fileNames = paths.map((p) => ({ fileName: basename(p) }));
+    const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileNames);
 
-    await AgentDataLibrary.uploadToS3(uploadEntry, filePath);
+    for (let i = 0; i < paths.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await AgentDataLibrary.uploadToS3(uploadEntries[i], paths[i]);
+    }
 
-    const fileSize = statSync(filePath).size;
-    await AgentDataLibrary.triggerIndexing(connection, url, uploadEntry.filePath, fileSize);
+    const uploadedFiles = uploadEntries.map((entry, i) => ({
+      filePath: entry.filePath,
+      fileSize: statSync(paths[i]).size,
+    }));
+    await AgentDataLibrary.triggerIndexing(connection, url, uploadedFiles);
 
     if (options?.waitMinutes) {
       const detail = await AgentDataLibrary.pollForReadiness(connection, url, libraryId, options.waitMinutes);
@@ -201,23 +215,32 @@ export class AgentDataLibrary {
   public static async addFile(
     connection: Connection,
     libraryId: string,
-    filePath: string
+    filePaths: string | string[]
   ): Promise<FileAddResult> {
     const url = baseUrl(connection, libraryId);
-    const fileName = basename(filePath);
+    const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
 
-    const uploadEntry = await AgentDataLibrary.getUploadUrl(connection, url, fileName);
-    await AgentDataLibrary.uploadToS3(uploadEntry, filePath);
+    const fileNames = paths.map((p) => ({ fileName: basename(p) }));
+    const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileNames);
 
-    const fileSize = statSync(filePath).size;
+    for (let i = 0; i < paths.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await AgentDataLibrary.uploadToS3(uploadEntries[i], paths[i]);
+    }
+
+    const uploadedFiles = uploadEntries.map((entry, i) => ({
+      filePath: entry.filePath,
+      fileSize: statSync(paths[i]).size,
+    }));
     await connection.request({
       method: 'POST',
       url: `${url}/files`,
-      body: JSON.stringify({ uploadedFiles: [{ filePath: uploadEntry.filePath, fileSize }] }),
+      body: JSON.stringify({ uploadedFiles }),
       headers: { 'Content-Type': 'application/json' },
     });
 
     await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_add_success' });
+    const fileName = paths.map((p) => basename(p)).join(', ');
     return { success: true, fileName, libraryId };
   }
 
@@ -245,14 +268,18 @@ export class AgentDataLibrary {
     }
   }
 
-  private static async getUploadUrl(connection: Connection, url: string, fileName: string): Promise<FileUploadUrlEntry> {
+  private static async getUploadUrls(
+    connection: Connection,
+    url: string,
+    files: Array<{ fileName: string }>
+  ): Promise<FileUploadUrlEntry[]> {
     const response = await connection.request<FileUploadUrlsResponse>({
       method: 'POST',
       url: `${url}/file-upload-urls`,
-      body: JSON.stringify({ files: [{ fileName }] }),
+      body: JSON.stringify({ files }),
       headers: { 'Content-Type': 'application/json' },
     });
-    return response.uploadUrls[0];
+    return response.uploadUrls;
   }
 
   private static async uploadToS3(uploadEntry: FileUploadUrlEntry, filePath: string): Promise<void> {
@@ -277,13 +304,12 @@ export class AgentDataLibrary {
   private static async triggerIndexing(
     connection: Connection,
     url: string,
-    s3FilePath: string,
-    fileSize: number
+    uploadedFiles: Array<{ filePath: string; fileSize: number }>
   ): Promise<IndexingResponse> {
     return connection.request<IndexingResponse>({
       method: 'POST',
       url: `${url}/indexing`,
-      body: JSON.stringify({ uploadedFiles: [{ filePath: s3FilePath, fileSize }] }),
+      body: JSON.stringify({ uploadedFiles }),
       headers: { 'Content-Type': 'application/json' },
     });
   }

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -183,6 +183,10 @@ export class AgentDataLibrary {
     const url = baseUrl(connection, libraryId);
     const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
 
+    if (paths.length === 0) {
+      throw new SfError('At least one file is required.', 'NoFilesProvided');
+    }
+
     await AgentDataLibrary.checkUploadReadiness(connection, url);
 
     const fileNames = paths.map((p) => ({ fileName: basename(p) }));
@@ -220,8 +224,12 @@ export class AgentDataLibrary {
     const url = baseUrl(connection, libraryId);
     const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
 
-    const fileNames = paths.map((p) => ({ fileName: basename(p) }));
-    const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileNames);
+    if (paths.length === 0) {
+      throw new SfError('At least one file is required.', 'NoFilesProvided');
+    }
+
+    const fileInfos = paths.map((p) => ({ fileName: basename(p) }));
+    const uploadEntries = await AgentDataLibrary.getUploadUrls(connection, url, fileInfos);
 
     for (let i = 0; i < paths.length; i++) {
       // eslint-disable-next-line no-await-in-loop
@@ -240,8 +248,9 @@ export class AgentDataLibrary {
     });
 
     await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_add_success' });
-    const fileName = paths.map((p) => basename(p)).join(', ');
-    return { success: true, fileName, libraryId };
+    const fileNames = paths.map((p) => basename(p));
+    const fileName = fileNames.join(', ');
+    return { success: true, fileName, fileNames, libraryId };
   }
 
   // ── Private helpers ───────────────────────────────────────

--- a/src/dataLibraryTypes.ts
+++ b/src/dataLibraryTypes.ts
@@ -111,5 +111,6 @@ export type UploadResult = {
 export type FileAddResult = {
   success: boolean;
   fileName: string;
+  fileNames: string[];
   libraryId: string;
 };

--- a/src/dataLibraryTypes.ts
+++ b/src/dataLibraryTypes.ts
@@ -97,6 +97,7 @@ export type UpdateLibraryInput = {
       contentFields?: string[];
       isRestrictToPublicArticle?: boolean;
     };
+    retrieverId?: string;
   };
 };
 

--- a/test/agentDataLibrary.test.ts
+++ b/test/agentDataLibrary.test.ts
@@ -62,6 +62,22 @@ describe('AgentDataLibrary', () => {
       expect(requests[0].url).to.include('/einstein/data-libraries');
     });
 
+    it('should pass sourceType filter as query param', async () => {
+      mockRequest({ libraries: [] });
+
+      await AgentDataLibrary.list(connection, { sourceType: 'SFDRIVE' });
+
+      expect(requests[0].url).to.include('?sourceType=SFDRIVE');
+    });
+
+    it('should not include query param when no filter', async () => {
+      mockRequest({ libraries: [] });
+
+      await AgentDataLibrary.list(connection);
+
+      expect(requests[0].url).to.not.include('?');
+    });
+
     it('should throw on API error', async () => {
       $$.fakeConnectionRequest = () => Promise.reject(new Error('Network error'));
 
@@ -511,6 +527,46 @@ describe('AgentDataLibrary', () => {
       }
     });
 
+    it('should upload multiple files in batch', async () => {
+      const { writeFileSync } = await import('node:fs');
+      const file2 = join(tmpdir(), 'adl-upload-test2.txt');
+      writeFileSync(file2, 'second file');
+
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/upload-readiness')) {
+          return Promise.resolve({ ready: true });
+        }
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [
+              { uploadUrl: 'https://s3.example.com/upload1', filePath: '$adl$/1JD000001/test1.txt', headers: {} },
+              { uploadUrl: 'https://s3.example.com/upload2', filePath: '$adl$/1JD000001/test2.txt', headers: {} },
+            ],
+          });
+        }
+        if (req.url?.includes('/indexing')) {
+          return Promise.resolve({ status: 'IN_PROGRESS', filesAccepted: 2 });
+        }
+        return Promise.resolve({});
+      };
+
+      const result = await AgentDataLibrary.upload(connection, '1JD000001', [testFilePath, file2]);
+
+      expect(result.status).to.equal('IN_PROGRESS');
+      expect(fetchStub.calledTwice).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal('https://s3.example.com/upload1');
+      expect(fetchStub.secondCall.args[0]).to.equal('https://s3.example.com/upload2');
+
+      const urlsReq = requests.find((r) => r.url?.includes('/file-upload-urls'));
+      const urlsBody = JSON.parse(urlsReq!.body!);
+      expect(urlsBody.files).to.have.lengthOf(2);
+
+      const indexingReq = requests.find((r) => r.url?.includes('/indexing'));
+      const indexBody = JSON.parse(indexingReq!.body!);
+      expect(indexBody.uploadedFiles).to.have.lengthOf(2);
+    });
+
     it('should throw on S3 upload failure', async () => {
       fetchStub.resolves(new Response('Forbidden', { status: 403 }));
       $$.fakeConnectionRequest = (req: any) => {
@@ -574,6 +630,37 @@ describe('AgentDataLibrary', () => {
       expect(filesReq).to.exist;
       const filesBody = JSON.parse(filesReq!.body!);
       expect(filesBody.uploadedFiles[0].filePath).to.equal('$adl$/1JD000001/new.txt');
+    });
+
+    it('should add multiple files in batch', async () => {
+      const { writeFileSync } = await import('node:fs');
+      const file2 = join(tmpdir(), 'adl-add-test2.txt');
+      writeFileSync(file2, 'second add file');
+
+      $$.fakeConnectionRequest = (req: any) => {
+        requests.push(req);
+        if (req.url?.includes('/file-upload-urls')) {
+          return Promise.resolve({
+            uploadUrls: [
+              { uploadUrl: 'https://s3.example.com/add1', filePath: '$adl$/1JD000001/file1.txt', headers: {} },
+              { uploadUrl: 'https://s3.example.com/add2', filePath: '$adl$/1JD000001/file2.txt', headers: {} },
+            ],
+          });
+        }
+        if (req.url?.includes('/files')) {
+          return Promise.resolve({ filesAccepted: 2 });
+        }
+        return Promise.resolve({});
+      };
+
+      const result = await AgentDataLibrary.addFile(connection, '1JD000001', [testFilePath, file2]);
+
+      expect(result.success).to.be.true;
+      expect(fetchStub.calledTwice).to.be.true;
+
+      const filesReq = requests.find((r) => r.url?.includes('/files') && r.method === 'POST');
+      const filesBody = JSON.parse(filesReq!.body!);
+      expect(filesBody.uploadedFiles).to.have.lengthOf(2);
     });
 
     it('should throw on S3 failure during add', async () => {

--- a/test/nuts/agentDataLibrary.nut.ts
+++ b/test/nuts/agentDataLibrary.nut.ts
@@ -98,16 +98,16 @@ describe('AgentDataLibrary NUTs — SFDRIVE', function () {
     expect(result.indexingStatus).to.have.property('stageDetails');
   });
 
-  it('should upload a file and wait for READY', async function () {
+  it('should upload multiple files and wait for READY', async function () {
     this.timeout(10 * 60 * 1000);
 
-    const result = await AgentDataLibrary.upload(connection, libraryId, testFile, { waitMinutes: 10 });
+    const result = await AgentDataLibrary.upload(connection, libraryId, [testFile, testFile2], { waitMinutes: 10 });
 
     expect(result.libraryId).to.equal(libraryId);
     expect(result.status).to.equal('READY');
     expect(result.retrieverId).to.be.a('string');
     expect(result.ragFeatureConfigId).to.equal(`ARFPC_${libraryId}`);
-    console.log(`Upload complete — retrieverId: ${result.retrieverId}`);
+    console.log(`Multi-file upload complete — retrieverId: ${result.retrieverId}`);
   });
 
   it('should update library metadata', async () => {
@@ -125,13 +125,36 @@ describe('AgentDataLibrary NUTs — SFDRIVE', function () {
     const result = await AgentDataLibrary.addFile(connection, libraryId, testFile2);
 
     expect(result.success).to.be.true;
-    expect(result.fileName).to.equal('adl-agents-nut-test2.txt');
+    expect(result.fileName).to.include('adl-agents-nut-test2.txt');
+  });
+
+  it('should add multiple files in batch (day-1)', async function () {
+    this.timeout(3 * 60 * 1000);
+
+    const file3 = join(tmpdir(), 'adl-agents-nut-test3.txt');
+    const file4 = join(tmpdir(), 'adl-agents-nut-test4.txt');
+    writeFileSync(file3, 'Third test file for multi-file add.');
+    writeFileSync(file4, 'Fourth test file for multi-file add.');
+
+    const result = await AgentDataLibrary.addFile(connection, libraryId, [file3, file4]);
+
+    expect(result.success).to.be.true;
+    expect(result.fileName).to.include('adl-agents-nut-test3.txt');
+    expect(result.fileName).to.include('adl-agents-nut-test4.txt');
   });
 
   it('should list files in the library', async () => {
     const files = await AgentDataLibrary.listFiles(connection, libraryId);
-    expect(files.length).to.be.greaterThan(0);
+    expect(files.length).to.be.greaterThan(2);
     console.log(`Files: ${files.map((f) => f.fileName).join(', ')}`);
+  });
+
+  it('should list libraries with sourceType filter', async () => {
+    const result = await AgentDataLibrary.list(connection, { sourceType: 'SFDRIVE' });
+    expect(result.libraries.length).to.be.greaterThan(0);
+    for (const lib of result.libraries) {
+      expect(lib.sourceType).to.equal('SFDRIVE');
+    }
   });
 });
 
@@ -263,6 +286,17 @@ describe('AgentDataLibrary NUTs — RETRIEVER', function () {
     });
 
     expect(result.masterLabel).to.equal('NUT_Ret_Updated');
+  });
+
+  it('should swap retrieverId via update', async () => {
+    const result = await AgentDataLibrary.update(connection, libraryId, {
+      groundingSource: {
+        sourceType: 'RETRIEVER',
+        retrieverId,
+      },
+    });
+
+    expect(result.retrieverId).to.equal(retrieverId);
   });
 
   it('should delete Retriever library', async () => {


### PR DESCRIPTION
fix: multi-file support, list filter, retriever swap @W-22816781@)
  - upload() and addFile() accept string | string[] for batch file operations
  - list() accepts optional sourceType filter param
  - UpdateLibraryInput adds retrieverId for retriever swap
  - getUploadUrl -> getUploadUrls (returns array for batch)
  - triggerIndexing accepts uploadedFiles array
  - Unit tests: multi-file upload, multi-file add, list filter (33 total)
  - NUT tests: multi-file upload, multi-file add, list filter, retriever swap

### What does this PR do?
  Adds multi-file batch support, sourceType list filter, and retriever swap to AgentDataLibrary:
  - upload() and addFile() accept string[] for batch file operations (single API call for multiple files)
  - list() accepts optional sourceType filter (SFDRIVE|KNOWLEDGE|RETRIEVER)
  - UpdateLibraryInput adds retrieverId for swapping retrievers on RETRIEVER libraries
  - Includes unit tests and NUT tests for all new functionality
  
### What issues does this PR fix or reference?
@W-22816781@