### PR TITLE
fix: send explicit empty body on POST fetchMcpServer @W-23371674@

### DIFF
--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -98,7 +98,11 @@ export class ApiCatalog {
   /** POST /api-catalog/mcp-servers/{id}/fetch */
   public static async fetchMcpServer(connection: Connection, id: string): Promise<McpServerFetchOutput> {
     const url = `${base(connection)}/mcp-servers/${encode(id)}/fetch`;
-    return ApiCatalog.request<McpServerFetchOutput>(connection, 'POST', url, 'fetchMcpServer');
+    // Send an explicit (empty) JSON body: a bodyless POST over HTTP/2 leaves the request
+    // stream half-open (no END_STREAM), so jsforce/undici never sees response headers and
+    // the call hangs until the 300s headers timeout. Passing a body sets Content-Length and
+    // closes the stream, so the response is read immediately.
+    return ApiCatalog.request<McpServerFetchOutput>(connection, 'POST', url, 'fetchMcpServer', {});
   }
 
   /** GET /api-catalog/mcp-servers/{id}/assets */

--- a/test/apiCatalog.test.ts
+++ b/test/apiCatalog.test.ts
@@ -120,11 +120,14 @@ describe('ApiCatalog client', () => {
   });
 
   describe('fetchMcpServer', () => {
-    it('POSTs to /mcp-servers/{id}/fetch', async () => {
+    it('POSTs to /mcp-servers/{id}/fetch with an explicit body', async () => {
       mockRequest({ assets: [] });
       await ApiCatalog.fetchMcpServer(connection, '1');
       expect(requests[0].method).to.equal('POST');
       expect(requests[0].url).to.match(/\/mcp-servers\/1\/fetch$/);
+      // A body must be sent: a bodyless POST over HTTP/2 leaves the stream half-open and the
+      // request hangs until the 300s headers timeout (jsforce/undici never sees the response).
+      expect(requests[0].body).to.equal('{}');
     });
   });
 


### PR DESCRIPTION
## What & why

`sf agent mcp fetch` (and any consumer of `ApiCatalog.fetchMcpServer`) hangs for
**300 seconds** and then fails with `HeadersTimeoutError`, regardless of the MCP
server's health or response.

### Root cause

`fetchMcpServer` was the only `POST` in the `ApiCatalog` client that called the
shared `request` helper **without a body**. The helper only sets `body` /
`Content-Length` when `body !== undefined`, so the request went out bodyless.

Over HTTP/2 (jsforce/undici), a `POST` with no body and no `Content-Length`
leaves the request stream **half-open** — the client never sends `END_STREAM`,
so the server-side reactive pipeline waits for more request data and undici
never receives the response headers. The call blocks until the 300s
`HeadersTimeoutError` fires.

The server actually responds fast — this is purely client-side stream framing.

### Fix

Pass an explicit empty JSON body `{}` to `fetchMcpServer`. The shared helper then
sets `Content-Length`, the request stream closes cleanly, and the response is
read immediately.

## Evidence

1. **Splunk (`aprst`)** — the API responds (HTTP 422 in ~2s) while the CLI keeps
   waiting the full 300s. Server response time is independent of the hang.
2. **`NODE_DEBUG=undici`** — the POST is initiated, then 300s of silence; the
   writable side is only shut down (`_final`) *after* the timeout fires,
   confirming the stream was never half-closed.
3. **`sf api request rest` control** — hitting the same endpoint with body `{}`
   returns in ~2-6s. With no body it hangs.
4. **Local build + real install** — with the fix, `fetch` drops from 300s to
   ~5-13s across every MCP server tested.

## Test plan

- Updated `test/apiCatalog.test.ts`: `fetchMcpServer` now asserts an explicit
  `{}` body is sent.
- `yarn build && yarn test` green (11/11).
- Installed the compiled `lib/` into a local `sf` CLI and exercised all
  `sf agent mcp` routes (create, list, get, update, fetch, asset list, asset
  replace, delete) against a live org — none hang; `fetch` returns assets in
  seconds.

@W-23371674@
