### PR TITLE
@W-22860636 feat: add ApiCatalog client for MCP server management

### DIFF
--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import {
+  type ListMcpServersOptions,
+  type McpServerCollection,
+  type McpServerCreateInput,
+  type McpServerCreateOutput,
+  type McpServerOutput,
+  type McpServerUpdateInput,
+  type McpServerFetchOutput,
+  type McpServerAssetCollection,
+  type McpServerAssetReplaceInput,
+} from './apiCatalogTypes.js';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+function base(connection: Connection): string {
+  return `/services/data/v${String(connection.version)}/api-catalog`;
+}
+
+function encode(...segments: string[]): string {
+  return segments.map((s) => encodeURIComponent(s)).join('/');
+}
+
+/**
+ * Thin client over the API Catalog Connect API. Every method is a one-to-one
+ * wrapper around a Connect endpoint via `connection.request`, mirroring the
+ * shape of `AgentDataLibrary` from `@salesforce/agents`.
+ */
+export class ApiCatalog {
+  // ── MCP servers (CRUD) ──────────────────────────────────────
+
+  /** GET /api-catalog/mcp-servers */
+  public static async listMcpServers(
+    connection: Connection,
+    options?: ListMcpServersOptions
+  ): Promise<McpServerCollection> {
+    const params = new URLSearchParams();
+    if (options?.label) params.set('label', options.label);
+    if (options?.type) params.set('type', options.type);
+    if (options?.status) params.set('status', options.status);
+    const qs = params.toString();
+    const url = qs ? `${base(connection)}/mcp-servers?${qs}` : `${base(connection)}/mcp-servers`;
+    return ApiCatalog.request<McpServerCollection>(connection, 'GET', url, 'listMcpServers');
+  }
+
+  /** POST /api-catalog/mcp-servers */
+  public static async createMcpServer(
+    connection: Connection,
+    input: McpServerCreateInput
+  ): Promise<McpServerCreateOutput> {
+    return ApiCatalog.request<McpServerCreateOutput>(
+      connection,
+      'POST',
+      `${base(connection)}/mcp-servers`,
+      'createMcpServer',
+      input
+    );
+  }
+
+  /** GET /api-catalog/mcp-servers/{id} */
+  public static async getMcpServer(connection: Connection, id: string): Promise<McpServerOutput> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}`;
+    return ApiCatalog.request<McpServerOutput>(connection, 'GET', url, 'getMcpServer');
+  }
+
+  /** PUT /api-catalog/mcp-servers/{id} */
+  public static async updateMcpServer(
+    connection: Connection,
+    id: string,
+    input: McpServerUpdateInput
+  ): Promise<McpServerOutput> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}`;
+    return ApiCatalog.request<McpServerOutput>(connection, 'PUT', url, 'updateMcpServer', input);
+  }
+
+  /** DELETE /api-catalog/mcp-servers/{id} */
+  public static async deleteMcpServer(connection: Connection, id: string): Promise<void> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}`;
+    await ApiCatalog.request<unknown>(connection, 'DELETE', url, 'deleteMcpServer');
+  }
+
+  /** POST /api-catalog/mcp-servers/{id}/fetch */
+  public static async fetchMcpServer(connection: Connection, id: string): Promise<McpServerFetchOutput> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}/fetch`;
+    return ApiCatalog.request<McpServerFetchOutput>(connection, 'POST', url, 'fetchMcpServer');
+  }
+
+  /** GET /api-catalog/mcp-servers/{id}/assets */
+  public static async listMcpServerAssets(connection: Connection, id: string): Promise<McpServerAssetCollection> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}/assets`;
+    return ApiCatalog.request<McpServerAssetCollection>(connection, 'GET', url, 'listMcpServerAssets');
+  }
+
+  /** PUT /api-catalog/mcp-servers/{id}/assets */
+  public static async replaceMcpServerAssets(
+    connection: Connection,
+    id: string,
+    input: McpServerAssetReplaceInput
+  ): Promise<McpServerAssetCollection> {
+    const url = `${base(connection)}/mcp-servers/${encode(id)}/assets`;
+    return ApiCatalog.request<McpServerAssetCollection>(connection, 'PUT', url, 'replaceMcpServerAssets', input);
+  }
+
+  // ── Shared request helper ───────────────────────────────────
+
+  private static async request<T>(
+    connection: Connection,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    url: string,
+    op: string,
+    body?: unknown
+  ): Promise<T> {
+    const req: { method: typeof method; url: string; body?: string; headers?: Record<string, string> } = {
+      method,
+      url,
+    };
+    if (body !== undefined) {
+      req.body = JSON.stringify(body);
+      req.headers = JSON_HEADERS;
+    }
+
+    let result: T;
+    try {
+      result = await connection.request<T>(req);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await ApiCatalog.emitTelemetry(`api_catalog_${op}_failed`);
+      throw wrapped;
+    }
+
+    // Emit a success event for mutating operations, mirroring AgentDataLibrary.
+    if (method !== 'GET') {
+      await ApiCatalog.emitTelemetry(`api_catalog_${op}_success`);
+    }
+    return result;
+  }
+
+  /** Best-effort telemetry — never let a telemetry failure mask the real result or error. */
+  private static async emitTelemetry(eventName: string): Promise<void> {
+    try {
+      await Lifecycle.getInstance().emitTelemetry({ eventName });
+    } catch {
+      // telemetry is best-effort
+    }
+  }
+}

--- a/src/apiCatalogTypes.ts
+++ b/src/apiCatalogTypes.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TypeScript shapes derived from shared-api-catalog-connect-api.yaml (v64.0).
+// Field names mirror the Connect API representations 1:1.
+
+export type McpServerType = 'EXTERNAL';
+export type McpAuthType = 'OAUTH' | 'NO_AUTH';
+export type McpAssetKind = 'MCP_TOOL' | 'MCP_PROMPT' | 'MCP_RESOURCE';
+
+// ── MCP servers ───────────────────────────────────────────────
+
+export type McpServerAuthorizationOutput = {
+  authType: McpAuthType;
+  identityProvider?: string;
+  scope?: string;
+};
+
+export type McpServerAuthorizationInput = {
+  authType: McpAuthType;
+  identityProvider?: string;
+  clientId?: string;
+  clientSecret?: string;
+  scope?: string;
+};
+
+export type McpServerOutput = {
+  id: string;
+  name: string;
+  label?: string;
+  description?: string;
+  type: McpServerType;
+  status: string;
+  serverUrl?: string;
+  authorization?: McpServerAuthorizationOutput;
+  createdById?: string;
+  createdDate?: string;
+  lastModifiedById?: string;
+  lastModifiedDate?: string;
+};
+
+export type McpServerCollection = {
+  mcpServers: McpServerOutput[];
+};
+
+export type McpServerCreateInput = {
+  name: string;
+  label?: string;
+  description?: string;
+  type: McpServerType;
+  serverUrl: string;
+  authorization?: McpServerAuthorizationInput;
+};
+
+export type McpServerUpdateInput = {
+  label?: string;
+  description?: string;
+  serverUrl?: string;
+  authorization?: McpServerAuthorizationInput;
+};
+
+export type McpFetchedAsset = {
+  id?: string;
+  name: string;
+  label?: string;
+  description?: string;
+  kind: McpAssetKind;
+  active?: boolean;
+  availableAsAgentAction?: boolean;
+  status?: string;
+};
+
+export type McpServerCreateOutput = {
+  server: McpServerOutput;
+  assets: McpFetchedAsset[];
+};
+
+export type McpServerFetchOutput = {
+  assets: McpFetchedAsset[];
+};
+
+export type McpServerAssetOutput = {
+  id: string;
+  name: string;
+  label?: string;
+  description?: string;
+  kind: McpAssetKind;
+  active: boolean;
+  availableAsAgentAction?: boolean;
+};
+
+export type McpServerAssetCollection = {
+  assets: McpServerAssetOutput[];
+};
+
+export type McpServerAssetReplaceItem = {
+  id?: string;
+  name?: string;
+  label?: string;
+  description?: string;
+  active?: boolean;
+  kind?: McpAssetKind;
+};
+
+export type McpServerAssetReplaceInput = {
+  assets: McpServerAssetReplaceItem[];
+};
+
+/**
+ * MCP connection status values the server may return on a server record.
+ * NOTE: only `ACTIVE` and `DISCONNECTED` are accepted by the `status` query
+ * filter on `listMcpServers`; the others can appear on output but are rejected
+ * (HTTP 400) if used as a filter value.
+ */
+export type McpConnectionStatus =
+  | 'ACTIVE'
+  | 'INCOMPLETE'
+  | 'INVALID'
+  | 'INACTIVE'
+  | 'NOT_APPLICABLE'
+  | 'CUSTOM'
+  | 'DISCONNECTED';
+
+/** Status values accepted by the `listMcpServers` `status` query filter. */
+export type McpServerStatusFilter = 'ACTIVE' | 'DISCONNECTED';
+
+// Query option bag.
+export type ListMcpServersOptions = { label?: string; type?: McpServerType; status?: McpServerStatusFilter };

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,3 +199,25 @@ export {
   type StageDetail,
   type SourceType,
 } from './dataLibraryTypes';
+export { ApiCatalog } from './apiCatalog';
+export {
+  type McpServerType,
+  type McpAuthType,
+  type McpAssetKind,
+  type McpConnectionStatus,
+  type McpServerStatusFilter,
+  type McpServerAuthorizationOutput,
+  type McpServerAuthorizationInput,
+  type McpServerOutput,
+  type McpServerCollection,
+  type McpServerCreateInput,
+  type McpServerUpdateInput,
+  type McpFetchedAsset,
+  type McpServerCreateOutput,
+  type McpServerFetchOutput,
+  type McpServerAssetOutput,
+  type McpServerAssetCollection,
+  type McpServerAssetReplaceItem,
+  type McpServerAssetReplaceInput,
+  type ListMcpServersOptions,
+} from './apiCatalogTypes';

--- a/test/apiCatalog.test.ts
+++ b/test/apiCatalog.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Connection } from '@salesforce/core';
+import { ApiCatalog } from '../src/apiCatalog';
+
+describe('ApiCatalog client', () => {
+  const $$ = new TestContext();
+  let testOrg: MockTestOrgData;
+  let connection: Connection;
+  let requests: Array<{ method?: string; url?: string; body?: string }>;
+
+  beforeEach(async () => {
+    testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    connection = await testOrg.getConnection();
+    requests = [];
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  function mockRequest(response: any): void {
+    $$.fakeConnectionRequest = (req: any) => {
+      requests.push(req);
+      return Promise.resolve(response);
+    };
+  }
+
+  describe('listMcpServers', () => {
+    it('GETs /mcp-servers and forwards filters', async () => {
+      mockRequest({ mcpServers: [] });
+      await ApiCatalog.listMcpServers(connection, { label: 'foo', type: 'EXTERNAL', status: 'ACTIVE' });
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.include('label=foo');
+      expect(requests[0].url).to.include('type=EXTERNAL');
+      expect(requests[0].url).to.include('status=ACTIVE');
+    });
+
+    it('GETs /mcp-servers without a query string when no filters', async () => {
+      mockRequest({ mcpServers: [] });
+      await ApiCatalog.listMcpServers(connection);
+      expect(requests[0].url).to.match(/\/mcp-servers$/);
+    });
+
+    it('percent-encodes filter values', async () => {
+      mockRequest({ mcpServers: [] });
+      await ApiCatalog.listMcpServers(connection, { label: 'a b&c' });
+      expect(requests[0].url).to.include('label=a+b%26c');
+    });
+  });
+
+  describe('getMcpServer', () => {
+    it('GETs /mcp-servers/{id}', async () => {
+      mockRequest({ id: '1', name: 'n', type: 'EXTERNAL', status: 'ACTIVE' });
+      await ApiCatalog.getMcpServer(connection, '1');
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1$/);
+    });
+  });
+
+  describe('listMcpServerAssets', () => {
+    it('GETs /mcp-servers/{id}/assets', async () => {
+      mockRequest({ assets: [] });
+      await ApiCatalog.listMcpServerAssets(connection, '1');
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1\/assets$/);
+    });
+  });
+
+  describe('createMcpServer', () => {
+    it('POSTs the body with JSON content-type', async () => {
+      mockRequest({ server: { id: '1', name: 'n', type: 'EXTERNAL', status: 'ACTIVE' }, assets: [] });
+      const result = await ApiCatalog.createMcpServer(connection, {
+        name: 'my-server',
+        type: 'EXTERNAL',
+        serverUrl: 'https://example.com/mcp',
+      });
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.include('/api-catalog/mcp-servers');
+      expect(JSON.parse(requests[0].body as string)).to.deep.include({ name: 'my-server', type: 'EXTERNAL' });
+      expect(result.server.id).to.equal('1');
+    });
+  });
+
+  describe('updateMcpServer', () => {
+    it('PUTs to /mcp-servers/{id}', async () => {
+      mockRequest({ id: '1', name: 'n', type: 'EXTERNAL', status: 'ACTIVE' });
+      await ApiCatalog.updateMcpServer(connection, '1', { label: 'New label' });
+      expect(requests[0].method).to.equal('PUT');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1$/);
+    });
+  });
+
+  describe('deleteMcpServer', () => {
+    it('DELETEs /mcp-servers/{id}', async () => {
+      mockRequest(undefined);
+      await ApiCatalog.deleteMcpServer(connection, '1');
+      expect(requests[0].method).to.equal('DELETE');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1$/);
+    });
+  });
+
+  describe('fetchMcpServer', () => {
+    it('POSTs to /mcp-servers/{id}/fetch', async () => {
+      mockRequest({ assets: [] });
+      await ApiCatalog.fetchMcpServer(connection, '1');
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1\/fetch$/);
+    });
+  });
+
+  describe('replaceMcpServerAssets', () => {
+    it('PUTs the asset allowlist', async () => {
+      mockRequest({ assets: [] });
+      await ApiCatalog.replaceMcpServerAssets(connection, '1', { assets: [{ name: 'tool-a', active: true }] });
+      expect(requests[0].method).to.equal('PUT');
+      expect(requests[0].url).to.match(/\/mcp-servers\/1\/assets$/);
+      expect(JSON.parse(requests[0].body as string).assets[0].name).to.equal('tool-a');
+    });
+  });
+
+  describe('error handling', () => {
+    it('wraps connection errors as SfError', async () => {
+      $$.fakeConnectionRequest = () => Promise.reject(new Error('boom'));
+      try {
+        await ApiCatalog.getMcpServer(connection, '1');
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect((err as Error).message).to.include('boom');
+      }
+    });
+  });
+});


### PR DESCRIPTION
#@W-22860636@ PR 1 of 2 — forcedotcom/agents

**Branch:** `feat/api-catalog-connect-api`
**Title:** `feat: add ApiCatalog client for MCP server management`

## Summary

Adds an `ApiCatalog` client class that wraps the MCP-server endpoints of the Salesforce
API Catalog Connect API (`/services/data/vXX/api-catalog/mcp-servers/...`), mirroring the
existing `AgentDataLibrary` pattern in this repo. This is the library layer consumed by
the new `sf agent mcp ...` commands in `salesforcecli/plugin-agent` (companion PR).

Scope is MCP-only (the catalog read endpoints are intentionally not included in this cut).

The API Catalog team needs MCP server management exposed through the CLI so the ADLC team
can build on it — same enablement path the ADL team followed with `AgentDataLibrary` +
`sf agent adl`.

## What's included

- `src/apiCatalog.ts` — `ApiCatalog` with one static method per MCP Connect endpoint
  (8 operations): `listMcpServers`, `createMcpServer`, `getMcpServer`, `updateMcpServer`,
  `deleteMcpServer`, `fetchMcpServer`, `listMcpServerAssets`, `replaceMcpServerAssets`.
  Each is a thin `connection.request` wrapper with `SfError.wrap` and best-effort
  telemetry (`api_catalog_*_success` / `_failed`).
- `src/apiCatalogTypes.ts` — request/response types derived from
  `shared-api-catalog-connect-api.yaml` (v64.0), MCP shapes only.
- `src/index.ts` — barrel exports for the class and MCP types.
- `test/apiCatalog.test.ts` — 11 unit tests (mocked connection) covering every method,
  query-param encoding, path-segment encoding, and the error path.

## Grounding against the real Connect impl

Validated against the Java resource impls in core (not just the OAS):
- `updateMcpServer` / `replaceMcpServerAssets` are **PUT** (confirmed against the impl), not PATCH.
- No pagination: every collection uses `Pageable.MAX_SINGLE_PAGE` server-side; the `status`
  filter on `listMcpServers` only accepts `ACTIVE` / `DISCONNECTED` (typed as `McpServerStatusFilter`).
- `clientSecret` is stripped on read (GET returns only non-sensitive auth metadata).

## Test plan

- `yarn build` (compile + lint) — clean.
- `yarn test:only` — 11 ApiCatalog tests pass (plus the existing suite unaffected).
