### PR TITLE
feat: add NGT (Agentforce Studio) parse surface @W-22904106@

### DIFF
--- a/messages/agentTest.md
+++ b/messages/agentTest.md
@@ -41,3 +41,23 @@ NGT conversationHistory on test case %s, input %s mixes turns with and without `
 # ngtLooksLikeLegacySpec
 
 This YAML looks like a legacy AiEvaluationDefinition spec (uses top-level `utterance:` / `expectedTopic:` / `customEvaluations:`). Use `--test-runner testing-center` for legacy authoring, or hand-edit the deployed XML for `<scorer scorerType="Custom">` blocks on NGT.
+
+# ngtMalformedMetadataXml
+
+Failed to parse AiTestingDefinition metadata XML: %s
+
+# ngtWrongMetadataRoot
+
+AiTestingDefinition metadata XML must have a top-level <%s> element.
+
+# ngtUnknownScorerNoExpected
+
+Unknown NGT scorer name '%s' has no <expectedValue> in the metadata. Cannot infer whether the scorer requires an expected value — add an <expectedValue> or use a known scorer.
+
+# ambiguousTestDefinition
+
+Both an AiEvaluationDefinition and an AiTestingDefinition exist for '%s' in the org. Disambiguate by passing a local metadata file path, or delete one of the metadata records.
+
+# ngtSpecCannotProduceLegacyMetadata
+
+This AgentTest holds an NGT (`NgtTestSpec`) spec but `getMetadata()` returns the legacy `AiEvaluationDefinition` shape. Use `convertToTestingMetadata` + `buildTestingMetadataXml` to serialize an NGT spec to its `AiTestingDefinition` XML.

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -20,7 +20,7 @@ import { Connection, Lifecycle, Messages, SfError } from '@salesforce/core';
 import { Duration, ensureArray } from '@salesforce/kit';
 import { ComponentSetBuilder, DeployResult, RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { parse, stringify } from 'yaml';
-import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 import {
   AvailableDefinition,
   AgentTestConfig,
@@ -34,6 +34,8 @@ import {
   NgtTestSpec,
   NgtTestCase,
   NgtTestCaseInput,
+  NgtTestCaseScorer,
+  NgtConversationTurn,
 } from './types.js';
 import { isNgtScorerName, NgtScorerCatalog, NgtScorerName } from './ngtScorerCatalog';
 import { metric, sanitizeFilename, TestRunnerType } from './utils';
@@ -71,8 +73,8 @@ export const AgentTestCreateLifecycleStages = {
  * `await agentTest.writeMetadata('path/to/metadataFile');`
  */
 export class AgentTest {
-  private specData?: TestSpec;
-  private data?: AiEvaluationDefinition;
+  private specData?: TestSpec | NgtTestSpec;
+  private data?: AiEvaluationDefinition | AiTestingDefinition;
 
   /**
    * Create an AgentTest based on one of:
@@ -210,39 +212,58 @@ export class AgentTest {
    * Returns the test spec data if already generated. Otherwise it will generate the spec by:
    *
    * 1. Read from an existing local spec file.
-   * 2. Read from an existing local AiEvaluationDefinition metadata file and convert it.
-   * 3. Use the provided org connection to read the remote AiEvaluationDefinition metadata.
+   * 2. Read from an existing local metadata file and convert it. Dispatches on root XML element:
+   * `<AiEvaluationDefinition>` → legacy `TestSpec`, `<AiTestingDefinition>` → `NgtTestSpec`.
+   * 3. Use the provided org connection to read the remote metadata. Both metadata types are queried;
+   * if both exist for the given name, throws `ambiguousTestDefinition`.
    *
-   * @param connection Org connection to use if this AgentTest only has an AiEvaluationDefinition API name.
-   * @returns Promise<TestSpec>
+   * @param connection Org connection to use if this AgentTest only has an API name.
+   * @returns Promise<TestSpec | NgtTestSpec>
    */
-  public async getTestSpec(connection?: Connection): Promise<TestSpec> {
+  public async getTestSpec(connection?: Connection): Promise<TestSpec | NgtTestSpec> {
     if (this.specData) {
       return this.specData;
     }
     if (this.data) {
-      this.specData = convertToSpec(this.data);
+      this.specData = isNgtMetadata(this.data) ? convertToNgtSpec(this.data) : convertToSpec(this.data);
       return this.specData;
     }
     if (this.config.specPath) {
-      this.specData = parse(await readFile(this.config.specPath, 'utf-8')) as TestSpec;
+      this.specData = parse(await readFile(this.config.specPath, 'utf-8')) as TestSpec | NgtTestSpec;
       return this.specData;
     }
     if (this.config.mdPath) {
-      this.data = await parseAgentTestXml(this.config.mdPath);
+      const xml = await readFile(this.config.mdPath, 'utf-8');
+      if (isNgtMetadataXml(xml)) {
+        this.data = parseNgtMetadataXml(xml);
+        this.specData = convertToNgtSpec(this.data);
+        return this.specData;
+      }
+      this.data = parseAgentTestXmlString(xml);
       this.specData = convertToSpec(this.data);
       return this.specData;
     }
     // read from the server if we have a connection and an API name only
     if (this.config.name) {
       if (connection) {
-        // @ts-expect-error jsForce types don't know about AiEvaluationDefinition yet
-        this.data = (await connection.metadata.read<AiEvaluationDefinition>(
-          'AiEvaluationDefinition',
-          this.config.name
-        )) as AiEvaluationDefinition;
-        this.specData = convertToSpec(this.data);
-        return this.specData;
+        const [evalDef, testingDef] = await Promise.all([
+          readMetadataSafe<AiEvaluationDefinition>(connection, 'AiEvaluationDefinition', this.config.name),
+          readMetadataSafe<AiTestingDefinition>(connection, 'AiTestingDefinition', this.config.name),
+        ]);
+        if (evalDef && testingDef) {
+          throw messages.createError('ambiguousTestDefinition', [this.config.name]);
+        }
+        if (testingDef) {
+          this.data = testingDef;
+          this.specData = convertToNgtSpec(testingDef);
+          return this.specData;
+        }
+        if (evalDef) {
+          this.data = evalDef;
+          this.specData = convertToSpec(this.data);
+          return this.specData;
+        }
+        throw messages.createError('missingTestSpecData');
       } else {
         throw messages.createError('missingConnection');
       }
@@ -264,15 +285,18 @@ export class AgentTest {
    */
   public async getMetadata(connection?: Connection): Promise<AiEvaluationDefinition> {
     if (this.data) {
-      return this.data;
+      return assertLegacyMetadata(this.data);
     }
     if (this.specData) {
+      if (isNgtSpec(this.specData)) {
+        throw messages.createError('ngtSpecCannotProduceLegacyMetadata');
+      }
       this.data = convertToMetadata(this.specData);
       return this.data;
     }
     if (this.config.mdPath) {
       this.data = await parseAgentTestXml(this.config.mdPath);
-      return this.data;
+      return assertLegacyMetadata(this.data);
     }
     if (this.config.specPath) {
       this.specData = parse(await readFile(this.config.specPath, 'utf-8')) as TestSpec;
@@ -303,13 +327,16 @@ export class AgentTest {
   public async writeTestSpec(outputFile: string): Promise<void> {
     const spec = await this.getTestSpec();
 
-    // by default, add the OOTB metrics to the spec, so generated MD will have it
-    spec.testCases.forEach((tc) => (tc.metrics = tc.metrics ?? Array.from(metric)));
-    // strip out undefined values and empty strings
-    const clean = Object.entries(spec).reduce<Partial<TestSpec>>((acc, [key, value]) => {
-      if (value !== undefined && value !== '') return { ...acc, [key]: value };
-      return acc;
-    }, {});
+    if (!isNgtSpec(spec)) {
+      // Legacy: by default, add the OOTB metrics to the spec, so generated MD will have it.
+      spec.testCases.forEach((tc) => (tc.metrics = tc.metrics ?? Array.from(metric)));
+    }
+
+    // strip out undefined values and empty strings at the top level
+    const clean: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(spec)) {
+      if (value !== undefined && value !== '') clean[key] = value;
+    }
 
     const yml = stringify(clean, undefined, {
       minContentWidth: 0,
@@ -330,6 +357,30 @@ export class AgentTest {
     await writeFile(outputFile, xml);
   }
 }
+
+/** Discriminate between legacy `TestSpec` and NGT `NgtTestSpec` at runtime. */
+const isNgtSpec = (spec: TestSpec | NgtTestSpec): spec is NgtTestSpec =>
+  Array.isArray(spec.testCases) &&
+  spec.testCases.length > 0 &&
+  'inputs' in spec.testCases[0] &&
+  'scorers' in spec.testCases[0];
+
+/** Discriminate between `AiEvaluationDefinition` and `AiTestingDefinition` at runtime. */
+const isNgtMetadata = (data: AiEvaluationDefinition | AiTestingDefinition): data is AiTestingDefinition => {
+  const cases = ensureArray((data as AiTestingDefinition).testCase);
+  if (cases.length === 0) return false;
+  return 'scorer' in cases[0];
+};
+
+/** Legacy-only contract for `getMetadata()`: refuse if the cached data is NGT. */
+const assertLegacyMetadata = (
+  data: AiEvaluationDefinition | AiTestingDefinition
+): AiEvaluationDefinition => {
+  if (isNgtMetadata(data)) {
+    throw messages.createError('ngtSpecCannotProduceLegacyMetadata');
+  }
+  return data;
+};
 
 // Convert AiEvaluationDefinition metadata XML content to a YAML test spec object.
 const convertToSpec = (data: AiEvaluationDefinition): TestSpec => ({
@@ -440,6 +491,10 @@ type AiEvaluationDefinitionXml = {
 };
 const parseAgentTestXml = async (mdPath: string): Promise<AiEvaluationDefinition> => {
   const xml = await readFile(mdPath, 'utf-8');
+  return parseAgentTestXmlString(xml);
+};
+
+const parseAgentTestXmlString = (xml: string): AiEvaluationDefinition => {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '$',
@@ -450,6 +505,35 @@ const parseAgentTestXml = async (mdPath: string): Promise<AiEvaluationDefinition
   });
   const xmlContent = parser.parse(xml) as AiEvaluationDefinitionXml;
   return xmlContent.AiEvaluationDefinition;
+};
+
+/** Sniff the top-level XML element name. Skips comments and the `<?xml?>` prolog. */
+const isNgtMetadataXml = (xml: string): boolean => {
+  // strip prolog and comments before the first element
+  const trimmed = xml
+    .replace(/<\?xml[^?]*\?>/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .trimStart();
+  return trimmed.startsWith('<AiTestingDefinition');
+};
+
+const readMetadataSafe = async <T>(
+  connection: Connection,
+  type: 'AiEvaluationDefinition' | 'AiTestingDefinition',
+  name: string
+): Promise<T | undefined> => {
+  try {
+    // @ts-expect-error jsForce types don't model these metadata types
+    const result = (await connection.metadata.read(type, name)) as T | undefined;
+    if (!result) return undefined;
+    // jsForce returns a record with only `fullName` populated when the record doesn't exist;
+    // treat that as not-found.
+    const r = result as { fullName?: string; testCase?: unknown };
+    if (r.testCase === undefined && Object.keys(result as object).length <= 1) return undefined;
+    return result;
+  } catch {
+    return undefined;
+  }
 };
 
 const buildMetadataXml = (data: AiEvaluationDefinition): string => {
@@ -629,4 +713,157 @@ export const buildTestingMetadataXml = (data: AiTestingDefinition): string => {
 
   const xml = builder.build(wrapped);
   return `<?xml version="1.0" encoding="UTF-8"?>\n${xml}`;
+};
+
+/**
+ * Parse an `AiTestingDefinition` source-format XML string into the `AiTestingDefinition`
+ * metadata object. Mirror of {@link parseAgentTestXmlString} for the NGT runner.
+ *
+ * Throws SfError on malformed XML or on a missing/wrong root element. Use
+ * {@link convertToNgtSpec} to convert the result into an `NgtTestSpec`.
+ */
+export const parseNgtMetadataXml = (xml: string): AiTestingDefinition => {
+  // XMLParser itself is forgiving — preflight with the strict validator so we surface
+  // SfError on common authoring mistakes instead of returning a half-parsed object.
+  const valid = XMLValidator.validate(xml);
+  if (valid !== true) {
+    const msg = valid?.err ? `${valid.err.code} at line ${valid.err.line}: ${valid.err.msg}` : 'unknown XML error';
+    throw ngtError('ngtMalformedMetadataXml', [msg]);
+  }
+
+  let xmlContent: AiTestingDefinitionXml;
+  try {
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '$',
+      isArray: (name) =>
+        name === 'testCase' || name === 'scorer' || name === 'contextVariable' || name === 'conversationHistory',
+      processEntities: true,
+      htmlEntities: true,
+    });
+    xmlContent = parser.parse(xml) as AiTestingDefinitionXml;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw ngtError('ngtMalformedMetadataXml', [cause]);
+  }
+
+  if (!xmlContent?.AiTestingDefinition) {
+    throw ngtError('ngtWrongMetadataRoot', ['AiTestingDefinition']);
+  }
+
+  return xmlContent.AiTestingDefinition;
+};
+
+/**
+ * Convert an `AiTestingDefinition` (parsed XML object form) back into an `NgtTestSpec`.
+ * Inverse of {@link convertToTestingMetadata}; collapses contiguous test cases that share
+ * an identical scorer set into a single multi-input case.
+ */
+export const convertToNgtSpec = (data: AiTestingDefinition): NgtTestSpec => {
+  const flatCases = ensureArray(data.testCase).map((tc) => parseTestCaseXml(tc));
+  const collapsedCases = collapseContiguousTestCases(flatCases);
+
+  const spec: NgtTestSpec = {
+    name: String(data.name),
+    subjectType: data.subjectType,
+    subjectName: String(data.subjectName),
+    testCases: collapsedCases,
+  };
+  if (data.description !== undefined && data.description !== '') spec.description = String(data.description);
+  if (data.subjectVersion !== undefined && data.subjectVersion !== '') {
+    spec.subjectVersion = String(data.subjectVersion);
+  }
+  return spec;
+};
+
+type AiTestingDefinitionXml = {
+  AiTestingDefinition: AiTestingDefinition;
+};
+
+const parseTestCaseXml = (tc: AiTestCase): NgtTestCase => {
+  const inputs = tc.inputs ?? ({ utterance: '' } as AiTestCase['inputs']);
+  const contextVariables = ensureArray(inputs.contextVariable).map((cv) => ({
+    name: String(cv.variableName),
+    value: String(cv.variableValue),
+  }));
+  const turnsRaw = ensureArray(inputs.conversationHistory);
+  const turnsParsed = turnsRaw.map((t) => parseConversationTurnXml(t));
+  const dropAutoIndex = isAutoAssignedIndices(turnsParsed.map((t) => t.index));
+  const conversationHistory = turnsParsed.map((t) => stripIndexIfAuto(t, dropAutoIndex));
+
+  const input: NgtTestCaseInput = { utterance: String(inputs.utterance ?? '') };
+  if (contextVariables.length > 0) input.contextVariables = contextVariables;
+  if (conversationHistory.length > 0) input.conversationHistory = conversationHistory;
+
+  const scorers = ensureArray(tc.scorer).map((s) => parseScorerXml(s));
+
+  return { inputs: [input], scorers };
+};
+
+const parseConversationTurnXml = (
+  turn: AiConversationTurnXml
+): { role: 'user' | 'agent'; message: string; topic?: string; index: number } => {
+  const message = String(turn.message ?? '');
+  const index = Number(turn.index);
+  if (turn.role === 'agent') {
+    return { role: 'agent', message, topic: String(turn.topic ?? ''), index };
+  }
+  return { role: 'user', message, index };
+};
+
+const isAutoAssignedIndices = (indices: number[]): boolean => {
+  if (indices.length === 0) return false;
+  return indices.every((idx, i) => idx === i);
+};
+
+const stripIndexIfAuto = (
+  turn: { role: 'user' | 'agent'; message: string; topic?: string; index: number },
+  drop: boolean
+): NgtConversationTurn => {
+  const base = drop ? {} : { index: turn.index };
+  if (turn.role === 'agent') {
+    return { role: 'agent', message: turn.message, topic: turn.topic ?? '', ...base };
+  }
+  return { role: 'user', message: turn.message, ...base };
+};
+
+const parseScorerXml = (scorer: AiTestCaseScorer): NgtTestCaseScorer => {
+  const name = String(scorer.name);
+  const hasExpected = scorer.expectedValue !== undefined && scorer.expectedValue !== '';
+  if (!isNgtScorerName(name)) {
+    if (!hasExpected) {
+      throw ngtError('ngtUnknownScorerNoExpected', [name]);
+    }
+    void Lifecycle.getInstance().emitWarning(
+      `Unknown NGT scorer name '${name}' parsed from AiTestingDefinition metadata. The deploy will be validated by the server.`
+    );
+    return { name, expected: String(scorer.expectedValue) };
+  }
+  if (hasExpected) {
+    return { name, expected: String(scorer.expectedValue) };
+  }
+  return { name };
+};
+
+/**
+ * Collapse contiguous test cases that share an identical (ordered) scorer set
+ * into a single `NgtTestCase` with multiple `inputs[]`. Inverts the multi-input
+ * fan-out applied by `convertToTestingMetadata`.
+ */
+const collapseContiguousTestCases = (cases: NgtTestCase[]): NgtTestCase[] => {
+  const out: NgtTestCase[] = [];
+  for (const tc of cases) {
+    const prev = out[out.length - 1];
+    if (prev && scorerSetsEqual(prev.scorers, tc.scorers)) {
+      prev.inputs.push(...tc.inputs);
+    } else {
+      out.push(tc);
+    }
+  }
+  return out;
+};
+
+const scorerSetsEqual = (a: NgtTestCaseScorer[], b: NgtTestCaseScorer[]): boolean => {
+  if (a.length !== b.length) return false;
+  return a.every((s, i) => s.name === b[i].name && (s.expected ?? null) === (b[i].expected ?? null));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,15 @@ export {
   NgtScorerCatalog,
   isNgtScorerName,
 } from './ngtScorerCatalog';
-export { AgentTest, AgentTestCreateLifecycleStages } from './agentTest';
+export {
+  AgentTest,
+  AgentTestCreateLifecycleStages,
+  validateNgtSpec,
+  convertToTestingMetadata,
+  convertToNgtSpec,
+  buildTestingMetadataXml,
+  parseNgtMetadataXml,
+} from './agentTest';
 export { ProductionAgent } from './agents/productionAgent';
 export { ScriptAgent } from './agents/scriptAgent';
 export { AgentBase } from './agents/agentBase';

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,24 +352,24 @@ export type CreateAgentScriptResponse = {
 // ====================================================
 export type AgentTestConfig = {
   /**
-   * The API name of a AiEvaluationDefinition.
+   * The API name of an AiEvaluationDefinition or AiTestingDefinition.
    */
   name?: string;
 
   /**
-   * The local file path of a AiEvaluationDefinition metadata file.
+   * The local file path of an AiEvaluationDefinition or AiTestingDefinition metadata file.
    */
   mdPath?: string;
 
   /**
-   * The local file path of an agent test spec file.
+   * The local file path of an agent test spec file (legacy YAML or NGT YAML).
    */
   specPath?: string;
 
   /**
-   * The agent test spec data.
+   * The agent test spec data (legacy `TestSpec` or NGT `NgtTestSpec`).
    */
-  specData?: TestSpec;
+  specData?: TestSpec | NgtTestSpec;
 };
 
 export type TestStatus = 'NEW' | 'IN_PROGRESS' | 'COMPLETED' | 'ERROR' | 'TERMINATED';

--- a/test/agentTest.test.ts
+++ b/test/agentTest.test.ts
@@ -729,7 +729,7 @@ testCases:
 
       readFileStub.resolves(xml);
 
-      const result = await agentTest.getTestSpec();
+      const result = (await agentTest.getTestSpec()) as TestSpec;
 
       expect(result.testCases).to.have.length(2);
       expect(result.testCases[0].expectedActions).to.deep.equal(['GetWeather']);
@@ -757,7 +757,7 @@ testCases:
 
       readFileStub.resolves(xml);
 
-      const result = await agentTest.getTestSpec();
+      const result = (await agentTest.getTestSpec()) as TestSpec;
 
       expect(result.testCases[0].expectedActions).to.deep.equal([]);
     });
@@ -799,7 +799,7 @@ testCases:
 
       readFileStub.resolves(xml);
 
-      const result = await agentTest.getTestSpec();
+      const result = (await agentTest.getTestSpec()) as TestSpec;
 
       expect(result.testCases[0].conversationHistory).to.deep.equal([
         {

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -25,7 +25,9 @@ import { AgentTest } from '../src';
 import {
   validateNgtSpec,
   convertToTestingMetadata,
+  convertToNgtSpec,
   buildTestingMetadataXml,
+  parseNgtMetadataXml,
 } from '../src/agentTest';
 import type { NgtTestSpec } from '../src/types';
 
@@ -468,6 +470,292 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       const def = convertToTestingMetadata(spec);
       const turns = def.testCase[0].inputs.conversationHistory!;
       expect(turns.map((t) => t.index)).to.deep.equal([7, 8]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // parseNgtMetadataXml — XML metadata → NgtTestSpec (reverse of convertToTestingMetadata)
+  // -------------------------------------------------------------------------
+  describe('parseNgtMetadataXml', () => {
+    /** Test helper: parse + convert in one step, mirroring how callers use these together. */
+    const parseToSpec = (xml: string): NgtTestSpec => convertToNgtSpec(parseNgtMetadataXml(xml));
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('round-trips the canonical fixture: yaml → metadata → xml → parse → yaml-equivalent spec', async () => {
+      const yamlPath = join(__dirname, 'fixtures', 'ngt-spec-returns-checkout.yaml');
+      const xmlPath = join(__dirname, 'fixtures', 'ngt-xml-returns-checkout.xml');
+
+      const { parse } = await import('yaml');
+      const sourceSpec = parse(await fs.readFile(yamlPath, 'utf-8')) as NgtTestSpec;
+
+      const xml = await fs.readFile(xmlPath, 'utf-8');
+      const parsed = parseToSpec(xml);
+
+      // Top-level passthrough fields.
+      expect(parsed.name).to.equal(sourceSpec.name);
+      expect(parsed.description).to.equal(sourceSpec.description);
+      expect(parsed.subjectName).to.equal(sourceSpec.subjectName);
+      expect(parsed.subjectType).to.equal(sourceSpec.subjectType);
+      expect(parsed.subjectVersion).to.equal(sourceSpec.subjectVersion);
+
+      // Multi-input case 7 in the fixture fans out to 3 <testCase> elements; the parser
+      // collapses those back into one case with 3 inputs sharing the scorer set.
+      expect(parsed.testCases).to.have.length(sourceSpec.testCases.length);
+
+      // Convert source → metadata → xml → parse and compare structurally.
+      const synthesizedXml = buildTestingMetadataXml(convertToTestingMetadata(sourceSpec));
+      const reparsed = parseToSpec(synthesizedXml);
+      expect(reparsed).to.deep.equal(parsed);
+    });
+
+    it('preserves all 11 catalog scorers across the canonical fixture (presence + expected shape)', async () => {
+      const xmlPath = join(__dirname, 'fixtures', 'ngt-xml-returns-checkout.xml');
+      const xml = await fs.readFile(xmlPath, 'utf-8');
+      const parsed = parseToSpec(xml);
+
+      const scorerNames = new Set<string>();
+      parsed.testCases.forEach((tc) => tc.scorers.forEach((s) => scorerNames.add(s.name)));
+
+      // The fixture exercises 9 of the 11 scorers (no conciseness, no output_latency_milliseconds-only case).
+      // Make sure the ones it covers all round-trip.
+      [
+        'topic_sequence_match',
+        'action_sequence_match',
+        'agent_handoff_match',
+        'bot_response_rating',
+        'response_match',
+        'coherence',
+        'factuality',
+        'completeness',
+        'task_resolution',
+        'output_latency_milliseconds',
+      ].forEach((expected) => {
+        expect(scorerNames.has(expected), `missing scorer ${expected}`).to.be.true;
+      });
+    });
+
+    it('multi-input fan-out reverses: 3 contiguous <testCase> with identical scorer set collapse to 1 case with 3 inputs', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name>\n' +
+        '  <subjectName>A</subjectName>\n' +
+        '  <subjectType>AGENT</subjectType>\n' +
+        '  <testCase>\n' +
+        '    <number>1</number>\n' +
+        '    <inputs><utterance>u1</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>T</expectedValue></scorer>\n' +
+        '  </testCase>\n' +
+        '  <testCase>\n' +
+        '    <number>2</number>\n' +
+        '    <inputs><utterance>u2</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>T</expectedValue></scorer>\n' +
+        '  </testCase>\n' +
+        '  <testCase>\n' +
+        '    <number>3</number>\n' +
+        '    <inputs><utterance>u3</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>T</expectedValue></scorer>\n' +
+        '  </testCase>\n' +
+        '</AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases).to.have.length(1);
+      expect(spec.testCases[0].inputs.map((i) => i.utterance)).to.deep.equal(['u1', 'u2', 'u3']);
+      expect(spec.testCases[0].scorers).to.deep.equal([{ name: 'topic_sequence_match', expected: 'T' }]);
+    });
+
+    it('does NOT collapse adjacent test cases when scorer sets differ', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u1</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>X</expectedValue></scorer></testCase>\n' +
+        '  <testCase><number>2</number><inputs><utterance>u2</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>Y</expectedValue></scorer></testCase>\n' +
+        '</AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases).to.have.length(2);
+    });
+
+    it('parses contextVariables and conversationHistory roundly (auto-assigned indices are dropped on parse)', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs>\n' +
+        '    <utterance>u</utterance>\n' +
+        '    <contextVariable><variableName>RoutableId</variableName><variableValue>0Mw</variableValue></contextVariable>\n' +
+        '    <conversationHistory><role>user</role><message>a</message><index>0</index></conversationHistory>\n' +
+        '    <conversationHistory><role>agent</role><message>b</message><topic>T</topic><index>1</index></conversationHistory>\n' +
+        '  </inputs>\n' +
+        '  <scorer><name>task_resolution</name></scorer>\n' +
+        '  </testCase></AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      const input = spec.testCases[0].inputs[0];
+      expect(input.contextVariables).to.deep.equal([{ name: 'RoutableId', value: '0Mw' }]);
+      expect(input.conversationHistory).to.deep.equal([
+        { role: 'user', message: 'a' },
+        { role: 'agent', message: 'b', topic: 'T' },
+      ]);
+    });
+
+    it('preserves explicit (non-auto) conversationHistory indices on parse', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs>\n' +
+        '    <utterance>u</utterance>\n' +
+        '    <conversationHistory><role>user</role><message>a</message><index>7</index></conversationHistory>\n' +
+        '    <conversationHistory><role>agent</role><message>b</message><topic>T</topic><index>8</index></conversationHistory>\n' +
+        '  </inputs>\n' +
+        '  <scorer><name>task_resolution</name></scorer></testCase></AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      const turns = spec.testCases[0].inputs[0].conversationHistory!;
+      expect(turns.map((t) => t.index)).to.deep.equal([7, 8]);
+    });
+
+    it('preserves the python-list-string for action_sequence_match expected verbatim', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u</utterance></inputs>\n' +
+        "    <scorer><name>action_sequence_match</name><expectedValue>['Verify_Customer','Get_Order_Status']</expectedValue></scorer>\n" +
+        '  </testCase></AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases[0].scorers[0].expected).to.equal("['Verify_Customer','Get_Order_Status']");
+    });
+
+    it('quality scorers (no <expectedValue>) round-trip without an expected field', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u</utterance></inputs>\n' +
+        '    <scorer><name>coherence</name></scorer>\n' +
+        '  </testCase></AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases[0].scorers[0]).to.deep.equal({ name: 'coherence' });
+      expect((spec.testCases[0].scorers[0] as { expected?: string }).expected).to.be.undefined;
+    });
+
+    it('throws ngtMalformedMetadataXml on unparseable XML', () => {
+      // fast-xml-parser is lenient on most input, but a stray < inside a tag name trips it.
+      const xml = '<AiTestingDefinition><name>S<<</name></AiTestingDefinition>';
+      try {
+        parseNgtMetadataXml(xml);
+        expect.fail('expected parseNgtMetadataXml to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtMalformedMetadataXml');
+      }
+    });
+
+    it('throws ngtWrongMetadataRoot when the root is AiEvaluationDefinition (legacy XML)', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>X</name></AiEvaluationDefinition>';
+      try {
+        parseNgtMetadataXml(xml);
+        expect.fail('expected parseNgtMetadataXml to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtWrongMetadataRoot');
+      }
+    });
+
+    it('preserves an unknown scorer name when expectedValue is present (lifecycle warn, not throw)', () => {
+      const lifecycleSpy = sinon.spy(Lifecycle.prototype, 'emitWarning');
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u</utterance></inputs>\n' +
+        '    <scorer><name>made_up_scorer</name><expectedValue>whatever</expectedValue></scorer>\n' +
+        '  </testCase></AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases[0].scorers[0]).to.deep.equal({
+        name: 'made_up_scorer',
+        expected: 'whatever',
+      });
+      expect(lifecycleSpy.called).to.be.true;
+    });
+
+    it('throws ngtUnknownScorerNoExpected when an unknown scorer has no expectedValue', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u</utterance></inputs>\n' +
+        '    <scorer><name>made_up_scorer</name></scorer>\n' +
+        '  </testCase></AiTestingDefinition>\n';
+      try {
+        // Throw lives in the convert step now (unknown-scorer detection needs the catalog
+        // lookup that convertToNgtSpec performs); the parse step is shape-only.
+        parseToSpec(xml);
+        expect.fail('expected parseToSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtUnknownScorerNoExpected');
+        expect((err as SfError).message).to.include('made_up_scorer');
+      }
+    });
+
+  });
+
+  // -------------------------------------------------------------------------
+  // AgentTest.getTestSpec dispatch on local md path
+  // -------------------------------------------------------------------------
+  describe('AgentTest.getTestSpec dispatch', () => {
+    let readFileStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      readFileStub = sinon.stub(fs, 'readFile');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('mdPath with <AiTestingDefinition> root → returns NgtTestSpec', async () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs><utterance>u</utterance></inputs>\n' +
+        '    <scorer><name>topic_sequence_match</name><expectedValue>T</expectedValue></scorer>\n' +
+        '  </testCase></AiTestingDefinition>\n';
+      readFileStub.resolves(xml);
+
+      const agentTest = new AgentTest({ mdPath: 'fake.aiTestingDefinition-meta.xml' });
+      const spec = (await agentTest.getTestSpec()) as NgtTestSpec;
+
+      // NGT shape: testCases[].inputs is an array, scorers is the marker.
+      expect(spec.testCases[0]).to.have.property('scorers');
+      expect(spec.testCases[0].inputs[0].utterance).to.equal('u');
+    });
+
+    it('mdPath with <AiEvaluationDefinition> root → still returns legacy TestSpec (regression)', async () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiEvaluationDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>L</name><subjectName>A</subjectName><subjectType>AGENT</subjectType>\n' +
+        '  <testCase><inputs><utterance>u</utterance></inputs>\n' +
+        '    <expectation><name>topic_sequence_match</name><expectedValue>T</expectedValue></expectation>\n' +
+        '    <expectation><name>action_sequence_match</name><expectedValue>["A"]</expectedValue></expectation>\n' +
+        '    <expectation><name>bot_response_rating</name><expectedValue>ok</expectedValue></expectation>\n' +
+        '  </testCase></AiEvaluationDefinition>\n';
+      readFileStub.resolves(xml);
+
+      const agentTest = new AgentTest({ mdPath: 'fake.aiEvaluationDefinition-meta.xml' });
+      const spec = await agentTest.getTestSpec();
+      // Legacy shape: top-level utterance + expectedTopic on the case.
+      expect((spec as { testCases: Array<{ utterance?: string }> }).testCases[0]).to.have.property('utterance', 'u');
     });
   });
 


### PR DESCRIPTION

### What does this PR do?
Adds the ability on the lib side to parse the XML `AiTestingDefinitions`, and sniffs the XML to figure out which type of testing definition to parse based on input. Symmetric with the create-surface PR #290 — same pattern, parallel naming.

### What issues does this PR fix or reference?
@W-12345678@