### PR TITLE
@W-23111346@ fix: remove erroneous _vN suffix stripping from publish developerName

### DIFF
--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -130,14 +130,14 @@ export class ScriptAgentPublisher {
    * and locates the corresponding authoring bundle directory and metadata file.
    *
    * @returns An object containing:
-   * - developerName: The cleaned developer name without version suffixes
+   * - developerName: The agent's developer name
    * - bundleDir: The path to the authoring bundle directory
    * - bundleMetaPath: The full path to the bundle-meta.xml file
    *
    * @throws SfError if the authoring bundle directory or metadata file cannot be found
    */
   private validateDeveloperName(): { developerName: string; bundleDir: string; bundleMetaPath: string } {
-    const developerName = this.agentJson.globalConfiguration.developerName.replace(/_v\d$/, '');
+    const developerName = this.agentJson.globalConfiguration.developerName;
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     // Try to find the authoring bundle directory by recursively searching from the default package path

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { mkdir, rm, writeFile, readFile } from 'node:fs/promises';
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
@@ -301,6 +301,50 @@ describe('AgentPublisher', () => {
       expect(refreshStub.called).to.be.false;
       expect(connection.accessToken).to.equal(originalAccessToken);
     });
+
+    it('should publish and deploy the real test_agent directory the search resolved', async () => {
+      await createTestBundleStructure('test_agent'); // real on-disk bundle dir
+
+      // Drive the publisher with a name that ends in the _<N> version convention.
+      const localAgentJson: AgentJson = {
+        ...agentJson,
+        globalConfiguration: {
+          ...agentJson.globalConfiguration,
+          developerName: 'test_agent',
+        },
+      };
+
+      process.env.SF_MOCK_DIR = join('test', 'mocks', 'publishNewAgent-Success');
+
+      $$.SANDBOX.stub(connection, 'singleRecordQuery')
+        .withArgs("SELECT Id FROM BotDefinition WHERE DeveloperName='test_agent'")
+        .throws(new Error('No records found'))
+        .withArgs("SELECT DeveloperName FROM BotVersion WHERE Id='0Bv000000000002'")
+        .resolves({ DeveloperName: 'developerNameDummy' });
+
+      // skipMetadataRetrieve=true so retrieveAgentMetadata is bypassed (no need to stub it).
+      publisher = new ScriptAgentPublisher(connection, sfProject, localAgentJson, true);
+
+      $$.SANDBOX.stub(utils, 'useNamedUserJwt').resolves(connection);
+      $$.SANDBOX.stub(connection, 'refreshAuth').resolves();
+
+      // Let the REAL deployAuthoringBundle run; stub only the org boundary it calls.
+      const pollStatusStub = $$.SANDBOX.stub().resolves({ response: { success: true } } as never);
+      const deployStub = $$.SANDBOX.stub().resolves({ pollStatus: pollStatusStub } as unknown);
+      const fromSourceStub = $$.SANDBOX.stub(ComponentSet, 'fromSource').returns({ deploy: deployStub } as never);
+
+      const result = await publisher.publishAgentJson();
+
+      // The real findAuthoringBundle resolved test_agent, and publish deployed THAT dir.
+      expect(fromSourceStub.calledOnce).to.be.true;
+
+      expect(fromSourceStub.firstCall.args[0]).to.equal(
+        resolve(join('force-app', 'main', 'default', 'aiAuthoringBundles', 'test_agent'))
+      );
+
+      expect(result).to.have.property('developerName', 'test_agent');
+    });
+
   });
 
   describe('getPublishedBotId', () => {

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -20,7 +20,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
   compiledArtifact: {
     schemaVersion: '2.0',
     globalConfiguration: {
-      developerName: 'test_agent_v1',
+      developerName: 'test_agent',
       label: '',
       description: '',
       enableEnhancedEventLogs: false,
@@ -31,7 +31,7 @@ export const compileAgentScriptResponseSuccess: CompileAgentScriptResponse = {
       contextVariables: [],
     },
     agentVersion: {
-      developerName: 'test_agent_v1',
+      developerName: 'test_agent',
       plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',
       systemMessages: [],
       modalityParameters: {
@@ -120,7 +120,7 @@ start_agent agent_router:
 export const testAgentJson: AgentJson = {
   schemaVersion: '2.0',
   globalConfiguration: {
-    developerName: 'test_agent_v1',
+    developerName: 'test_agent',
     label: 'Test Agent',
     description: 'A test agent',
     agentType: 'AgentforceServiceAgent',
@@ -131,7 +131,7 @@ export const testAgentJson: AgentJson = {
     contextVariables: [],
   },
   agentVersion: {
-    developerName: 'test_agent_v1',
+    developerName: 'test_agent',
     company: 'Test Company',
     role: 'Test Role',
     plannerType: 'Atlas__ConcurrentMultiAgentOrchestration',


### PR DESCRIPTION
### What does this PR do?
 Removes an erroneous `.replace(/_v\d$/, '')` call in `ScriptAgentPublisher.validateDeveloperName()` that was silently stripping a trailing `_vN` version suffix from the agent's developerName.

  The developer name now comes through verbatim from `globalConfiguration.developerName`, so the publisher resolves the authoring bundle directory and `*.bundle-meta.xml` file using the agent's actual name. Previously, any agent whose developer name legitimately ended in `_vN` (e.g. `my_agent_v1`) had that suffix dropped, causing the bundle lookup to target the wrong name and fail with CannotFindBundle.

### What issues does this PR fix or reference?
Users with `_v<N>` in their agent API name would not be able to have their agent bundles found for publish.