### PR TITLE
fix: stop publish when agent compilation fails

### DIFF
--- a/src/agents/scriptAgent.ts
+++ b/src/agents/scriptAgent.ts
@@ -272,7 +272,17 @@ export class ScriptAgent extends AgentBase {
         });
       }
 
-      await this.compile();
+      const compileResult = await this.compile();
+
+      if (compileResult.status === 'failure') {
+        this.agentJson = undefined;
+
+        throw SfError.create({
+          name: 'AgentCompilationError',
+          message: ['Agent compilation failed.', ...compileResult.errors.map((error) => error.description)].join('\n'),
+          data: compileResult,
+        });
+      }
     } finally {
       // Always restore original content after compilation
       this.agentScriptContent = originalContent;

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -26,6 +26,7 @@ import { AgentSource, COMPILATION_API_EXIT_CODES } from '../src/types';
 import { ScriptAgent } from '../src';
 import { ScriptAgentPublisher } from '../src/agents/scriptAgentPublisher';
 import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
+import { compileAgentScriptResponseFailure, compileAgentScriptResponseSuccess } from './testData';
 
 function createMockConnectionManager(conn: Connection): ConnectionManager {
   return {
@@ -176,6 +177,60 @@ describe('Agents', () => {
         expect(error).to.be.instanceOf(SfError);
         expect((error as SfError).exitCode).to.equal(COMPILATION_API_EXIT_CODES.SERVER_ERROR);
       }
+    });
+
+    it('does not publish a cached artifact when the latest compilation fails', async () => {
+      const successfulCompilation = compileAgentScriptResponseSuccess;
+
+      if (successfulCompilation.status !== 'success') {
+        throw new Error('Expected the successful compilation fixture');
+      }
+
+      const staleAgentJson = {
+        ...successfulCompilation.compiledArtifact,
+        globalConfiguration: {
+          ...successfulCompilation.compiledArtifact.globalConfiguration,
+          developerName: 'myAgent',
+          label: 'Previously compiled agent',
+        },
+      };
+
+      const compileRequestStub = requestStub.withArgs(sinon.match.has('url', sinon.match(/authoring\/scripts/)));
+
+      // First compilation succeeds and populates ScriptAgent.agentJson.
+      compileRequestStub.onFirstCall().resolves({
+        ...compileAgentScriptResponseSuccess,
+        compiledArtifact: staleAgentJson,
+      });
+
+      // publish() performs another compilation, which now fails.
+      compileRequestStub.onSecondCall().resolves(compileAgentScriptResponseFailure);
+
+      const publishStub = $$.SANDBOX.stub(ScriptAgentPublisher.prototype, 'publishAgentJson').resolves({
+        id: 'unexpected-id',
+        entityId: 'unexpected-entity-id',
+      } as never);
+
+      const agent = new ScriptAgent({
+        connection,
+        project: sfProject,
+        aabName: 'myAgent',
+      });
+
+      const firstCompilation = await agent.compile();
+      expect(firstCompilation.status).to.equal('success');
+
+      let caught: unknown;
+      try {
+        await agent.publish();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(compileRequestStub.callCount).to.equal(2);
+      expect(publishStub.called, 'publisher must not run after compilation failure').to.equal(false);
+      expect(caught).to.be.instanceOf(SfError);
+      expect((caught as SfError).name).to.equal('AgentCompilationError');
     });
 
     it('should apply string replacements during publish', async () => {


### PR DESCRIPTION
### What does this PR do?

`ScriptAgent.publish()` recompiles the current AgentScript before publishing,
but it previously did not check the returned compilation status. AgentScript
syntax errors are returned as `{ status: "failure", compiledArtifact: null }`
rather than thrown.

If the `ScriptAgent` already had an artifact cached from an earlier successful
compilation, publishing continued with that older artifact after the new
compilation failed.

This change stops publishing when compilation fails, clears the cached
artifact, and throws an `AgentCompilationError` containing the compilation
details.

The regression test reproduces the issue by returning a successful compilation
response followed by a failure response. Before this change,
`ScriptAgentPublisher.publishAgentJson()` was still called after the failure.

Tests:

- `yarn compile`
- `yarn lint` — 0 errors
- `yarn test:only` — 407 passing, 1 pending
- `yarn nyc mocha "test/agents.test.ts"` — 26 passing, 1 pending
- `yarn nyc mocha "test/agentPublisher.test.ts"` — 20 passing

### What issues does this PR fix or reference?

N/A