### PR TITLE
feat: echo serverFingerprint on MCP fetch/replace to guard against tool drift @W-23608280

### DIFF
--- a/src/apiCatalogTypes.ts
+++ b/src/apiCatalogTypes.ts
@@ -94,6 +94,11 @@ export type McpServerCreateOutput = {
 
 export type McpServerFetchOutput = {
   assets: McpFetchedAsset[];
+  // Opaque hash of the server's current tool definitions, echoed by POST /fetch.
+  // Round-trip it into replaceMcpServerAssets (serverFingerprint) to confirm that
+  // the definitions you reviewed are still current; keeping a drifted (OUT_OF_SYNC)
+  // tool active without it is rejected with a 409 (server-side drift guard).
+  serverFingerprint?: string;
 };
 
 export type McpServerAssetOutput = {
@@ -121,6 +126,10 @@ export type McpServerAssetReplaceItem = {
 
 export type McpServerAssetReplaceInput = {
   assets: McpServerAssetReplaceItem[];
+  // Optional optimistic-concurrency token from a prior POST /fetch (serverFingerprint).
+  // When supplied, the server verifies the definitions haven't drifted since; when
+  // omitted, keeping an already-active OUT_OF_SYNC tool active is rejected with 409.
+  serverFingerprint?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds the optional `serverFingerprint` field to the ApiCatalog MCP types so the
fetch → review → replace round-trip can carry the tool-drift token. This is the
library layer consumed by the `--server-fingerprint` flag added to `sf agent mcp
asset replace` in the companion `salesforcecli/plugin-agent` PR.

**Background — the rug pull.** An EXTERNAL MCP server can silently change the
**description** of an already-active tool after an admin approved it. The
description is exactly what the LLM reads, so this is a prompt-injection /
exfiltration vector. The Connect API already supported an optimistic-concurrency
`serverFingerprint` on `PUT /assets`, but `POST /fetch` never echoed it back — so
the client had no value to round-trip and the check was always skipped. This PR
closes the client-side contract gap.

## What's included

- `McpServerFetchOutput.serverFingerprint` — echoed by `POST /fetch`; an opaque
  hash of the server's current tool definitions.
- `McpServerAssetReplaceInput.serverFingerprint` — round-tripped into `PUT
  /assets` so the server verifies the reviewed definitions haven't drifted
  (status `OUT_OF_SYNC`). Keeping an already-active drifted tool active without it
  is rejected with a `409`.

`replaceMcpServerAssets` already forwards the whole `input` object, so no client
logic change is needed — only the contract types.

## Test plan

- `yarn build` (compile + lint) — clean.
- `tsc --noEmit` — clean.
- Existing `test/apiCatalog.test.ts` suite unaffected (the client passes the input
  through verbatim; the new field is additive and optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)