### PR TITLE
fix: remove version suffix stripping from validateDeveloperName @W-23111346@

### DIFF
--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -137,7 +137,9 @@ export class ScriptAgentPublisher {
    * @throws SfError if the authoring bundle directory or metadata file cannot be found
    */
   private validateDeveloperName(): { developerName: string; bundleDir: string; bundleMetaPath: string } {
-    const developerName = this.agentJson.globalConfiguration.developerName.replace(/_v\d$/, '');
+    // Strip only the platform-generated uppercase version suffix (e.g., _V1, _V2, _V10).
+    // Lowercase _v<N> should NOT be stripped as it may be part of the user's chosen API name.
+    const developerName = this.agentJson.globalConfiguration.developerName.replace(/_V\d+$/, '');
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     // Try to find the authoring bundle directory by recursively searching from the default package path

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -130,16 +130,18 @@ export class ScriptAgentPublisher {
    * and locates the corresponding authoring bundle directory and metadata file.
    *
    * @returns An object containing:
-   * - developerName: The cleaned developer name without version suffixes
+   * - developerName: The developer name from the compiled agent JSON
    * - bundleDir: The path to the authoring bundle directory
    * - bundleMetaPath: The full path to the bundle-meta.xml file
    *
    * @throws SfError if the authoring bundle directory or metadata file cannot be found
    */
   private validateDeveloperName(): { developerName: string; bundleDir: string; bundleMetaPath: string } {
-    // Strip only the platform-generated uppercase version suffix (e.g., _V1, _V2, _V10).
-    // Lowercase _v<N> should NOT be stripped as it may be part of the user's chosen API name.
-    const developerName = this.agentJson.globalConfiguration.developerName.replace(/_V\d+$/, '');
+    // Use globalConfiguration.developerName as-is. This value comes directly from the
+    // user's .agent file (developer_name field) and is never modified by the platform.
+    // Previously, a regex was stripping _v<N> suffixes, but that incorrectly broke agents
+    // whose API names legitimately end with that pattern (e.g., Simple_Agent_v1).
+    const developerName = this.agentJson.globalConfiguration.developerName;
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     // Try to find the authoring bundle directory by recursively searching from the default package path

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -107,10 +107,44 @@ describe('AgentPublisher', () => {
   });
 
   describe('constructor', () => {
-    it('should validate developer name and bundle directory during construction', async () => {
+    it('should strip uppercase version suffix (_V1) from developer name', async () => {
       await createTestBundleStructure();
 
       const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
+      expect(publisher['developerName']).to.equal('test_agent');
+      expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
+    });
+
+    it('should NOT strip lowercase version suffix (_v1) from developer name', async () => {
+      // Create bundle for the full name including lowercase _v1
+      await createTestBundleStructure('My_Agent_v1');
+
+      const agentJsonLowercaseV: AgentJson = {
+        ...agentJson,
+        globalConfiguration: {
+          ...agentJson.globalConfiguration,
+          developerName: 'My_Agent_v1',
+        },
+      };
+
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonLowercaseV, false);
+      // Lowercase _v1 should be preserved as part of the user's chosen API name
+      expect(publisher['developerName']).to.equal('My_Agent_v1');
+      expect(publisher['bundleMetaPath']).to.include('My_Agent_v1.bundle-meta.xml');
+    });
+
+    it('should strip multi-digit uppercase version suffix (_V10) from developer name', async () => {
+      await createTestBundleStructure('test_agent');
+
+      const agentJsonMultiDigit: AgentJson = {
+        ...agentJson,
+        globalConfiguration: {
+          ...agentJson.globalConfiguration,
+          developerName: 'test_agent_V10',
+        },
+      };
+
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonMultiDigit, false);
       expect(publisher['developerName']).to.equal('test_agent');
       expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
     });

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -34,7 +34,7 @@ describe('AgentPublisher', () => {
   let sfProject: SfProject;
   let agentJson: AgentJson;
 
-  async function createTestBundleStructure(developerName = 'test_agent'): Promise<void> {
+  async function createTestBundleStructure(developerName = 'test_agent_v1'): Promise<void> {
     const bundlePath = join('force-app', 'main', 'default', 'aiAuthoringBundles', developerName);
     const bundleFilePath = join(bundlePath, `${developerName}.bundle-meta.xml`);
     await mkdir(bundlePath, { recursive: true });
@@ -61,7 +61,7 @@ describe('AgentPublisher', () => {
   }
 
   function createValidateDeveloperNameStub(
-    developerName = 'test_agent',
+    developerName = 'test_agent_v1',
     bundleDir = 'test-bundle-dir',
     bundleMetaPath = 'test-meta-path'
   ) {
@@ -107,16 +107,23 @@ describe('AgentPublisher', () => {
   });
 
   describe('constructor', () => {
-    it('should strip uppercase version suffix (_V1) from developer name', async () => {
-      await createTestBundleStructure();
+    it('should use globalConfiguration.developerName as-is without stripping', async () => {
+      await createTestBundleStructure('test_agent');
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJson, false);
+      const agentJsonExact: AgentJson = {
+        ...agentJson,
+        globalConfiguration: {
+          ...agentJson.globalConfiguration,
+          developerName: 'test_agent',
+        },
+      };
+
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonExact, false);
       expect(publisher['developerName']).to.equal('test_agent');
       expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
     });
 
-    it('should NOT strip lowercase version suffix (_v1) from developer name', async () => {
-      // Create bundle for the full name including lowercase _v1
+    it('should preserve lowercase version suffix (_v1) in developer name', async () => {
       await createTestBundleStructure('My_Agent_v1');
 
       const agentJsonLowercaseV: AgentJson = {
@@ -128,25 +135,24 @@ describe('AgentPublisher', () => {
       };
 
       const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonLowercaseV, false);
-      // Lowercase _v1 should be preserved as part of the user's chosen API name
       expect(publisher['developerName']).to.equal('My_Agent_v1');
       expect(publisher['bundleMetaPath']).to.include('My_Agent_v1.bundle-meta.xml');
     });
 
-    it('should strip multi-digit uppercase version suffix (_V10) from developer name', async () => {
-      await createTestBundleStructure('test_agent');
+    it('should preserve uppercase version suffix (_V1) in developer name', async () => {
+      await createTestBundleStructure('My_Agent_V1');
 
-      const agentJsonMultiDigit: AgentJson = {
+      const agentJsonUppercaseV: AgentJson = {
         ...agentJson,
         globalConfiguration: {
           ...agentJson.globalConfiguration,
-          developerName: 'test_agent_V10',
+          developerName: 'My_Agent_V1',
         },
       };
 
-      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonMultiDigit, false);
-      expect(publisher['developerName']).to.equal('test_agent');
-      expect(publisher['bundleMetaPath']).to.include('test_agent.bundle-meta.xml');
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonUppercaseV, false);
+      expect(publisher['developerName']).to.equal('My_Agent_V1');
+      expect(publisher['bundleMetaPath']).to.include('My_Agent_V1.bundle-meta.xml');
     });
 
     it('should throw error when authoring bundle directory does not exist', () => {
@@ -173,7 +179,7 @@ describe('AgentPublisher', () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
       // Mock connection.singleRecordQuery to return undefined (no existing bot)
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent_v1'")
         .throws(new Error('No records found'))
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
@@ -194,7 +200,7 @@ describe('AgentPublisher', () => {
 
       const result = await publisher.publishAgentJson();
 
-      expect(result).to.have.property('developerName', 'test_agent');
+      expect(result).to.have.property('developerName', 'test_agent_v1');
       expect(retrieveAgentMetadataStub.calledOnce).to.be.true;
       expect(deployAuthoringBundleStub.calledOnce).to.be.true;
     });
@@ -203,7 +209,7 @@ describe('AgentPublisher', () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
       // Mock connection.singleRecordQuery to return undefined (no existing bot)
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent_v1'")
         .throws(new Error('No records found'))
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
@@ -226,7 +232,7 @@ describe('AgentPublisher', () => {
 
       const result = await publisher.publishAgentJson();
 
-      expect(result).to.have.property('developerName', 'test_agent');
+      expect(result).to.have.property('developerName', 'test_agent_v1');
       expect(retrieveAgentMetadataStub.notCalled).to.be.true;
     });
 
@@ -234,7 +240,7 @@ describe('AgentPublisher', () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
       // Mock connection.singleRecordQuery to return undefined (no existing bot)
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent_v1'")
         .throws(new Error('No records found'))
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
@@ -256,7 +262,7 @@ describe('AgentPublisher', () => {
 
       const result = await publisher.publishAgentJson();
 
-      expect(result).to.have.property('developerName', 'test_agent');
+      expect(result).to.have.property('developerName', 'test_agent_v1');
       expect(retrieveAgentMetadataStub.calledOnce).to.be.true;
     });
 
@@ -273,7 +279,7 @@ describe('AgentPublisher', () => {
 
       // Mock connection.singleRecordQuery to return undefined (no existing bot)
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent_v1'")
         .resolves({ Id: '0Xx000000000001' })
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v2' });
@@ -286,7 +292,7 @@ describe('AgentPublisher', () => {
 
       const result = await publisher.publishAgentJson();
 
-      expect(result).to.have.property('developerName', 'test_agent');
+      expect(result).to.have.property('developerName', 'test_agent_v1');
       expect(retrieveAgentMetadataStub.calledOnce).to.be.true;
       expect(deployAuthoringBundleStub.calledOnce).to.be.true;
     });
@@ -314,7 +320,7 @@ describe('AgentPublisher', () => {
     it('should not mutate the caller-supplied connection during publish', async () => {
       process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
       $$.SANDBOX.stub(connection, 'singleRecordQuery')
-        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent_v1'")
         .throws(new Error('No records found'))
         .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
         .resolves({ DeveloperName: 'v1' });
@@ -683,8 +689,8 @@ describe('AgentPublisher', () => {
       expect(capturedMetadataEntries).to.include('GenAiFunction:Function3');
 
       // Verify that Bot and Agent entries are still included
-      expect(capturedMetadataEntries).to.include('Bot:test_agent');
-      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Bot:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1_v1');
 
       validateStub.restore();
     });
@@ -758,8 +764,8 @@ describe('AgentPublisher', () => {
       expect(genAiFunctionEntries).to.be.empty;
 
       // Verify that Bot and Agent entries are still included
-      expect(capturedMetadataEntries).to.include('Bot:test_agent');
-      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Bot:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1_v1');
 
       validateStub.restore();
     });
@@ -807,8 +813,8 @@ describe('AgentPublisher', () => {
       expect(genAiFunctionEntries).to.be.empty;
 
       // Verify that Bot and Agent entries are still included
-      expect(capturedMetadataEntries).to.include('Bot:test_agent');
-      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Bot:test_agent_v1');
+      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1_v1');
 
       validateStub.restore();
     });

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -20,7 +20,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
   compiledArtifact: {
     schemaVersion: '2.0',
     globalConfiguration: {
-      developerName: 'test_agent_V1',
+      developerName: 'test_agent_v1',
       label: '',
       description: '',
       enableEnhancedEventLogs: false,
@@ -31,7 +31,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
       contextVariables: [],
     },
     agentVersion: {
-      developerName: 'test_agent_V1',
+      developerName: 'test_agent_v1',
       plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',
       systemMessages: [],
       modalityParameters: {
@@ -120,7 +120,7 @@ start_agent agent_router:
 export const testAgentJson: AgentJson = {
   schemaVersion: '2.0',
   globalConfiguration: {
-    developerName: 'test_agent_V1',
+    developerName: 'test_agent_v1',
     label: 'Test Agent',
     description: 'A test agent',
     agentType: 'AgentforceServiceAgent',
@@ -131,7 +131,7 @@ export const testAgentJson: AgentJson = {
     contextVariables: [],
   },
   agentVersion: {
-    developerName: 'test_agent_V1',
+    developerName: 'test_agent_v1',
     company: 'Test Company',
     role: 'Test Role',
     plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -20,7 +20,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
   compiledArtifact: {
     schemaVersion: '2.0',
     globalConfiguration: {
-      developerName: 'test_agent_v1',
+      developerName: 'test_agent_V1',
       label: '',
       description: '',
       enableEnhancedEventLogs: false,
@@ -31,7 +31,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
       contextVariables: [],
     },
     agentVersion: {
-      developerName: 'test_agent_v1',
+      developerName: 'test_agent_V1',
       plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',
       systemMessages: [],
       modalityParameters: {
@@ -120,7 +120,7 @@ start_agent agent_router:
 export const testAgentJson: AgentJson = {
   schemaVersion: '2.0',
   globalConfiguration: {
-    developerName: 'test_agent_v1',
+    developerName: 'test_agent_V1',
     label: 'Test Agent',
     description: 'A test agent',
     agentType: 'AgentforceServiceAgent',
@@ -131,7 +131,7 @@ export const testAgentJson: AgentJson = {
     contextVariables: [],
   },
   agentVersion: {
-    developerName: 'test_agent_v1',
+    developerName: 'test_agent_V1',
     company: 'Test Company',
     role: 'Test Role',
     plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',


### PR DESCRIPTION
## Summary

- Removes the regex `.replace(/_v\d$/, '')` from `ScriptAgentPublisher.validateDeveloperName()` entirely
- `globalConfiguration.developerName` is now used as-is, since it comes directly from the user's `.agent` file (`developer_name` field) and is never modified by the platform
- Fixes publishing failure for agents whose API names legitimately end with `_v<N>` (e.g., `Simple_Agent_v1`)

## Root Cause

The original code assumed that `globalConfiguration.developerName` might contain a platform-appended version suffix (like `_v1`). Investigation showed this is never the case — the version suffix only appears in `agentVersion.developerName` (the BotVersion DeveloperName), not in the agent's own developer name.

The regex `/_v\d$/` would match and strip the `_v1` from a user-chosen name like `Simple_Agent_v1`, causing `findAuthoringBundle()` to look for `Simple_Agent` instead — which doesn't exist.

## What Changed

| Before | After |
|--------|-------|
| `const developerName = this.agentJson.globalConfiguration.developerName.replace(/_v\d$/, '');` | `const developerName = this.agentJson.globalConfiguration.developerName;` |

## Test Plan

- [x] Updated constructor tests to verify developer name is preserved as-is for both `_v1` and `_V1` suffixes
- [x] Updated all test fixtures to use `test_agent_v1` (the exact pattern that triggered the bug)
- [x] All 21 tests passing
- [ ] Manual verification: `sf agent publish authoring-bundle --api-name Simple_Agent_v1` should succeed

## GUS Work Item
W-23074545

## BUG Work Item
W-23111346