### PR TITLE
fix: guard against nodes without a tools array when publishing authoring bundles

### DIFF
--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -184,7 +184,9 @@ export class ScriptAgentPublisher {
 
     const genAiPluginAndFunctions = this.agentJson.agentVersion.nodes.flatMap((n) => [
       `GenAiPlugin:${n.developerName}`,
-      ...n.tools.map((t) => `GenAiFunction:${t.name}`),
+      // Some node types (e.g. `related_agent` from a `connected_subagent` block) are pure
+      // delegation stubs and compile with no `tools` array, so guard against undefined.
+      ...(n.tools ?? []).map((t) => `GenAiFunction:${t.name}`),
     ]);
 
     const cs = await ComponentSetBuilder.build({

--- a/src/types.ts
+++ b/src/types.ts
@@ -918,7 +918,8 @@ export type AgentJson = {
       beforeReasoning: string;
       instructions: string;
       focusPrompt: string;
-      tools: Array<{
+      // Optional: delegation node types (e.g. `related_agent`) compile with no `tools`.
+      tools?: Array<{
         type: string;
         target: string | null;
         boundInputs: unknown;

--- a/test/agentPublisher.test.ts
+++ b/test/agentPublisher.test.ts
@@ -774,6 +774,86 @@ describe('AgentPublisher', () => {
       validateStub.restore();
     });
 
+    it('should not crash when a node has no tools property (e.g. a related_agent delegation node)', async () => {
+      // Regression test for the crash reported against `sf agent publish authoring-bundle`:
+      // `related_agent` nodes (compiled from AgentScript `connected_subagent` blocks, which
+      // have no `actions:` section) omit the `tools` array entirely. The old code did
+      // `n.tools.map(...)` unconditionally and threw
+      // `TypeError: Cannot read properties of undefined (reading 'map')`.
+      // Note this differs from the `tools: []` case above: here the property is absent, not empty.
+      const relatedAgentNode = {
+        type: 'related_agent',
+        reasoningType: 'standard',
+        description: 'Delegate to a connected subagent',
+        beforeReasoning: '',
+        instructions: '',
+        focusPrompt: '',
+        // tools intentionally omitted — this is what caused the crash
+        preToolCall: null,
+        postToolCall: null,
+        afterReasoning: null,
+        developerName: 'RelatedAgentNode',
+        label: 'Related Agent Node',
+        onInit: null,
+        transitions: null,
+        onExit: null,
+        actionDefinitions: [],
+      };
+      const agentJsonWithRelatedAgentNode: AgentJson = {
+        ...agentJson,
+        agentVersion: {
+          ...agentJson.agentVersion,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          nodes: [relatedAgentNode as any],
+        },
+      };
+
+      const validateStub = createValidateDeveloperNameStub();
+      const publisher = new ScriptAgentPublisher(connection, sfProject, agentJsonWithRelatedAgentNode, false);
+
+      // Setup successful metadata retrieval mock
+      const compSet = new ComponentSet();
+      const mdApiRetrieve = new MetadataApiRetrieve({
+        usernameOrConnection: testOrg.getMockUserInfo().Username,
+        output: 'nowhere',
+      });
+      $$.SANDBOX.stub(mdApiRetrieve, 'pollStatus').resolves({
+        // @ts-expect-error only stubbed response
+        response: {
+          success: true,
+        },
+      });
+      $$.SANDBOX.stub(compSet, 'retrieve').resolves(mdApiRetrieve);
+
+      let capturedMetadataEntries: string[] = [];
+      const buildStub = $$.SANDBOX.stub(ComponentSetBuilder, 'build').callsFake(async (options) => {
+        if (options?.metadata?.metadataEntries) {
+          capturedMetadataEntries = options.metadata.metadataEntries;
+        }
+        return compSet;
+      });
+
+      // @ts-expect-error private method
+      const retrieveAgentMetadata = publisher.retrieveAgentMetadata.bind(publisher);
+      // Should NOT throw despite the node lacking a `tools` property.
+      await retrieveAgentMetadata('v1');
+
+      expect(buildStub.calledOnce).to.be.true;
+
+      // The GenAiPlugin entry is still emitted for the node...
+      expect(capturedMetadataEntries).to.include('GenAiPlugin:RelatedAgentNode');
+
+      // ...but no GenAiFunction entries, since the node has no tools.
+      const genAiFunctionEntries = capturedMetadataEntries.filter((entry) => entry.startsWith('GenAiFunction:'));
+      expect(genAiFunctionEntries).to.be.empty;
+
+      // Bot and Agent entries are still included.
+      expect(capturedMetadataEntries).to.include('Bot:test_agent');
+      expect(capturedMetadataEntries).to.include('Agent:test_agent_v1');
+
+      validateStub.restore();
+    });
+
     it('should not include GenAiPlugin and GenAiFunction entries when nodes array is empty', async () => {
       // Use the default agentJson which has empty nodes array
       const validateStub = createValidateDeveloperNameStub();


### PR DESCRIPTION
## What & why

`sf agent publish authoring-bundle` crashes with `TypeError: Cannot read properties of undefined (reading 'map')` for agents that contain a `related_agent` node.

`related_agent` nodes are compiled from AgentScript `connected_subagent` blocks. Because a `connected_subagent` is a pure delegation stub (it has no `actions:` section), the compiled node omits the `tools` array entirely. `ScriptAgentPublisher.retrieveAgentMetadata` assumed every node had a `tools` array and called `n.tools.map(...)` unconditionally, so the publish blew up before the (already-succeeded) server-side publish could finish deploying the authoring bundle.

## Fix

- `scriptAgentPublisher.ts`: guard the map with `(n.tools ?? [])`.
- `types.ts`: make `tools?` optional on the node type so it matches the compiled artifact. This also means the missing-guard case is now caught at compile time (`tsc` flags `n.tools` as possibly undefined).

## Tests

- Added a regression test asserting `retrieveAgentMetadata` does not throw when a node has the `tools` property **absent** (a `related_agent`-style node) — distinct from the existing `tools: []` empty-array case.
- Full publisher suite: **21 passing**. `tsc --noEmit` clean.

## Context

Reported by a customer blocked from deploying an Orchestrator/multi-agent (Super Agent) via the CLI. Root-caused from a `--dev-debug` log: the true stack was `scriptAgentPublisher.js:187` `Array.flatMap` → `.map` on `undefined`.

> Note: a separate secondary bug (`SfCommandError.from` also crashing on undefined `actions`, which masked the real error in the log) lives in a different package and is **not** addressed here.