### PR TITLE
chore: nuts-create-user @W-23915028@

### DIFF
--- a/test/nuts/agent.nut.ts
+++ b/test/nuts/agent.nut.ts
@@ -53,6 +53,31 @@ async function waitForEinsteinReady(connection: Connection, maxAttempts = 30): P
   throw new Error(`Einstein AI did not become ready within ${timeoutSeconds} seconds timeout`);
 }
 
+// Poll until the given permission set is visibly assigned to the user, so the license/permset is
+// committed and queryable before it's referenced downstream. This avoids relying on a freshly-created
+// user's entitlements being visible within the same request that consumes them.
+async function waitForPermSetAssignment(
+  connection: Connection,
+  userId: string,
+  permSetName: string,
+  maxAttempts = 12
+): Promise<void> {
+  // eslint-disable-next-line no-await-in-loop
+  for (let i = 0; i < maxAttempts; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await connection.query<{ Id: string }>(
+      `SELECT Id FROM PermissionSetAssignment WHERE AssigneeId='${userId}' AND PermissionSet.Name='${permSetName}'`
+    );
+    if (result.records.length > 0) {
+      // Give the license/permset assignment a brief settle window so it is fully committed before use.
+      await sleep(30_000); // eslint-disable-line no-await-in-loop
+      return;
+    }
+    await sleep(10_000); // eslint-disable-line no-await-in-loop
+  }
+  throw new Error(`Permission set ${permSetName} was not assigned to user ${userId} within timeout`);
+}
+
 // Format a UTC timestamp as MM/DD/YYYY:HH:mm:ss for CI log correlation (Splunk-friendly).
 function fmtUtc(d: Date): string {
   const p = (n: number): string => String(n).padStart(2, '0');
@@ -526,6 +551,46 @@ describe('agent NUTs', () => {
   });
 
   describe('agent create', () => {
+    // Pre-provisioned Bot User Id passed to Agent.create via agentSettings.userId (see before() below).
+    let botUserId: string;
+
+    before(async () => {
+      // Pre-provision a Bot User up front and hand its Id to Agent.create via agentSettings.userId.
+      // The 'customer' agentType maps to core's EinsteinServiceAgent, which requires a Bot User holding
+      // the Digital Agent license + AgentforceServiceAgentUser runtime permset. When no userId is
+      // supplied, core auto-creates that user in the SAME transaction as the BotDefinition save, and the
+      // pre-save validation trigger intermittently cannot see the just-created license/permset
+      // assignment, failing with "User doesn't have access to agent." Creating and fully provisioning the
+      // user here — and letting it settle before Agent.create runs — makes core reuse an already-committed
+      // user instead of racing on a freshly-created one. This describe provisions its own bot user so it
+      // does not depend on the ordering of the 'List and Get Bot Metadata' describe.
+      const { Id: profileId } = await connection.singleRecordQuery<{ Id: string }>(
+        "SELECT Id FROM Profile WHERE Name='Einstein Agent User'"
+      );
+
+      const botUsername = genUniqueString('botUser_%s@test.org');
+      const botUser = await User.create({ org: defaultOrg });
+      // @ts-expect-error - private method. Must use this to prevent the auth flow that happens with the createUser method
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      const { userId } = (await botUser.createUserInternal({
+        username: botUsername,
+        lastName: 'AgentUser',
+        alias: 'agtCrt',
+        timeZoneSidKey: 'America/Denver',
+        email: botUsername,
+        emailEncodingKey: 'UTF-8',
+        languageLocaleKey: 'en_US',
+        localeSidKey: 'en_US',
+        profileId,
+      } as UserFields)) as { userId: string };
+      botUserId = userId;
+
+      await botUser.assignPermissionSets(userId, ['AgentforceServiceAgentUser']);
+
+      // Wait for the license/permset assignment to be committed and visible before Agent.create runs.
+      await waitForPermSetAssignment(connection, userId, 'AgentforceServiceAgentUser');
+    });
+
     it('should create an agent spec', async () => {
       const agentConfig: AgentJobSpecCreateConfig = {
         agentType: 'customer',
@@ -568,6 +633,8 @@ describe('agent NUTs', () => {
         saveAgent: true,
         agentSettings: {
           agentName,
+          // Reuse an already-provisioned Bot User so core does not auto-create (and race-validate) one.
+          userId: botUserId,
         },
         generationInfo: {
           defaultInfo: {


### PR DESCRIPTION
## What

Fix the intermittent failure of the NUT `agent NUTs > agent create > should create an agent from a spec` (`test/nuts/agent.nut.ts`), which fails in core with:

```
SalesforceGenericException: Error creating agent : User doesn't have access to agent.
  ... copilot.utils.CopilotBuilder.build
Caused by: PreSaveValidationException: User doesn't have access to agent.
```

## Why

The test calls `Agent.create` with `agentType: 'customer'` and no `agentSettings.userId`. `customer` maps to core's `EinsteinServiceAgent`, which requires a Bot User holding the Digital Agent license + `AgentforceServiceAgentUser` runtime permset. With no `userId` supplied, core auto-creates that Bot User **in the same transaction** as the `BotDefinition` save. The `BotDefinition` pre-save validation trigger then re-validates the just-created user's license/permset — which is not reliably visible within the same request — producing the intermittent `"User doesn't have access to agent."` (a same-transaction consistency race, not a hard entitlement gap).

## How

The `agent create` describe now pre-provisions its **own** Bot User up front (self-contained — no dependency on the `List and Get Bot Metadata` describe's ordering):

- Creates a unique user on the `Einstein Agent User` profile (carries the Digital Agent license), reusing the existing `User.create` + `createUserInternal` pattern in this file.
- Assigns `AgentforceServiceAgentUser`.
- Polls `PermissionSetAssignment` and settles so the license/permset is committed and visible before `Agent.create` runs.
- Passes the resolved id via `agentSettings.userId` (already supported — `src/types.ts:240`), so core reuses an already-committed, fully-provisioned user instead of racing on a freshly-created one.

Existing `logNutFailure(...)` diagnostics and the `isSuccess` / metadata assertions are unchanged. No source/library changes — test-only.

## Validation

- `yarn build` + `yarn lint` pass (0 errors).
- Ran the `agent create` describe locally against scratch orgs on pods **CS281** and **CS257**: both created the agent with `isSuccess: true` and **no `"User doesn't have access to agent."` error**. `2 passing`.

**Final validation is the NUT run in CI** across random pods, since the original failure was intermittent/pod-sensitive. This PR targets that intermittent `"User doesn't have access to agent."` failure.


@W-23915028@