### PR TITLE
fix: make nock a devDependency to prevent proxy startup crash @W-23607779

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "@salesforce/source-deploy-retrieve": "^12.36.2",
     "@salesforce/types": "^1.7.3",
     "fast-xml-parser": "^5.8.0",
-    "nock": "^14.0.15",
     "yaml": "^2.8.4"
   },
   "devDependencies": {
     "@salesforce/cli-plugins-testkit": "^5.3.58",
     "@salesforce/dev-scripts": "^11.0.4",
     "esbuild": "^0.28.0",
+    "nock": "^14.0.15",
     "ts-morph": "^28.0.0",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -19,7 +19,11 @@ import { type Stats, statSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { Connection, Logger, SfError } from '@salesforce/core';
 import { env } from '@salesforce/kit';
-import nock from 'nock';
+// Type-only import: erased at compile time so `nock` (and its transitive
+// `@mswjs/interceptors`, which registers global HTTP interceptors on load) is
+// never pulled onto the runtime require graph. The value is loaded lazily via
+// dynamic import in `request()`, and only when `SF_MOCK_DIR` is set.
+import type nock from 'nock';
 import { requestWithEndpointFallback } from './utils';
 
 type HttpHeaders = {
@@ -157,6 +161,13 @@ export class MaybeMock {
   ): Promise<T> {
     if (this.mockDir) {
       this.logger.debug(`Mocking ${method} request to ${url} using ${this.mockDir}`);
+      // Load nock lazily: it is only needed when mocking is explicitly enabled,
+      // and importing it eagerly pulls @mswjs/interceptors onto the runtime
+      // require graph, which breaks consumers running behind a proxy. nock is
+      // intentionally a devDependency — this path only runs when a developer or
+      // test sets SF_MOCK_DIR, so the import is guaranteed to resolve there.
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      const { default: nock } = await import('nock');
       const responses = await readResponses<T>(this.mockDir, url, this.logger);
       const baseUrl = this.connection.baseUrl();
       const scope = this.scopes.get(baseUrl) ?? nock(baseUrl);


### PR DESCRIPTION
## Problem

`@salesforce/mcp` 0.30.9+ crashes at startup for users behind a corporate proxy / custom CA:

```
Error: No socket was returned in the `connect()` function
    at ProxyAgent.createConnection (.../agent-base/dist/index.js)
    at MockHttpSocket.passthrough (.../@mswjs/interceptors/...)
```

**Root cause is in this package.** `nock` was a **runtime** dependency (`dependencies`), imported eagerly at the top of `src/maybe-mock.ts`. `MaybeMock` is on the load path of every public entry point (`agent.ts`, `agentTester.ts`, `agentforceStudioTester.ts`, `productionAgent.ts`, `scriptAgentPublisher.ts`), so simply importing `@salesforce/agents` pulled `nock@14`'s bundled `@mswjs/interceptors` onto the runtime require graph. Its global HTTP interceptors register on load and collide with the consumer's `ProxyAgent`.

The regression entered at **`@salesforce/agents` 1.6.5**, which bumped `nock` `^13.5.6` → `^14.0.15` (commit `200187da`, "fix(deps): bump major dependency versions"). nock@13 had no `@mswjs/interceptors`; nock@14 does. Downstream, this surfaced once `@salesforce/mcp`'s `^1.3.0` range on agents resolved to ≥1.6.5 (0.30.9+).

> Impact is a proxied-corp subset (needs 0.30.9+, a proxy/custom CA, and a tree that resolved to `nock@14` rather than deduping to a safe `nock@13`) — but non-deterministic: a cache-clear/reinstall can flip an unaffected user into the crash.

## Fix

`nock` is only needed when `SF_MOCK_DIR` is set, which only happens in dev/test. This PR:

- Moves `nock` from `dependencies` → `devDependencies`.
- Replaces the eager `import nock from 'nock'` with a **type-only** import (erased at compile time) plus a **dynamic `import('nock')`** inside the `if (this.mockDir)` branch.

Net effect: `nock` and `@mswjs/interceptors` stay off the runtime require graph for all production consumers, while the mocking feature is unchanged for anyone who sets `SF_MOCK_DIR`.

## Verification

- ✅ `import('./lib/index.js')` loads **neither** `nock` nor `@mswjs/interceptors` (checked via `require.cache`).
- ✅ All 402 unit tests pass — they set `SF_MOCK_DIR`, so they exercise the new dynamic-import path (`agentTester.ts` remains at 100% coverage).
- ✅ `yarn compile` (src + test) and `yarn lint` both clean.

## Note

This does not change the mockable-endpoint surface. The runtime agent-conversation endpoints in `productionAgent.ts` (`/sessions/.../messages`, `/agents/.../sessions`, `/sessions/{id}`) already bypass `MaybeMock` and are unaffected.

@W-23607779@