### PR TITLE
fix: throw when groundingContext is passed without promptTemplateName in createSpec (@W-23896239@)

### DIFF
--- a/messages/agents.md
+++ b/messages/agents.md
@@ -37,3 +37,7 @@ No active version found for agent %s.
 # noVersionsFound
 
 No versions found for agent %s.
+
+# groundingContextRequiresPromptTemplate
+
+The "groundingContext" property requires the "promptTemplateName" property. Grounding context is only used to ground a customized prompt template, so it has no effect without one.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -361,6 +361,11 @@ const verifyAgentSpecConfig = (config: AgentJobSpecCreateConfig): void => {
   if (!agentType || !role || !companyName || !companyDescription) {
     throw messages.createError('invalidAgentSpecConfig');
   }
+  // groundingContext only travels inside the customizedInfo block, which requires a promptTemplateName.
+  // Without a template there's nothing to ground, so fail loudly instead of silently dropping the value.
+  if (config.groundingContext && !config.promptTemplateName) {
+    throw messages.createError('groundingContextRequiresPromptTemplate');
+  }
 };
 
 // Decodes all HTML entities in ai-assist API responses.

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -81,6 +81,22 @@ describe('Agents', () => {
     expect(output.topics[0]).to.have.property('name', 'Guest_Experience_Enhancement');
   });
 
+  it('createSpec throws when groundingContext is provided without promptTemplateName', async () => {
+    try {
+      await Agent.createSpec(connection, {
+        agentType: 'customer',
+        role: 'answer questions about vacation_rentals',
+        companyName: 'Coral Cloud Enterprises',
+        companyDescription: 'Provide vacation rentals and activities',
+        groundingContext: 'Only recommend pet-friendly rentals.',
+      });
+      expect.fail('expected createSpec to throw when groundingContext is set without promptTemplateName');
+    } catch (err) {
+      expect(err).to.be.instanceOf(SfError);
+      expect((err as SfError).name).to.equal('GroundingContextRequiresPromptTemplateError');
+    }
+  });
+
   describe('HTML entity decoding', () => {
     it('should decode HTML entities in error messages', () => {
       const errorResponse = {


### PR DESCRIPTION
## What & why

`Agent.createSpec` only attaches `config.groundingContext` to the request when `config.promptTemplateName` is also set — `groundingContext` lives inside the `customizedInfo` block, which is built solely under the `if (config.promptTemplateName)` branch (`src/agent.ts`). A caller who passed `groundingContext` **without** a `promptTemplateName` had the value **silently discarded** — no error, no warning.

The wire schema makes this a genuine constraint, not just an implementation detail: `customizedInfo` requires `promptTemplateName: string`, and `groundingContext` is an optional child of it (`src/types.ts`). Grounding context exists only to ground a customized prompt template — there is no wire slot to send it independently. So passing it alone is a caller mistake that should be reported, not swallowed.

## Change

- `src/agent.ts`: `verifyAgentSpecConfig` now throws when `groundingContext` is set but `promptTemplateName` is not.
- `messages/agents.md`: new `groundingContextRequiresPromptTemplate` error message.
- `test/agents.test.ts`: unit test asserting `createSpec` throws `GroundingContextRequiresPromptTemplateError` in that case.

The check runs before any HTTP request, so misuse fails fast and locally.

## Behavior change

Only affects callers who were already misusing the API (grounding context alone). Previously their call "succeeded" while dropping the value; now it throws a clear, actionable error.

## Tests / verification

- `test/agents.test.ts`: 26 passing (new test included); build + lint clean (0 errors).
- Live e2e on a scratch org via the compiled lib:
  - `groundingContext` without `promptTemplateName` → throws `GroundingContextRequiresPromptTemplateError` with the clear message.
  - baseline `createSpec` (no `groundingContext`) → still reaches the org and returns topics.

@W-23896239@