### PR TITLE
fix: send context variables when previewing a published agent via --api-name @W-23842329@

### DIFF
--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -19,6 +19,7 @@ import {
   type AgentPreviewEndResponse,
   AgentPreviewInterface,
   type AgentPreviewSendResponse,
+  type AgentPreviewStartOptions,
   type AgentPreviewStartResponse,
   type BotActivationResponse,
   type BotMetadata,
@@ -60,7 +61,16 @@ export class ProductionAgent extends AgentBase {
     }
 
     this.preview = {
-      start: (apexDebugging?: boolean): Promise<AgentPreviewStartResponse> => this.startPreview(apexDebugging),
+      start: (
+        apexDebuggingOrOptions?: boolean | AgentPreviewStartOptions,
+        startOptions?: AgentPreviewStartOptions
+      ): Promise<AgentPreviewStartResponse> => {
+        // The CLI passes an AgentPreviewStartOptions object as the first arg; a boolean means apexDebugging.
+        if (typeof apexDebuggingOrOptions === 'object' && apexDebuggingOrOptions !== null) {
+          return this.startPreview(undefined, apexDebuggingOrOptions);
+        }
+        return this.startPreview(apexDebuggingOrOptions, startOptions);
+      },
       send: (message: string): Promise<AgentPreviewSendResponse> => this.sendMessage(message),
       getAllTraces: (): Promise<PlannerResponse[]> => this.getAllTracesFromDisc(),
       end: (reason: EndReason): Promise<AgentPreviewEndResponse> => this.endSession(reason),
@@ -340,7 +350,10 @@ export class ProductionAgent extends AgentBase {
     return botVersionMetadata;
   }
 
-  private async startPreview(apexDebugging?: boolean): Promise<AgentPreviewStartResponse> {
+  private async startPreview(
+    apexDebugging?: boolean,
+    options?: AgentPreviewStartOptions
+  ): Promise<AgentPreviewStartResponse> {
     if (!this.id) {
       await this.getId();
     }
@@ -365,6 +378,10 @@ export class ProductionAgent extends AgentBase {
       streamingCapabilities: {
         chunkTypes: ['Text'],
       },
+      // The committed-agent endpoint (/agents/{id}/sessions) accepts the same `variables` array as the
+      // preview endpoint used by ScriptAgent. Without this, --context-variables were silently dropped
+      // when previewing by --api-name. The wire field is `variables`, not `contextVariables`.
+      variables: options?.contextVariables ?? [],
       bypassUser,
     };
 

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -19,7 +19,7 @@ import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
 import { ProductionAgent } from '../src/agents/productionAgent';
 import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
-import type { BotMetadata } from '../src/types';
+import type { BotMetadata, ContextVariable } from '../src/types';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agents');
@@ -798,6 +798,29 @@ describe('ProductionAgent', () => {
       await agent.preview.start();
 
       expect(getStartRequestBody().bypassUser).to.equal(true);
+    });
+
+    it('sends context variables as the `variables` array when provided', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata('EinsteinServiceAgent'));
+
+      const contextVariables: ContextVariable[] = [
+        { name: 'CustomerId', type: 'Text', value: '001xx000003DGb2' },
+        { name: 'IsVip', type: 'Boolean', value: 'true' },
+      ];
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start({ contextVariables });
+
+      expect(getStartRequestBody().variables).to.deep.equal(contextVariables);
+    });
+
+    it('defaults `variables` to an empty array when no context variables are provided', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata('EinsteinServiceAgent'));
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start();
+
+      expect(getStartRequestBody().variables).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
## What

Forward `--context-variables` to the session-start request when previewing a **committed/published** agent via `--api-name`.

## Why

Context variables were silently dropped on the `--api-name` (committed agent) preview path. `ProductionAgent.startPreview` built the session-start body without a `variables` field, so the committed-agent endpoint (`/agents/{id}/sessions`) never received them — even though the `--authoring-bundle` (`ScriptAgent`) path forwarded them correctly. Users passing `--context-variables` saw their values silently ignored.

## How

- Widen the `preview.start` wrapper to accept an `AgentPreviewStartOptions` object (the shape the CLI actually passes) in addition to the legacy `boolean` `apexDebugging` argument, and thread it into `startPreview`.
- Add `variables: options?.contextVariables ?? []` to the request body, matching the exact shape `ScriptAgent` already sends (`{ name, type, value }`).

## Testing

- Added two unit tests: `variables` is sent when context variables are provided, and defaults to `[]` when none are.
- `yarn build`, `yarn lint`, and the `productionAgent` suite (17 passing) are green.
- Verified end-to-end against a real org:
  - Captured the committed-agent wire body — `"variables":[{"name":"...","type":"Text","value":"..."}]` is now present.
  - A/B confirmed the committed (`--api-name`) path sends a payload identical to the working `--authoring-bundle` path.
  - A **linked** context variable seeded via `$Context.<Name>` propagates end-to-end and is echoed back by the agent.

@W-23842329@