### PR TITLE
fix: send bypassUser:false for employee agents on --api-name preview @W-23734892@

### DIFF
--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -350,6 +350,13 @@ export class ProductionAgent extends AgentBase {
       this.apexDebugging = apexDebugging;
     }
 
+    // Employee agents (AgentforceEmployeeAgent / InternalCopilot) run as the logged-in user, so the
+    // Agent API requires a user context on session start and rejects `bypassUser: true` with a
+    // "400 Invalid user ID" error. Only bypass the user for non-employee agents. This mirrors the
+    // logic already present on the ScriptAgent (--authoring-bundle) preview path.
+    const botMetadata = await this.getBotMetadata();
+    const bypassUser = botMetadata.AgentType !== 'AgentforceEmployeeAgent';
+
     const body = {
       externalSessionKey: randomUUID(),
       instanceConfig: {
@@ -358,7 +365,7 @@ export class ProductionAgent extends AgentBase {
       streamingCapabilities: {
         chunkTypes: ['Text'],
       },
-      bypassUser: true,
+      bypassUser,
     };
 
     try {

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
 import { ProductionAgent } from '../src/agents/productionAgent';
@@ -724,6 +725,79 @@ describe('ProductionAgent', () => {
         expect(error).to.be.instanceOf(SfError);
         expect((error as SfError).message).to.include(messages.getMessage('noVersionsFound', ['TestAgent']));
       }
+    });
+  });
+
+  describe('preview.start bypassUser', () => {
+    const buildBotMetadata = (agentType: string): BotMetadata => ({
+      Id: '0Xx123456789ABC',
+      IsDeleted: false,
+      DeveloperName: 'TestAgent',
+      MasterLabel: 'Test Agent',
+      CreatedDate: '2025-01-01T00:00:00.000+0000',
+      CreatedById: 'user123',
+      LastModifiedDate: '2025-01-02T00:00:00.000+0000',
+      LastModifiedById: 'user123',
+      SystemModstamp: '2025-01-02T00:00:00.000+0000',
+      BotUserId: 'botUser123',
+      Description: 'Test bot description',
+      Type: 'AgentForce',
+      AgentType: agentType,
+      AgentTemplate: null,
+      BotVersions: {
+        records: [
+          {
+            Id: 'version1',
+            Status: 'Active',
+            IsDeleted: false,
+            BotDefinitionId: '0Xx123456789ABC',
+            DeveloperName: 'TestAgent_v1',
+            CreatedDate: '2025-01-01T00:00:00.000+0000',
+            CreatedById: 'user123',
+            LastModifiedDate: '2025-01-01T00:00:00.000+0000',
+            LastModifiedById: 'user123',
+            SystemModstamp: '2025-01-01T00:00:00.000+0000',
+            VersionNumber: 1,
+            CopilotPrimaryLanguage: 'en_US',
+            ToneType: 'formal',
+            CopilotSecondaryLanguages: [],
+          },
+        ],
+      },
+    });
+
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // Capture the session-start request body without hitting the network.
+      requestStub = $$.SANDBOX.stub(connection, 'request');
+      requestStub.resolves({ sessionId: 'test-session-id', _links: {}, messages: [] } as never);
+    });
+
+    const getStartRequestBody = (): Record<string, unknown> => {
+      const startCall = requestStub
+        .getCalls()
+        .find((c) => (c.args[0] as { url: string }).url.endsWith('/sessions'));
+      if (!startCall) throw new Error('agent sessions request not captured');
+      return JSON.parse((startCall.args[0] as { body: string }).body) as Record<string, unknown>;
+    };
+
+    it('sends bypassUser: false for an employee agent', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata('AgentforceEmployeeAgent'));
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start();
+
+      expect(getStartRequestBody().bypassUser).to.equal(false);
+    });
+
+    it('sends bypassUser: true for a non-employee (service) agent', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata('EinsteinServiceAgent'));
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start();
+
+      expect(getStartRequestBody().bypassUser).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

The production (`--api-name`) agent preview path hardcoded `bypassUser: true` when starting a session. Employee agents (`AgentforceEmployeeAgent` / `InternalCopilot`) run **as the logged-in user**, so the Agent API rejects that combination with `400 AgentApiException: Invalid user ID provided on start session`.

This branches `bypassUser` on the agent type in `ProductionAgent.startPreview()` — only bypassing the user for non-employee agents — mirroring the logic that already exists on the `ScriptAgent` (`--authoring-bundle`) preview path. `getBotMetadata()` is already invoked earlier on this path and is memoized, so no additional query is made.

```ts
// before
bypassUser: true

// after
const botMetadata = await this.getBotMetadata();
const bypassUser = botMetadata.AgentType !== 'AgentforceEmployeeAgent';
```

**Testing**
- Unit tests added for both branches (employee → `false`, non-employee → `true`); verified they fail against the previous hardcoded behavior. Full suite green (406 passing).
- Verified end-to-end against a live employee agent via `--api-name`: `start` / `send` / `end` all succeed (previously `start` returned `400 Invalid user ID`). Confirms `bypassUser: false` alone is sufficient — no explicit user ID needed.

### What issues does this PR fix or reference?

@W-23734892@

Reported in #agentforce-dx: `sf agent preview start --api-name <employee agent>` failed while `--authoring-bundle` worked. This restores the headless-by-name preview flow for employee agents.
