### PR TITLE
feat: add serverFingerprint to MCP fetch/replace types @W-23827791@

### DIFF
--- a/src/apiCatalogTypes.ts
+++ b/src/apiCatalogTypes.ts
@@ -94,6 +94,12 @@ export type McpServerCreateOutput = {
 
 export type McpServerFetchOutput = {
   assets: McpFetchedAsset[];
+  /**
+   * Optimistic-concurrency token for the current server definition. Echo it back
+   * unchanged on `replaceMcpServerAssets` (PUT /assets) to detect and reject an
+   * intervening server change. Absent/null when no drift assessment.
+   */
+  serverFingerprint?: string;
 };
 
 export type McpServerAssetOutput = {
@@ -121,6 +127,12 @@ export type McpServerAssetReplaceItem = {
 
 export type McpServerAssetReplaceInput = {
   assets: McpServerAssetReplaceItem[];
+  /**
+   * Optional optimistic-concurrency token from a prior `fetchMcpServer` response.
+   * When supplied, the save is rejected (server-changed error) if the live server
+   * definition no longer matches. When omitted, no concurrency check is performed.
+   */
+  serverFingerprint?: string;
 };
 
 /**

--- a/test/apiCatalog.test.ts
+++ b/test/apiCatalog.test.ts
@@ -129,6 +129,18 @@ describe('ApiCatalog client', () => {
       // request hangs until the 300s headers timeout (jsforce/undici never sees the response).
       expect(requests[0].body).to.equal('{}');
     });
+
+    it('returns serverFingerprint when present in the response', async () => {
+      mockRequest({ assets: [], serverFingerprint: 'abc123' });
+      const result = await ApiCatalog.fetchMcpServer(connection, '1');
+      expect(result.serverFingerprint).to.equal('abc123');
+    });
+
+    it('leaves serverFingerprint undefined when absent from the response', async () => {
+      mockRequest({ assets: [] });
+      const result = await ApiCatalog.fetchMcpServer(connection, '1');
+      expect(result.serverFingerprint).to.be.undefined;
+    });
   });
 
   describe('replaceMcpServerAssets', () => {
@@ -138,6 +150,21 @@ describe('ApiCatalog client', () => {
       expect(requests[0].method).to.equal('PUT');
       expect(requests[0].url).to.match(/\/mcp-servers\/1\/assets$/);
       expect(JSON.parse(requests[0].body as string).assets[0].name).to.equal('tool-a');
+    });
+
+    it('round-trips serverFingerprint in the request body when supplied', async () => {
+      mockRequest({ assets: [] });
+      await ApiCatalog.replaceMcpServerAssets(connection, '1', {
+        assets: [{ name: 'tool-a', active: true }],
+        serverFingerprint: 'abc123',
+      });
+      expect(JSON.parse(requests[0].body as string).serverFingerprint).to.equal('abc123');
+    });
+
+    it('omits serverFingerprint from the request body when not supplied', async () => {
+      mockRequest({ assets: [] });
+      await ApiCatalog.replaceMcpServerAssets(connection, '1', { assets: [{ name: 'tool-a', active: true }] });
+      expect(JSON.parse(requests[0].body as string)).to.not.have.property('serverFingerprint');
     });
   });
 


### PR DESCRIPTION
### What & why

  ApiCatalog.fetchMcpServer and ApiCatalog.replaceMcpServerAssets are unaware of serverFingerprint
  API now returns from POST /mcp-servers/{id}/fetch and accepts on PUT /mcp-servers/{id}/assets 

Without it, `@salesforce/agents` consumers have no way to detect that a remote MCP server's tool definitions changed between reviewing them and saving the allowlist.

### Change
  
  Added serverFingerprint?: string to two existing types in src/apiCatalogTypes.ts:
  - McpServerFetchOutput — the /fetch response (producer)
  - McpServerAssetReplaceInput — the PUT /assets request body (consumer)

No changes to src/apiCatalog.ts: both fetchMcpServer and replaceMcpServerAssets already pass the full body/response through the generic request<T>() helper, so the new field flows through automatically once the types declare it. No changes to src/index.ts: both types were already re-exported.

###   Test plan

  - Updated test/apiCatalog.test.ts: fetchMcpServer now asserts serverFingerprint is returned when present and left undefined when absent from the response;
  replaceMcpServerAssets now asserts serverFingerprint is round-tripped in the serialized request body when supplied and omitted (not sent as undefined)
  when not.
  - yarn build && yarn test green (15/15), 100% statement/branch/function/line coverage on apiCatalog.ts.

this is a continuation of the work made on https://github.com/forcedotcom/agents/pull/325

@W-23827791@