### PR TITLE
feat: update ADL types and methods to match 262.11 Connect API @W-23237764@

### DIFF
--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -25,10 +25,10 @@ import {
   type UpdateLibraryInput,
   type UploadResult,
   type FileAddResult,
-  type GroundingFileRef,
+  type FileListResponse,
 } from './dataLibraryTypes.js';
 
-export { type DataLibrarySummary, type DataLibraryDetail, type IndexingStatusResponse, type CreateLibraryInput, type UpdateLibraryInput, type UploadResult, type FileAddResult, type GroundingFileRef } from './dataLibraryTypes.js';
+export { type DataLibrarySummary, type DataLibraryDetail, type IndexingStatusResponse, type CreateLibraryInput, type UpdateLibraryInput, type UploadResult, type FileAddResult, type FileListResponse } from './dataLibraryTypes.js';
 
 type UploadReadinessResponse = { ready: boolean };
 type FileUploadUrlEntry = { uploadUrl: string; filePath: string; headers: Record<string, string> };
@@ -143,11 +143,19 @@ export class AgentDataLibrary {
     }
   }
 
-  public static async status(connection: Connection, libraryId: string): Promise<IndexingStatusResponse> {
+  public static async status(
+    connection: Connection,
+    libraryId: string,
+    options?: { includeArtifacts?: boolean }
+  ): Promise<IndexingStatusResponse> {
     try {
+      let url = `${baseUrl(connection, libraryId)}/status`;
+      if (options?.includeArtifacts) {
+        url += '?includeArtifacts=true';
+      }
       return await connection.request<IndexingStatusResponse>({
         method: 'GET',
-        url: `${baseUrl(connection, libraryId)}/status`,
+        url,
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
@@ -156,9 +164,42 @@ export class AgentDataLibrary {
     }
   }
 
-  public static async listFiles(connection: Connection, libraryId: string): Promise<GroundingFileRef[]> {
-    const detail = await AgentDataLibrary.get(connection, libraryId);
-    return detail.groundingSource?.groundingFileRefs ?? [];
+  public static async listFiles(
+    connection: Connection,
+    libraryId: string,
+    options?: {
+      pageSize?: number;
+      offset?: number;
+      sortBy?: string;
+      sortOrder?: string;
+      name?: string;
+      status?: string;
+    }
+  ): Promise<FileListResponse> {
+    try {
+      let url = `${baseUrl(connection, libraryId)}/files`;
+      const params = new URLSearchParams();
+      if (options?.pageSize !== undefined) params.append('pageSize', String(options.pageSize));
+      if (options?.offset !== undefined) params.append('offset', String(options.offset));
+      if (options?.sortBy) params.append('sortBy', options.sortBy);
+      if (options?.sortOrder) params.append('sortOrder', options.sortOrder);
+      if (options?.name) params.append('name', options.name);
+      if (options?.status) params.append('status', options.status);
+
+      const queryString = params.toString();
+      if (queryString) {
+        url += `?${queryString}`;
+      }
+
+      return await connection.request<FileListResponse>({
+        method: 'GET',
+        url,
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_files_failed' });
+      throw wrapped;
+    }
   }
 
   public static async deleteFile(connection: Connection, libraryId: string, fileId: string): Promise<void> {

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -244,7 +244,7 @@ export class AgentDataLibrary {
     await AgentDataLibrary.triggerIndexing(connection, url, uploadedFiles);
 
     if (options?.waitMinutes) {
-      const detail = await AgentDataLibrary.pollForReadiness(connection, url, libraryId, options.waitMinutes);
+      const detail = await AgentDataLibrary.pollForReadiness(connection, url, libraryId, options.waitMinutes * 60);
       return {
         libraryId,
         retrieverId: detail.retrieverId,
@@ -362,13 +362,17 @@ export class AgentDataLibrary {
     });
   }
 
+  public static async waitForReady(connection: Connection, libraryId: string, waitSeconds: number): Promise<DataLibraryDetail> {
+    return AgentDataLibrary.pollForReadiness(connection, baseUrl(connection, libraryId), libraryId, waitSeconds);
+  }
+
   private static async pollForReadiness(
     connection: Connection,
     url: string,
     libraryId: string,
-    waitMinutes: number
+    waitSeconds: number
   ): Promise<DataLibraryDetail> {
-    const deadline = Date.now() + waitMinutes * 60_000;
+    const deadline = Date.now() + waitSeconds * 1_000;
     const pollInterval = 10_000;
 
     // eslint-disable-next-line no-await-in-loop
@@ -385,6 +389,6 @@ export class AgentDataLibrary {
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 
-    throw new SfError(`Indexing did not complete within ${waitMinutes} minutes.`, 'UploadTimeout');
+    throw new SfError(`Indexing did not complete within ${waitSeconds} seconds.`, 'UploadTimeout');
   }
 }

--- a/src/dataLibraryTypes.ts
+++ b/src/dataLibraryTypes.ts
@@ -104,8 +104,9 @@ export type GroundingSource = {
     primaryIndexField1?: string;
     primaryIndexField2?: string;
     contentFields?: string[];
-    dataCategoryIds?: string[];
-    dataCategoryNames?: string[];
+    dataCategorySelectionIds?: string[];
+    dataCategorySelectionNames?: string[];
+    isDataCategoryRuleEnabled?: boolean;
     isRestrictToPublicArticle?: boolean;
   };
 };
@@ -125,6 +126,7 @@ export type UpdateLibraryInput = {
     knowledgeConfig?: {
       contentFields?: string[];
       isRestrictToPublicArticle?: boolean;
+      isDataCategoryRuleEnabled?: boolean;
     };
     retrieverId?: string;
   };

--- a/src/dataLibraryTypes.ts
+++ b/src/dataLibraryTypes.ts
@@ -16,6 +16,25 @@
 
 export type SourceType = 'SFDRIVE' | 'KNOWLEDGE' | 'RETRIEVER';
 
+export type RetrieverDetail = {
+  id: string;
+  label: string;
+  apiName?: string;
+};
+
+export type RetrieverActionDetail = {
+  id: string;
+  label: string;
+  apiName?: string;
+};
+
+export type StageArtifact = {
+  id: string;
+  label: string;
+  apiName?: string;
+  assetType: string;
+};
+
 export type DataLibrarySummary = {
   libraryId: string;
   masterLabel: string;
@@ -23,6 +42,8 @@ export type DataLibrarySummary = {
   description?: string;
   sourceType: string;
   status: string;
+  retriever?: RetrieverDetail;
+  retrieverAction?: RetrieverActionDetail;
 };
 
 export type GroundingFileRef = {
@@ -32,6 +53,7 @@ export type GroundingFileRef = {
   fileSize: number;
   createdDate?: string;
   createdBy?: string;
+  status?: string;
 };
 
 export type DataLibraryDetail = {
@@ -44,6 +66,9 @@ export type DataLibraryDetail = {
   retrieverId?: string;
   retrieverLabel?: string;
   dataSpaceScopeId?: string;
+  retriever?: RetrieverDetail;
+  retrieverAction?: RetrieverActionDetail;
+  totalFileCount?: number;
   groundingSource?: {
     [key: string]: unknown;
     groundingSourceType?: string;
@@ -57,6 +82,8 @@ export type StageDetail = {
   completedAt?: number;
   startedAt?: number;
   error?: string;
+  artifacts?: StageArtifact[];
+  errorCode?: string;
 };
 
 export type IndexingStatusResponse = {
@@ -77,6 +104,8 @@ export type GroundingSource = {
     primaryIndexField1?: string;
     primaryIndexField2?: string;
     contentFields?: string[];
+    dataCategoryIds?: string[];
+    dataCategoryNames?: string[];
     isRestrictToPublicArticle?: boolean;
   };
 };
@@ -113,4 +142,11 @@ export type FileAddResult = {
   fileName: string;
   fileNames: string[];
   libraryId: string;
+};
+
+export type FileListResponse = {
+  files: GroundingFileRef[];
+  totalSize: number;
+  currentPageUrl?: string;
+  nextPageUrl?: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,10 @@ export {
   type GroundingSource,
   type StageDetail,
   type SourceType,
+  type RetrieverDetail,
+  type RetrieverActionDetail,
+  type StageArtifact,
+  type FileListResponse,
 } from './dataLibraryTypes';
 export { ApiCatalog } from './apiCatalog';
 export {

--- a/test/agentDataLibrary.test.ts
+++ b/test/agentDataLibrary.test.ts
@@ -694,4 +694,71 @@ describe('AgentDataLibrary', () => {
       }
     });
   });
+
+  describe('waitForReady', () => {
+    it('should return immediately when retrieverId is present on first poll', async () => {
+      $$.fakeConnectionRequest = () =>
+        Promise.resolve({ libraryId: '1JD000001', retrieverId: '1Cx000001', status: 'READY' });
+
+      const result = await AgentDataLibrary.waitForReady(connection, '1JD000001', 30);
+
+      expect(result.retrieverId).to.equal('1Cx000001');
+      expect(result.status).to.equal('READY');
+    });
+
+    it('should poll until retrieverId appears', async () => {
+      let pollCount = 0;
+      $$.fakeConnectionRequest = () => {
+        pollCount++;
+        if (pollCount >= 3) {
+          return Promise.resolve({ libraryId: '1JD000001', retrieverId: '1Cx000002', status: 'READY' });
+        }
+        return Promise.resolve({ libraryId: '1JD000001', status: 'IN_PROGRESS' });
+      };
+
+      const result = await AgentDataLibrary.waitForReady(connection, '1JD000001', 60);
+
+      expect(result.retrieverId).to.equal('1Cx000002');
+      expect(pollCount).to.be.greaterThanOrEqual(3);
+    });
+
+    it('should throw IndexingFailed when status is FAILED', async () => {
+      $$.fakeConnectionRequest = () =>
+        Promise.resolve({ libraryId: '1JD000001', status: 'FAILED' });
+
+      try {
+        await AgentDataLibrary.waitForReady(connection, '1JD000001', 60);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.name).to.equal('IndexingFailed');
+      }
+    });
+
+    it('should throw UploadTimeout when deadline exceeded', async () => {
+      $$.fakeConnectionRequest = () =>
+        Promise.resolve({ libraryId: '1JD000001', status: 'IN_PROGRESS' });
+
+      try {
+        // 1 second timeout — will exceed immediately after first poll + 10s interval
+        await AgentDataLibrary.waitForReady(connection, '1JD000001', 1);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.name).to.equal('UploadTimeout');
+        expect(err.message).to.include('1 seconds');
+      }
+    });
+
+    it('should accept sub-minute wait times (e.g., 30 seconds)', async () => {
+      let pollCount = 0;
+      $$.fakeConnectionRequest = () => {
+        pollCount++;
+        return Promise.resolve({ libraryId: '1JD000001', retrieverId: '1Cx000003', status: 'READY' });
+      };
+
+      const result = await AgentDataLibrary.waitForReady(connection, '1JD000001', 30);
+
+      expect(result.retrieverId).to.equal('1Cx000003');
+      expect(pollCount).to.equal(1);
+    });
+  });
 });

--- a/test/agentDataLibrary.test.ts
+++ b/test/agentDataLibrary.test.ts
@@ -367,26 +367,37 @@ describe('AgentDataLibrary', () => {
   });
 
   describe('listFiles', () => {
-    it('should extract groundingFileRefs from detail', async () => {
+    it('should return paginated file list from /files endpoint', async () => {
       mockRequest({
-        libraryId: '1JD000001',
-        groundingSource: {
-          groundingFileRefs: [{ fileId: '1Jc000001', fileName: 'doc.pdf', filePath: 'path/doc.pdf', fileSize: 1024 }],
-        },
+        files: [{ fileId: '1Jc000001', fileName: 'doc.pdf', filePath: 'path/doc.pdf', fileSize: 1024, status: 'INDEXED' }],
+        totalSize: 1,
+        currentPageUrl: '/einstein/data-libraries/1JD000001/files?pageSize=50&offset=0',
       });
 
-      const files = await AgentDataLibrary.listFiles(connection, '1JD000001');
+      const result = await AgentDataLibrary.listFiles(connection, '1JD000001');
 
-      expect(files).to.have.lengthOf(1);
-      expect(files[0].fileName).to.equal('doc.pdf');
+      expect(result.files).to.have.lengthOf(1);
+      expect(result.files[0].fileName).to.equal('doc.pdf');
+      expect(result.totalSize).to.equal(1);
+      expect(requests[0].url).to.include('/files');
     });
 
-    it('should return empty array when no files', async () => {
-      mockRequest({ libraryId: '1JD000001', groundingSource: {} });
+    it('should return empty files array when no files', async () => {
+      mockRequest({ files: [], totalSize: 0 });
 
-      const files = await AgentDataLibrary.listFiles(connection, '1JD000001');
+      const result = await AgentDataLibrary.listFiles(connection, '1JD000001');
 
-      expect(files).to.have.lengthOf(0);
+      expect(result.files).to.have.lengthOf(0);
+      expect(result.totalSize).to.equal(0);
+    });
+
+    it('should pass pagination options as query params', async () => {
+      mockRequest({ files: [], totalSize: 0 });
+
+      await AgentDataLibrary.listFiles(connection, '1JD000001', { pageSize: 10, status: 'INDEXED' });
+
+      expect(requests[0].url).to.include('pageSize=10');
+      expect(requests[0].url).to.include('status=INDEXED');
     });
   });
 

--- a/test/nuts/agentDataLibrary.nut.ts
+++ b/test/nuts/agentDataLibrary.nut.ts
@@ -232,6 +232,111 @@ describe('AgentDataLibrary NUTs — KNOWLEDGE', function () {
   });
 });
 
+describe('AgentDataLibrary NUTs — Data Categories', function () {
+  this.timeout(5 * 60 * 1000);
+
+  let connection: Connection;
+  let libraryId: string;
+  const dataCategoryNames = process.env.DATA_CATEGORY_NAMES;
+
+  before(async function () {
+    if (!targetOrg || !dataCategoryNames) {
+      console.log('Skipping Data Category NUTs: set TARGET_ORG and DATA_CATEGORY_NAMES env vars');
+      this.skip();
+    }
+    const org = await Org.create({ aliasOrUsername: targetOrg });
+    connection = org.getConnection();
+  });
+
+  after(async () => {
+    if (libraryId && connection) {
+      try {
+        await AgentDataLibrary.delete(connection, libraryId);
+        console.log(`Cleanup: deleted data category library ${libraryId}`);
+      } catch {
+        console.log(`Cleanup: delete failed for ${libraryId}`);
+      }
+    }
+  });
+
+  it('should create KNOWLEDGE library with dataCategorySelectionNames and auto-enable rule', async () => {
+    const devName = `NUT_DC_${Date.now()}`;
+    const categories = dataCategoryNames!.split(',').map((n) => n.trim());
+
+    const result = await AgentDataLibrary.create(connection, {
+      masterLabel: devName,
+      developerName: devName,
+      groundingSource: {
+        sourceType: 'KNOWLEDGE',
+        knowledgeConfig: {
+          primaryIndexField1: 'ArticleNumber',
+          primaryIndexField2: 'Title',
+          contentFields: ['Summary'],
+          isDataCategoryRuleEnabled: true,
+          dataCategorySelectionNames: categories,
+        },
+      },
+    });
+
+    expect(result).to.have.property('libraryId');
+    libraryId = result.libraryId;
+
+    const detail = await AgentDataLibrary.get(connection, libraryId);
+    const kc = detail.groundingSource as { knowledgeConfig?: { isDataCategoryRuleEnabled?: boolean; dataCategorySelectionIds?: string[] } };
+    expect(kc.knowledgeConfig?.isDataCategoryRuleEnabled).to.be.true;
+    expect(kc.knowledgeConfig?.dataCategorySelectionIds).to.be.an('array').with.length.greaterThan(0);
+    console.log(`Created with ${kc.knowledgeConfig!.dataCategorySelectionIds!.length} resolved category IDs`);
+  });
+
+  it('should disable data category rule via update (best-effort)', async () => {
+    try {
+      const result = await AgentDataLibrary.update(connection, libraryId, {
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: {
+            isDataCategoryRuleEnabled: false,
+          },
+        },
+      });
+
+      const kc = result.groundingSource as { knowledgeConfig?: { isDataCategoryRuleEnabled?: boolean } };
+      expect(kc.knowledgeConfig?.isDataCategoryRuleEnabled).to.be.false;
+      console.log('✓ Data category rule disabled via update');
+    } catch (err: unknown) {
+      const error = err as { message?: string };
+      if (error.message?.includes('provisioning operation is currently in progress')) {
+        console.log('Update skipped — library still provisioning (expected)');
+      } else {
+        throw err;
+      }
+    }
+  });
+
+  it('should re-enable data category rule via update (best-effort)', async () => {
+    try {
+      const result = await AgentDataLibrary.update(connection, libraryId, {
+        groundingSource: {
+          sourceType: 'KNOWLEDGE',
+          knowledgeConfig: {
+            isDataCategoryRuleEnabled: true,
+          },
+        },
+      });
+
+      const kc = result.groundingSource as { knowledgeConfig?: { isDataCategoryRuleEnabled?: boolean } };
+      expect(kc.knowledgeConfig?.isDataCategoryRuleEnabled).to.be.true;
+      console.log('✓ Data category rule re-enabled via update');
+    } catch (err: unknown) {
+      const error = err as { message?: string };
+      if (error.message?.includes('provisioning operation is currently in progress')) {
+        console.log('Update skipped — library still provisioning (expected)');
+      } else {
+        throw err;
+      }
+    }
+  });
+});
+
 describe('AgentDataLibrary NUTs — RETRIEVER', function () {
   this.timeout(3 * 60 * 1000);
 

--- a/test/nuts/agentDataLibrary.nut.ts
+++ b/test/nuts/agentDataLibrary.nut.ts
@@ -304,3 +304,148 @@ describe('AgentDataLibrary NUTs — RETRIEVER', function () {
     libraryId = '';
   });
 });
+
+describe('AgentDataLibrary NUTs — 262.11 Features', function () {
+  this.timeout(3 * 60 * 1000);
+
+  let connection: Connection;
+  const readyLibraryId = process.env.READY_SFDRIVE_ID;
+  const knowledgeLibraryId = process.env.READY_KNOWLEDGE_ID;
+
+  before(async function () {
+    if (!targetOrg || !readyLibraryId) {
+      console.log('Skipping 262.11 NUTs: set TARGET_ORG and READY_SFDRIVE_ID env vars');
+      this.skip();
+    }
+    const org = await Org.create({ aliasOrUsername: targetOrg });
+    connection = org.getConnection();
+  });
+
+  it('should get status with includeArtifacts and return artifacts array', async () => {
+    const result = await AgentDataLibrary.status(connection, readyLibraryId!, { includeArtifacts: true });
+
+    expect(result.indexingStatus.libraryId).to.equal(readyLibraryId);
+    expect(result.indexingStatus).to.have.property('stageDetails');
+    expect(result.indexingStatus.stageDetails).to.be.an('array');
+
+    // At least one stage should have artifacts
+    const stageDetails = result.indexingStatus.stageDetails ?? [];
+    const stagesWithArtifacts = stageDetails.filter((stage) => stage.artifacts && stage.artifacts.length > 0);
+    expect(stagesWithArtifacts.length).to.be.greaterThan(0);
+
+    // Verify artifacts structure
+    const firstStageWithArtifacts = stagesWithArtifacts[0];
+    expect(firstStageWithArtifacts.artifacts).to.be.an('array');
+    console.log(`Stage "${firstStageWithArtifacts.name}" has ${firstStageWithArtifacts.artifacts?.length} artifacts`);
+  });
+
+  it('should listFiles and return FileListResponse shape', async () => {
+    const response = await AgentDataLibrary.listFiles(connection, readyLibraryId!);
+
+    expect(response).to.have.property('files');
+    expect(response).to.have.property('totalSize');
+    expect(response.files).to.be.an('array');
+    expect(response.totalSize).to.be.a('number');
+    expect(response.files.length).to.be.greaterThan(0);
+    console.log(`Library has ${response.files.length} files (totalSize: ${response.totalSize})`);
+  });
+
+  it('should listFiles with pageSize and return pagination URLs', async () => {
+    const response = await AgentDataLibrary.listFiles(connection, readyLibraryId!, { pageSize: 1 });
+
+    expect(response).to.have.property('files');
+    expect(response).to.have.property('totalSize');
+    expect(response.files).to.be.an('array');
+    expect(response.files.length).to.equal(1);
+    expect(response).to.have.property('currentPageUrl');
+
+    // Should have nextPageUrl if there are more files
+    if (response.totalSize > 1) {
+      expect(response).to.have.property('nextPageUrl');
+      expect(response.nextPageUrl).to.be.a('string');
+      console.log(`Pagination works — page 1 of ${response.totalSize} files`);
+    }
+  });
+
+  it('should listFiles with status filter', async () => {
+    const response = await AgentDataLibrary.listFiles(connection, readyLibraryId!, { status: 'INDEXED' });
+
+    expect(response).to.have.property('files');
+    expect(response.files).to.be.an('array');
+
+    // All returned files should have status INDEXED
+    for (const file of response.files) {
+      expect(file.status).to.equal('INDEXED');
+    }
+
+    console.log(`Found ${response.files.length} INDEXED files`);
+  });
+
+  it('should return files with status field', async () => {
+    const response = await AgentDataLibrary.listFiles(connection, readyLibraryId!);
+
+    expect(response.files.length).to.be.greaterThan(0);
+
+    // Every file should have a status field
+    for (const file of response.files) {
+      expect(file).to.have.property('status');
+      expect(file.status).to.be.a('string');
+    }
+
+    const statusCounts: Record<string, number> = {};
+    for (const file of response.files) {
+      const status = file.status ?? 'UNKNOWN';
+      statusCounts[status] = (statusCounts[status] || 0) + 1;
+    }
+
+    console.log(`File statuses: ${JSON.stringify(statusCounts)}`);
+  });
+
+  it('should return totalFileCount on library detail', async () => {
+    const driveResult = await AgentDataLibrary.get(connection, readyLibraryId!);
+    console.log(`SFDRIVE totalFileCount: ${driveResult.totalFileCount ?? 'not present'}`);
+
+    if (driveResult.totalFileCount !== undefined) {
+      expect(driveResult.totalFileCount).to.be.a('number');
+    }
+
+    if (knowledgeLibraryId) {
+      const knowledgeResult = await AgentDataLibrary.get(connection, knowledgeLibraryId);
+      console.log(`Knowledge totalFileCount: ${knowledgeResult.totalFileCount ?? 'not present'}`);
+      if (knowledgeResult.totalFileCount !== undefined) {
+        expect(knowledgeResult.totalFileCount).to.be.a('number');
+      }
+    }
+  });
+
+  it('should return retriever as structured object with id and label', async () => {
+    const result = await AgentDataLibrary.get(connection, readyLibraryId!);
+
+    expect(result).to.have.property('retriever');
+    expect(result.retriever).to.be.an('object');
+
+    if (result.retriever) {
+      expect(result.retriever).to.have.property('id');
+      expect(result.retriever).to.have.property('label');
+      expect(result.retriever.id).to.be.a('string');
+      expect(result.retriever.label).to.be.a('string');
+      console.log(`Retriever: ${result.retriever.label} (${result.retriever.id})`);
+    }
+  });
+
+  it('should return retrieverAction as structured object with id and label', async () => {
+    const result = await AgentDataLibrary.get(connection, readyLibraryId!);
+
+    // retrieverAction may not always be present, but if it is, verify structure
+    if (result.retrieverAction) {
+      expect(result.retrieverAction).to.be.an('object');
+      expect(result.retrieverAction).to.have.property('id');
+      expect(result.retrieverAction).to.have.property('label');
+      expect(result.retrieverAction.id).to.be.a('string');
+      expect(result.retrieverAction.label).to.be.a('string');
+      console.log(`RetrieverAction: ${result.retrieverAction.label} (${result.retrieverAction.id})`);
+    } else {
+      console.log('RetrieverAction not present (this is optional)');
+    }
+  });
+});

--- a/test/nuts/agentDataLibrary.nut.ts
+++ b/test/nuts/agentDataLibrary.nut.ts
@@ -144,9 +144,9 @@ describe('AgentDataLibrary NUTs — SFDRIVE', function () {
   });
 
   it('should list files in the library', async () => {
-    const files = await AgentDataLibrary.listFiles(connection, libraryId);
-    expect(files.length).to.be.greaterThan(2);
-    console.log(`Files: ${files.map((f) => f.fileName).join(', ')}`);
+    const response = await AgentDataLibrary.listFiles(connection, libraryId);
+    expect(response.files.length).to.be.greaterThan(2);
+    console.log(`Files: ${response.files.map((f) => f.fileName).join(', ')}`);
   });
 
   it('should list libraries with sourceType filter', async () => {


### PR DESCRIPTION
### What does this PR do?
  Update ADL types and library methods to match the 262.11 Connect API.

  **New types:**
  - `RetrieverDetail`, `RetrieverActionDetail` — structured retriever objects (replacing legacy string IDs)
  - `StageArtifact` — provisioned DC asset metadata per stage
  - `FileListResponse` — paginated file list response shape

  **Updated types:**
  - `DataLibrarySummary`/`DataLibraryDetail`: add `retriever`, `retrieverAction`, `totalFileCount`
  - `StageDetail`: add `artifacts`, `errorCode`
  - `GroundingFileRef`: add `status` (JIT indexing)
  - `GroundingSource.knowledgeConfig`: add `dataCategoryIds`, `dataCategoryNames`

  **Method changes:**
  - `status()`: accepts optional `{ includeArtifacts?: boolean }` — appends query param
  - `listFiles()`: switches from reading capped detail endpoint (FILE_LOAD_LIMIT=200) to dedicated `GET
  /files` with pagination params (pageSize, offset, sortBy, sortOrder, name, status). Return type changes
  from `GroundingFileRef[]` to `FileListResponse` (**breaking** for direct consumers).


### What issues does this PR fix or reference?
@W-23237764@

### Dependent PR
 - https://github.com/salesforcecli/plugin-agent/pull/453