### PR TITLE
fix: send x-attributed-client no-builder header on --api-name preview start (@W-23896240@)

### DIFF
--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -391,6 +391,7 @@ export class ProductionAgent extends AgentBase {
         url,
         body: JSON.stringify(body),
         headers: {
+          'x-attributed-client': 'no-builder', // <- removes markdown from responses
           'x-client-name': 'afdx',
         },
       });

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -822,5 +822,24 @@ describe('ProductionAgent', () => {
 
       expect(getStartRequestBody().variables).to.deep.equal([]);
     });
+
+    const getStartRequestHeaders = (): Record<string, string> => {
+      const startCall = requestStub
+        .getCalls()
+        .find((c) => (c.args[0] as { url: string }).url.endsWith('/sessions'));
+      if (!startCall) throw new Error('agent sessions request not captured');
+      return (startCall.args[0] as { headers: Record<string, string> }).headers;
+    };
+
+    it('sends the x-attributed-client: no-builder header on session start to strip markdown', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata('EinsteinServiceAgent'));
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start();
+
+      const headers = getStartRequestHeaders();
+      expect(headers['x-attributed-client']).to.equal('no-builder');
+      expect(headers['x-client-name']).to.equal('afdx');
+    });
   });
 });


### PR DESCRIPTION
## What & why

The v1.1 preview path (`ScriptAgent`, `--authoring-bundle`) sends `x-attributed-client: no-builder` on session start, which tells the server to strip markdown from agent responses so previews render cleanly in a terminal. The v1 committed preview path (`ProductionAgent`, `--api-name`) did **not** — it sent only `x-client-name: afdx`.

This brings the two preview-start requests to parity so `--api-name` previews behave like the authoring-bundle path.

## Change

- `src/agents/productionAgent.ts`: add `'x-attributed-client': 'no-builder'` to the `startPreview` session-start request headers.

The header is added on **start-session only** (it's session-scoped, mirroring `ScriptAgent` where the same header lives only on the start-session POST — not on `sendMessage`/`endSession`).

## Header parity

| Request | ScriptAgent (v1.1) | ProductionAgent (v1) |
|---|---|---|
| start session | `no-builder` + `afdx` | `no-builder` + `afdx` (this PR) |
| send message | `afdx` only | `afdx` only |
| end session | — | — |

## Tests

- Added a unit test asserting the header is sent on session start.
- `test/productionAgent.test.ts`: 18/18 passing; build + lint clean.

## Verification notes

Live A/B on org `sf-test-nico` against a committed agent confirmed **no regression** on the v1 `/agents/{id}/sessions` endpoint (sessions start, messages send, responses valid). A visible markdown→plain-text demonstration on the v1 path could not be produced with the test agent used, because that agent's committed version routes to guardrail responses and does not emit markdown on v1 regardless of the header. The change rests on parity with the established, relied-upon v1.1 behavior.

@W-23896240@