### PR TITLE
feat!: require Node >=22, drop EOL Node versions @W-23480655@

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "url": "https://github.com/forcedotcom/agents.git"
   },
   "dependencies": {
-    "@salesforce/core": "^8.32.6",
-    "@salesforce/kit": "^3.2.6",
-    "@salesforce/source-deploy-retrieve": "^12.36.2",
+    "@salesforce/core": "^9.0.0",
+    "@salesforce/kit": "^4.0.0",
+    "@salesforce/source-deploy-retrieve": "^13.0.0",
     "@salesforce/types": "^1.8.0",
     "fast-xml-parser": "^5.8.0",
     "yaml": "^2.8.4"
@@ -30,7 +30,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "/lib",

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -19,10 +19,8 @@ import { type Stats, statSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { Connection, Logger, SfError } from '@salesforce/core';
 import { env } from '@salesforce/kit';
-// Type-only import: erased at compile time so `nock` (and its transitive
-// `@mswjs/interceptors`, which registers global HTTP interceptors on load) is
-// never pulled onto the runtime require graph. The value is loaded lazily via
-// dynamic import in `request()`, and only when `SF_MOCK_DIR` is set.
+// Type-only import: erased at compile time. Only used for the `nock.Body`
+// constraint on the generic type parameter.
 import type nock from 'nock';
 import { requestWithEndpointFallback } from './utils';
 
@@ -131,13 +129,13 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
 /**
  * A class to act as an in-between the library's request, and the orgs response
  *
- * if `SF_MOCK_DIR` is set it will read from the directory, resolving files as API responses with nock
+ * if `SF_MOCK_DIR` is set it will read from the directory, returning file contents directly as API responses
  *
  * if it is NOT set, it will hit the endpoint and use real server responses
  */
 export class MaybeMock {
   private mockDir = getMockDir();
-  private scopes = new Map<string, nock.Scope>();
+  private mockCallCounts = new Map<string, number>();
   private logger: Logger;
 
   public constructor(private connection: Connection) {
@@ -161,42 +159,14 @@ export class MaybeMock {
   ): Promise<T> {
     if (this.mockDir) {
       this.logger.debug(`Mocking ${method} request to ${url} using ${this.mockDir}`);
-      // Load nock lazily: it is only needed when mocking is explicitly enabled,
-      // and importing it eagerly pulls @mswjs/interceptors onto the runtime
-      // require graph, which breaks consumers running behind a proxy. nock is
-      // intentionally a devDependency — this path only runs when a developer or
-      // test sets SF_MOCK_DIR, so the import is guaranteed to resolve there.
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      const { default: nock } = await import('nock');
       const responses = await readResponses<T>(this.mockDir, url, this.logger);
-      const baseUrl = this.connection.baseUrl();
-      const scope = this.scopes.get(baseUrl) ?? nock(baseUrl);
-      // Look up status code to determine if it's successful or not
-      // Be have to assert this is a number because AgentTester has a status that is non-numeric
-      const getCode = (response: T): number =>
-        typeof response === 'object' && 'status' in response && typeof response.status === 'number'
-          ? response.status
-          : 200;
-      // This is a hack to work with SFAP prod, dev, and test endpoints
-      url = url.replace(/https:\/\/(dev\.|test\.)?api\.salesforce\.com/, '');
-      this.scopes.set(baseUrl, scope);
-      switch (method) {
-        case 'GET':
-          for (const response of responses) {
-            scope.get(url).reply(getCode(response), response);
-          }
-          break;
-        case 'POST':
-          for (const response of responses) {
-            scope.post(url, body as nock.RequestBodyMatcher).reply(getCode(response), response);
-          }
-          break;
-        case 'DELETE':
-          for (const response of responses) {
-            scope.delete(url).reply(getCode(response), response);
-          }
-          break;
-      }
+      // Return mock responses directly — nock cannot intercept jsforce's undici-based
+      // HTTP transport, so we short-circuit here. For polling scenarios with multiple
+      // mock files, successive calls cycle through the responses in order.
+      const key = `${method}:${url}`;
+      const callIndex = this.mockCallCounts.get(key) ?? 0;
+      this.mockCallCounts.set(key, callIndex + 1);
+      return responses[Math.min(callIndex, responses.length - 1)];
     }
 
     this.logger.debug(`Making ${method} request to ${url}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,7 +761,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.31.0", "@salesforce/core@^8.31.1", "@salesforce/core@^8.32.6":
+"@salesforce/core@^8.31.1":
   version "8.32.6"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.32.6.tgz#2824dc917888dc040995dfef3a9e83d41fafbdea"
   integrity sha512-ZR973WoqCgi6cR58WhgokbHVZOaADNKHiuM1FAwS5pTLQnC91xYi04i2e/gpAX2AUf7Ya6zjbusYtZNpSyKKAQ==
@@ -769,6 +769,31 @@
     "@jsforce/jsforce-node" "^3.10.17"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
+    ajv "^8.18.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.1"
+    form-data "^4.0.5"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.3"
+    jszip "3.10.1"
+    memfs "4.38.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.8.0"
+    ts-retry-promise "^0.8.1"
+    zod "^4.1.12"
+
+"@salesforce/core@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.0.0.tgz#bf7a2816a322b8febc5349f5a1c884b8be073b06"
+  integrity sha512-sL4sr8MXcdsHZJr0bacMY0ZJmbPwBEvJudDIlKxKdQu/62d1aNBvACPFfL32QJdu2sOkEpgF3CX/0znkU43g2g==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.17"
+    "@salesforce/kit" "^4.0.0"
+    "@salesforce/ts-types" "^3.0.0"
     ajv "^8.18.0"
     change-case "^4.1.2"
     fast-levenshtein "^3.0.0"
@@ -830,19 +855,26 @@
   dependencies:
     "@salesforce/ts-types" "^2.0.12"
 
+"@salesforce/kit@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-4.0.0.tgz#ef2be4c59abf57156175d340e4cdc356bc28095e"
+  integrity sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==
+  dependencies:
+    "@salesforce/ts-types" "^3.0.0"
+
 "@salesforce/prettier-config@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"
   integrity sha512-hYOhoPTCSYMDYn+U1rlEk16PoBeAJPkrdg4/UtAzupM1mRRJOwEPMG1d7U8DxJFKuXW3DMEYWr2MwAIBDaHmFg==
 
-"@salesforce/source-deploy-retrieve@^12.36.2":
-  version "12.36.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.2.tgz#54b8f414687960581a5513216bcd5b77b9489136"
-  integrity sha512-N3+dnM2EBsviXbnzP89iuBbdSyzB5b3RqUPZwyCw99SF6x6u9GKQVL164kfWyozl4XtZnhTQvbU75qkriFYWoQ==
+"@salesforce/source-deploy-retrieve@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-13.0.0.tgz#dcdaf8461d6ad7af937f5b9daf38844e3933247f"
+  integrity sha512-MBqBM9Waewh+tCR89KlDHEGaUJ9cAjwS2FIyIn+Zq/NwW7aRucyCF25MWs4gSHeFsBiNUGyGtxlIt+2oWNUIlw==
   dependencies:
-    "@salesforce/core" "^8.31.0"
-    "@salesforce/kit" "^3.2.4"
-    "@salesforce/ts-types" "^2.0.12"
+    "@salesforce/core" "^9.0.0"
+    "@salesforce/kit" "^4.0.0"
+    "@salesforce/ts-types" "^3.0.0"
     "@salesforce/types" "^1.6.0"
     fast-levenshtein "^3.0.0"
     fast-xml-parser "^5.7.3"
@@ -859,6 +891,11 @@
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.12.tgz#60420622812a7ec7e46d220667bc29b42dc247ff"
   integrity sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==
+
+"@salesforce/ts-types@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-3.0.0.tgz#375b13e92f594bc9d0a09716d77fc753bd31e6a6"
+  integrity sha512-lTCoI1NtQWiMDyn7B9N/CfWK9WmSpRnbYWqKTZYstn3mZ2DWSYwJXTh5Oh2wAAS9LAD/vaoU3F/TrV3q7wfnYw==
 
 "@salesforce/types@^1.6.0", "@salesforce/types@^1.8.0":
   version "1.8.0"


### PR DESCRIPTION
## Summary
- Bumps `engines.node` to `>=22.0.0`
- Bumps `@salesforce/core` to `^9.0.0`
- Bumps `@salesforce/kit` to `^4.0.0`
- Bumps `@salesforce/source-deploy-retrieve` to `^13.0.0`

@W-23480655@

BREAKING CHANGE: engines.node raised to >=22.0.0, dropping support for Node 18 and 20

## Test plan
- [x] `yarn build` passes
- [ ] `yarn test` — 20 pre-existing failures on main (unrelated to this change)