### PR TITLE
@W-23111346@ test: fix contextVariables NUT reading nonexistent trace.steps

### DIFF
--- a/test/nuts/agent.nut.ts
+++ b/test/nuts/agent.nut.ts
@@ -435,14 +435,13 @@ describe('agent NUTs', () => {
         expect(traces).to.be.an('array');
         expect(traces.length).to.be.greaterThan(0, 'expected at least one trace from the planner');
 
-        // Walk every step of every trace looking for the override echoed back as session state.
-        // Shape varies by step type, so we stringify and substring-match.
-        const allStepsJson = traces
-          .flatMap((t) => (t as { steps?: unknown[] })?.steps ?? [])
-          .map((s) => JSON.stringify(s))
-          .join('\n');
+        // Walk every trace (including its plan steps) looking for the override echoed back as
+        // session state. The PlannerResponse shape varies by step type and the value may live in
+        // prompt content (e.g. an LLMExecutionStep's context_variables block) or a top-level field,
+        // so we stringify the whole trace and substring-match.
+        const allTracesJson = traces.map((t) => JSON.stringify(t)).join('\n');
 
-        expect(allStepsJson).to.contain(overrideValue, 'expected override value to appear in at least one trace step');
+        expect(allTracesJson).to.contain(overrideValue, 'expected override value to appear in at least one trace');
       });
 
       it('should end the preview session', async () => {


### PR DESCRIPTION
## What

The NUT `should reflect supplied contextVariables in the live preview session trace` (`test/nuts/agent.nut.ts`) reads a property that does not exist on a trace object:

```ts
.flatMap((t) => (t as { steps?: unknown[] })?.steps ?? [])
```

`agent.preview.getAllTraces()` returns `PlannerResponse[]`, and `PlannerResponse` (`src/types.ts`) names its step array **`plan`**, not `steps` — confirmed by the captured trace fixtures (`test/mocks/trace_*.json`), which all use a top-level `plan` key and never `steps`.

Because `t.steps` was always `undefined`, the assembled string was empty (`''`), so the assertion failed with:

```
AssertionError: expected override value to appear in at least one trace step:
  expected '' to include '0MwXX0000000000000'
```

(The empty string `''` is the fingerprint: the prior `traces.length > 0` assertion passed, so traces existed — only the accessor was wrong.)

## Fix

Stringify the whole trace and substring-match, rather than digging into a (mis-named) step field:

```ts
const allTracesJson = traces.map((t) => JSON.stringify(t)).join('\n');
expect(allTracesJson).to.contain(overrideValue, 'expected override value to appear in at least one trace');
```

This removes the spurious `''` failure and is robust to step shape and to wherever the server echoes the override value (e.g. an `LLMExecutionStep`'s `context_variables` block or a top-level field).

## Verification

- `tsc` type-check: ✅ clean
- `eslint` on the changed file: ✅ clean
- Live NUT: **not run** — requires an authenticated devhub/scratch org, which I did not have. The `''` symptom is fixed with certainty; whether the live planner echoes the override value back is server-dependent (see note below).

## Note for reviewers (possible follow-up)

This is a live-org NUT. Even with the accessor fixed, the value `0MwXX...` only appears in the trace if the preview server echoes the supplied context variable back. Two things may prevent that and could need a follow-up if the test is still flaky:

- The test supplies the variable name `$Context.RoutableId`, but the boilerplate `.agent` template declares it as plain `RoutableId`.
- `RoutableId` is declared as a `linked string` sourced from `@MessagingSession.Id`, so the server may resolve it from the linked record rather than honoring a client-supplied override.

This PR scope is limited to fixing the accessor bug that makes the assertion compare against `''`.

@W-23111346@