### PR TITLE
do-not-merge/testing-nuts-failure-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ See [DEVELOPING](./DEVELOPING.md) for details on building and testing the librar
 ## Publishing
 
 `@salesforce/agents` publishes when changes are merged into `main`. The version is bumped per the rules of the release orb and [standard-version](https://github.com/conventional-changelog/standard-version).
+
+<!-- CI trigger: verifying NUT failure-log output ([NUT-CONTEXT] / [NUT-FAILURE]). Do not merge. -->


### PR DESCRIPTION
**Do not merge.** Throwaway PR to trigger CI and verify the new NUT failure-logging output.

Only change is a comment appended to README.md — the point is to run the `nuts` and `xNuts-plugin-agent` jobs and confirm:
- `[NUT-CONTEXT]` appears in both jobs (every run) with orgId + pod + UTC timestamp.
- `[NUT-FAILURE]` appears for the deterministic z3 failure in `xNuts-plugin-agent` (and for the agents `nuts` create-agent test if the scratch org lands on an affected pod).

Grep the job logs for `[NUT-CONTEXT]` / `[NUT-FAILURE]`. Close without merging when done.