### PR TITLE
feat: add securityWarning to McpFetchedAsset

### DIFF
--- a/src/apiCatalogTypes.ts
+++ b/src/apiCatalogTypes.ts
@@ -81,6 +81,10 @@ export type McpFetchedAsset = {
   active?: boolean;
   availableAsAgentAction?: boolean;
   status?: string;
+  // Populated by the introspection endpoints that return live tool metadata:
+  // POST /mcp-servers/{id}/fetch and the auto-fetch in POST /mcp-servers (create).
+  // Absent from the stored asset-allowlist responses.
+  securityWarning?: string;
 };
 
 export type McpServerCreateOutput = {


### PR DESCRIPTION
## Summary

The MCP server fetch/introspection endpoint (`POST /mcp-servers/{id}/fetch`) returns a per-tool `securityWarning` string when a tool's definition changed since it was last approved. This adds `securityWarning?: string` to `McpFetchedAsset` so consumers (e.g. `sf agent mcp fetch` in `plugin-agent`) can surface it and let a user review it before re-approving a tool.

- Only the live `/fetch` response populates this field; `create` and asset responses do not, so it is optional.
- `fetchMcpServer` deserializes the response directly, so no client-side mapping change was needed — the field flows through automatically.

## Test plan

- `tsc` + `eslint` clean
- `mocha test/apiCatalog.test.ts` — 11/11 passing

@W-23572634@
