### PR TITLE
fix: record reasoning traces for --api-name previews via v1.1 plans endpoint @W-23896220@

### DIFF
--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -151,9 +151,21 @@ export class ProductionAgent extends AgentBase {
     return foundVersion;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await,class-methods-use-this,@typescript-eslint/no-unused-vars
   public async getTrace(planId: string): Promise<PlannerResponse | undefined> {
-    return undefined;
+    if (!this.sessionId) {
+      return undefined;
+    }
+    // The committed (v1) Agent API has no plan/trace endpoint of its own, but the v1.1 preview plans
+    // endpoint accepts a v1 committed session's sessionId and returns its reasoning trace. This mirrors
+    // ScriptAgent.getTrace; the only difference is stripping the trailing `/v1` from this agent's apiBase.
+    const previewBase = this.apiBase.replace(/\/v1$/, '');
+    return requestWithEndpointFallback<PlannerResponse>(await this.getJwtConnection(), {
+      method: 'GET',
+      url: `${previewBase}/v1.1/preview/sessions/${this.sessionId}/plans/${planId}`,
+      headers: {
+        'x-client-name': 'afdx',
+      },
+    });
   }
 
   public getHistoryFromDisc(sessionId?: string): Promise<{
@@ -299,9 +311,11 @@ export class ProductionAgent extends AgentBase {
       const agentTurn = ++this.turnCounter;
       await logTurnToHistory(agentEntry, agentTurn, this.historyDir, this.historyBuffer);
 
-      // Fetch and write trace immediately if available
+      // Fetch and write trace immediately if available. A trace-fetch failure must not fail the
+      // message turn, so fall back to recording no trace (the prior behavior) if it can't be retrieved.
       if (planId) {
-        await recordTraceForTurn(this.historyDir, agentTurn, planId, undefined, this.historyBuffer);
+        const trace = await this.getTrace(planId).catch(() => undefined);
+        await recordTraceForTurn(this.historyDir, agentTurn, planId, trace, this.historyBuffer);
       }
 
       // Flush buffer to keep turn-index.json and metadata.json up to date

--- a/src/agents/productionAgent.ts
+++ b/src/agents/productionAgent.ts
@@ -312,7 +312,7 @@ export class ProductionAgent extends AgentBase {
       await logTurnToHistory(agentEntry, agentTurn, this.historyDir, this.historyBuffer);
 
       // Fetch and write trace immediately if available. A trace-fetch failure must not fail the
-      // message turn, so fall back to recording no trace (the prior behavior) if it can't be retrieved.
+      // message turn, so fall back to recording no trace if it can't be retrieved.
       if (planId) {
         const trace = await this.getTrace(planId).catch(() => undefined);
         await recordTraceForTurn(this.historyDir, agentTurn, planId, trace, this.historyBuffer);

--- a/test/productionAgent.test.ts
+++ b/test/productionAgent.test.ts
@@ -19,7 +19,7 @@ import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
 import { ProductionAgent } from '../src/agents/productionAgent';
 import { ConnectionManager, setManagerForTesting } from '../src/connectionManager';
-import type { BotMetadata, ContextVariable } from '../src/types';
+import type { BotMetadata, ContextVariable, PlannerResponse } from '../src/types';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agents');
@@ -821,6 +821,85 @@ describe('ProductionAgent', () => {
       await agent.preview.start();
 
       expect(getStartRequestBody().variables).to.deep.equal([]);
+    });
+  });
+
+  describe('getTrace', () => {
+    const buildBotMetadata = (): BotMetadata => ({
+      Id: '0Xx123456789ABC',
+      IsDeleted: false,
+      DeveloperName: 'TestAgent',
+      MasterLabel: 'Test Agent',
+      CreatedDate: '2025-01-01T00:00:00.000+0000',
+      CreatedById: 'user123',
+      LastModifiedDate: '2025-01-02T00:00:00.000+0000',
+      LastModifiedById: 'user123',
+      SystemModstamp: '2025-01-02T00:00:00.000+0000',
+      BotUserId: 'botUser123',
+      Description: 'Test bot description',
+      Type: 'AgentForce',
+      AgentType: 'EinsteinServiceAgent',
+      AgentTemplate: null,
+      BotVersions: {
+        records: [
+          {
+            Id: 'version1',
+            Status: 'Active',
+            IsDeleted: false,
+            BotDefinitionId: '0Xx123456789ABC',
+            DeveloperName: 'TestAgent_v1',
+            CreatedDate: '2025-01-01T00:00:00.000+0000',
+            CreatedById: 'user123',
+            LastModifiedDate: '2025-01-01T00:00:00.000+0000',
+            LastModifiedById: 'user123',
+            SystemModstamp: '2025-01-01T00:00:00.000+0000',
+            VersionNumber: 1,
+            CopilotPrimaryLanguage: 'en_US',
+            ToneType: 'formal',
+            CopilotSecondaryLanguages: [],
+          },
+        ],
+      },
+    });
+
+    const trace: PlannerResponse = {
+      type: 'PlanSuccessResponse',
+      planId: 'plan-123',
+      sessionId: 'test-session-id',
+      intent: 'answer',
+      topic: 'general',
+      plan: [],
+    };
+
+    it('returns undefined when no session has been started', async () => {
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      expect(await agent.getTrace('plan-123')).to.equal(undefined);
+    });
+
+    it('GETs the v1.1 preview plans endpoint for the committed session and returns the trace', async () => {
+      $$.SANDBOX.stub(connection, 'singleRecordQuery').resolves(buildBotMetadata());
+
+      const requestStub = $$.SANDBOX.stub(connection, 'request');
+      // Session start returns the sessionId; the getTrace call returns the reasoning trace.
+      requestStub.onFirstCall().resolves({ sessionId: 'test-session-id', _links: {}, messages: [] } as never);
+      requestStub.resolves(trace as never);
+
+      const agent = new ProductionAgent({ connection, project: sfProject, apiNameOrId: 'TestAgent' });
+      await agent.preview.start();
+
+      const result = await agent.getTrace('plan-123');
+
+      const traceCall = requestStub
+        .getCalls()
+        .find((c) => (c.args[0] as { url: string }).url.includes('/plans/'));
+      if (!traceCall) throw new Error('getTrace request not captured');
+      const { url, method } = traceCall.args[0] as { url: string; method: string };
+
+      expect(method).to.equal('GET');
+      expect(url).to.equal(
+        'https://api.salesforce.com/einstein/ai-agent/v1.1/preview/sessions/test-session-id/plans/plan-123'
+      );
+      expect(result).to.deep.equal(trace);
     });
   });
 });


### PR DESCRIPTION
## What & why

`ProductionAgent.getTrace` was a no-op stub that always returned `undefined`, so committed (`--api-name`) previews never recorded a reasoning trace — `getAllTraces()` came back empty and no trace was written to disc for a turn.

The committed (v1) Agent API has no plan/trace endpoint of its own, but the v1.1 preview plans endpoint accepts a v1 committed session's `sessionId` and returns its reasoning trace. This mirrors `ScriptAgent.getTrace`; the only difference is stripping the trailing `/v1` from this agent's `apiBase`.

## Changes

- **`src/agents/productionAgent.ts`**
  - Implement `getTrace(planId)` to GET `/v1.1/preview/sessions/{sessionId}/plans/{planId}` (header `x-client-name: afdx`), returning `undefined` when there's no active session.
  - Wire it into `sendMessage`: fetch the trace and record it for the turn, with `.catch(() => undefined)` so a trace-fetch failure never fails the message turn (falls back to the prior no-trace behavior).
- **`test/productionAgent.test.ts`** — add `getTrace` tests: returns `undefined` before a session starts; GETs the correct v1.1 plans URL and returns the trace.

## Testing

- `yarn build` clean; `yarn lint` 0 errors.
- Full unit suite: 408 passing, 0 failing (incl. 2 new tests).
- Live e2e against a scratch org via `--api-name`: `getTrace()` returned a real `PlanSuccessResponse` (15 plan steps) and `getAllTraces()` confirmed the trace was persisted to disc by the `sendMessage` turn.

@W-23896220@