### PR TITLE
chore: standardize logging to msg-ctx format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md
+
+Guidance for coding sessions in this repo. This file is a hub: it points to the conventions
+we expect every change to follow. Read the linked docs before writing code in their area.
+
+`@salesforce/agents` — client-side APIs for working with Salesforce agents (TypeScript).
+
+## Conventions
+
+- **[Logging](ai-docs/logging.md)** — how we log. Log through `CtxLogger`, keep messages
+  static with variable data in structured fields, and write every line to pass the 3am test.
+  Read this before adding or changing any log line.
+
+_Add new convention docs under `ai-docs/` and link them here as the hub grows._
+
+## Verifying a change
+
+- `yarn build` — typecheck/compile (equivalently `yarn tsc -b`).
+- `yarn test` — the test suite (the mocha unit tests run via `yarn mocha "test/**/*.test.ts"`).
+
+Run both before considering a change done.

--- a/ai-docs/logging.md
+++ b/ai-docs/logging.md
@@ -1,0 +1,171 @@
+# Logging
+
+How we log in this codebase. Follow it for every new or changed log line.
+
+## The bar: the 3am test
+
+Write every log line for an engineer who was paged at 3am to diagnose a production
+incident in this service, has never seen the code, cannot run it or read the source, and
+has ten minutes. If that person could not tell what happened, why, and what the system did
+next from the log line alone, the line is not good enough yet.
+
+## Use `CtxLogger`
+
+Always log through `CtxLogger` (`src/ctxLogger.ts`) — never call `@salesforce/core`'s
+`Logger` directly, and never hand-build message strings. Construct one logger per component
+(named after that component) and call it like an ordinary logger:
+
+```ts
+import { CtxLogger } from './ctxLogger';
+
+const logger = CtxLogger.child('AgentPublisher');
+
+logger.debug('Publishing agent', { developerName });
+logger.warn('Failed to trigger data library indexing', { libraryId, errName, errMsg });
+```
+
+For a module-scoped logger, use the lazy singleton the codebase already uses:
+
+```ts
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
+  if (!logger) {
+    logger = CtxLogger.child('AgentDataLibrary');
+  }
+  return logger;
+};
+```
+
+Each level method — `trace` / `debug` / `info` / `warn` / `error` — takes a **static
+message** and a **fields object**:
+
+```ts
+logger.error('Data library create request failed', {
+  sourceType,
+  statusCode,
+  errName: wrapped.name,
+  errMsg: wrapped.message,
+});
+```
+
+`CtxLogger` does two things with that call, and this is the whole point of using it:
+
+1. It emits the fields object as **structured fields** — the machine-parseable source of
+   truth.
+2. It renders those same fields into a human-readable `key=value, key=value` breadcrumb and
+   appends it to the message after ` | `, so the emitted line reads
+   `Data library create request failed | sourceType=KNOWLEDGE, statusCode=500, errName=..., errMsg=...`.
+
+Because the message and the breadcrumb are produced from one fields object in one call, they
+can never drift apart. Do not replicate this by hand with `Logger` — that reintroduces the
+drift `CtxLogger` exists to prevent.
+
+## Keep the message static; put variable data in fields
+
+The message string must be **identical for every occurrence of the event** so it stays
+greppable and aggregation/alerting works. All variable data goes in the fields object, never
+interpolated into the message.
+
+```ts
+// Yes — static message, variable data in fields.
+logger.warn('Agent is not yet published', { agentApiName });
+
+// No — variable data baked into the message breaks aggregation.
+logger.warn(`Agent ${agentApiName} is not yet published`);
+```
+
+Match the existing field-naming convention: **camelCase** (`developerName`, `libraryId`,
+`statusCode`, `durationMs`, `errName`, `errMsg`). Reuse the same field name everywhere for
+the same concept — inconsistent names break correlation.
+
+### What the fields renderer does (so you log the right things)
+
+`CtxLogger` renders the appended breadcrumb with these rules. Log values that survive them:
+
+- **Non-primitives and empties are dropped** from the breadcrumb — `null`, `undefined`,
+  empty string, empty array, and plain objects (including `Error` objects) render nothing.
+  So never pass a raw `Error` as a field and expect it to read: log a **primitive
+  projection** instead — `errName: wrapped.name, errMsg: wrapped.message` — and, for HTTP
+  paths, `statusCode: getHttpStatusCode(error)`. Wrap first with `SfError.wrap(error)`.
+- Arrays are joined with `;`; `Date`s render as ISO.
+- Control characters (CR/LF/tab) in a value are collapsed to a space, so a field value can
+  never forge a second log line.
+- A value containing a `,` or `|` is quoted so the pair stays unambiguous.
+
+## Pick the right level
+
+Levels are contracts. Choose by who needs to act, not by how the code feels.
+
+- **error** — an unexpected failure that needs a human. State what failed, why, and what
+  happens next. Never generic ("An error occurred" is banned — name the specific failure).
+- **warn** — degraded or unexpected but handled. State what might go wrong as a result.
+- **info** — a meaningful milestone or state transition an on-call engineer cares about.
+- **debug / trace** — a decision or behavior, useful only while actively diagnosing.
+
+Expected failures are **not** errors. A 404, a "no records" lookup, a validation rejection,
+an intentional timeout/abort — these are `debug`/`info`/`warn` at most. Reserve `error` for
+the genuinely unexpected. (Example: on a not-yet-published agent we `debug` "not yet
+published"; only a lookup that actually *failed* is a `warn`.)
+
+## Where to log
+
+- Log at **system boundaries** — service entry points, external/API calls, persistence,
+  significant state transitions — not deep inside pure helpers or data transformers. The
+  caller already has the context; deep logging just duplicates it and adds noise.
+- Log the **decision, not just the data**: `threshold exceeded { value: 95, limit: 90, action: 'shutdown' }`
+  beats `value is 95`.
+- Log the **start** of an operation only when it can hang and you need "where did it stall?"
+  debugging (e.g. a long poll). Otherwise one line on completion is cleaner.
+- Include a **duration** (`durationMs`) on anything that can be slow.
+
+## Answer these on every log line
+
+Every `error` must answer all five; `info`/`warn` answer as many as apply:
+
+- **Who** — which component/method is running, and what triggered it.
+- **What** — the goal it was pursuing (for errors, what specifically it failed to do).
+- **When/Where** — where in the flow this sits; could a reader place it on a sequence diagram?
+- **Why** — for errors, the exception type/message and the offending data (scrubbed).
+- **What happens next** — required on every `error`: rethrow? retry? fall back? no-op? Is the
+  customer affected?
+
+## Loops and batches: aggregate, don't log per item
+
+Never log once per iteration. Make a loop observable by accumulating as it runs and emitting
+**one** summary when it ends.
+
+- Declare the accumulator (counts of processed/succeeded/failed/skipped, elapsed, involved
+  ids) **before** the loop and **outside** any `try`, so it survives to both the summary and
+  the catch.
+- On normal completion, log one `info` summary with the full aggregate — capture it fully,
+  don't truncate or sample (noise filters downstream; data absent at 3am cannot be rebuilt).
+- If the loop throws, the handler logs that same aggregate alongside the error, so the reader
+  sees how far it got ("failed on item 5000 of 10000; 4999 succeeded").
+
+## Error handling
+
+- **Don't log *and* re-throw.** Log where you handle (swallow) the error; re-throw where you
+  don't — double-logging creates duplicate lines up the stack. Where the codebase logs a
+  failure and still rethrows, it does so at `debug` and pairs it with a durable telemetry
+  signal (`Lifecycle.getInstance().emitTelemetry({ eventName: '..._failed' })`); the
+  telemetry, not the log, is the thing that gets acted on.
+- Never let a swallowed error vanish silently. An empty `catch {}` on a path that matters
+  needs at least a breadcrumb that distinguishes an **expected** outcome (e.g. an
+  intentional `AbortError`/timeout) from a **real** failure.
+- At `error` level include the exception detail (via the `errName`/`errMsg` projection
+  above). Don't attach stack-trace noise to `warn`/`info`.
+
+## Security and sensitive data
+
+- Never log request or response bodies — they carry PII, tokens, and secrets. Log metadata:
+  status code, size, duration.
+- Scrub PII from field values.
+- Security-sensitive operations (auth, permission changes, data export, admin actions) belong
+  in a separate, immutable audit stream — not the application log.
+
+## Hard rules
+
+- No `error` may be safely ignorable. If it can be ignored, downgrade it.
+- No message may say only "An error occurred" or any generic equivalent — name the failure.
+- No log line may require reading the source to interpret.
+- The logger must never throw and must never be the reason a request fails.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
-import { Connection, generateApiName, Lifecycle, Logger, Messages, SfError, SfProject } from '@salesforce/core';
+import { Connection, generateApiName, Lifecycle, Messages, SfError, SfProject } from '@salesforce/core';
 import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
 import {
@@ -33,7 +33,7 @@ import {
   ScriptAgentOptions,
 } from './types';
 import { MaybeMock } from './maybe-mock';
-import { decodeHtmlEntities, findLocalAgents, logCtx } from './utils';
+import { CtxLogger, decodeHtmlEntities, findLocalAgents } from './utils';
 import { ScriptAgent } from './agents/scriptAgent';
 import { ProductionAgent } from './agents/productionAgent';
 import { managerFor } from './connectionManager';
@@ -44,10 +44,10 @@ export type AgentInstance = ScriptAgent | ProductionAgent;
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agents');
 
-let logger: Logger;
-const getLogger = (): Logger => {
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
   if (!logger) {
-    logger = Logger.childFromRoot('Agent');
+    logger = CtxLogger.child('Agent');
   }
   return logger;
 };
@@ -235,7 +235,7 @@ export class Agent {
 
     // When previewing agent creation just return the response.
     if (!config.saveAgent) {
-      logCtx(getLogger(), 'debug', 'Previewing agent creation', {
+      getLogger().debug('Previewing agent creation', {
         agentName: config.agentSettings?.agentName,
         agentApiName: config.agentSettings?.agentApiName,
         saveAgent: config.saveAgent ?? false,
@@ -251,7 +251,7 @@ export class Agent {
       throw messages.createError('missingAgentName');
     }
 
-    logCtx(getLogger(), 'debug', 'Creating agent', {
+    getLogger().debug('Creating agent', {
       agentName: config.agentSettings?.agentName,
       agentApiName: config.agentSettings?.agentApiName,
       projectPath: project.getPath(),

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -273,11 +273,11 @@ export class Agent {
         // action dependencies via rootTypesWithDependencies. Older orgs fall back to the
         // legacy Agent manifest.
         const useNewFormat = supportsAiAgentDefinition(standardConnection);
-        getLogger().debug(
-          `Retrieving created agent ${apiName} using ${
-            useNewFormat ? 'new AiAgentDefinition' : 'legacy Agent'
-          } format (org API v${standardConnection.getApiVersion()})`
-        );
+        getLogger().debug('Retrieving created agent', {
+          agentApiName: apiName,
+          format: useNewFormat ? 'AiAgentDefinition' : 'Agent',
+          orgApiVersion: standardConnection.getApiVersion(),
+        });
         let metadataEntries: string[];
         if (useNewFormat) {
           // agentId is typed optional; a success response without it would otherwise NPE on the
@@ -328,15 +328,16 @@ export class Agent {
         // nothing, producing a success:true retrieve that wrote zero agent files. Surface that.
         const fileResponses = retrieveResult.getFileResponses();
         const resolvedTypes = [...new Set(fileResponses.map((f) => f.type))];
-        getLogger().debug(
-          `Agent metadata retrieve resolved ${fileResponses.length} component(s) of type(s): ${
-            resolvedTypes.join(', ') || 'none'
-          }`
-        );
+        getLogger().debug('Agent metadata retrieve resolved components', {
+          agentApiName: apiName,
+          componentCount: fileResponses.length,
+          types: resolvedTypes,
+        });
         if (useNewFormat && fileResponses.length === 0) {
-          getLogger().warn(
-            `New-format retrieve for ${apiName} resolved zero components — org (API v${standardConnection.getApiVersion()}) may have the AiAgentDefinition feature flag disabled.`
-          );
+          getLogger().warn('New-format retrieve resolved zero components; org may have the AiAgentDefinition feature flag disabled', {
+            agentApiName: apiName,
+            orgApiVersion: standardConnection.getApiVersion(),
+          });
         }
       } catch (err) {
         const error = SfError.wrap(err);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -33,7 +33,8 @@ import {
   ScriptAgentOptions,
 } from './types';
 import { MaybeMock } from './maybe-mock';
-import { CtxLogger, decodeHtmlEntities, findLocalAgents } from './utils';
+import { decodeHtmlEntities, findLocalAgents } from './utils';
+import { CtxLogger } from './ctxLogger';
 import { ScriptAgent } from './agents/scriptAgent';
 import { ProductionAgent } from './agents/productionAgent';
 import { managerFor } from './connectionManager';

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -33,7 +33,7 @@ import {
   ScriptAgentOptions,
 } from './types';
 import { MaybeMock } from './maybe-mock';
-import { decodeHtmlEntities, findLocalAgents, msgCtx } from './utils';
+import { decodeHtmlEntities, findLocalAgents, logCtx } from './utils';
 import { ScriptAgent } from './agents/scriptAgent';
 import { ProductionAgent } from './agents/productionAgent';
 import { managerFor } from './connectionManager';
@@ -235,13 +235,12 @@ export class Agent {
 
     // When previewing agent creation just return the response.
     if (!config.saveAgent) {
-      const previewCtx = {
+      logCtx(getLogger(), 'debug', 'Previewing agent creation', {
         agentName: config.agentSettings?.agentName,
         agentApiName: config.agentSettings?.agentApiName,
         saveAgent: config.saveAgent ?? false,
         projectPath: project.getPath(),
-      };
-      getLogger().debug(msgCtx('Previewing agent creation', previewCtx), previewCtx);
+      });
       await Lifecycle.getInstance().emit(AgentCreateLifecycleStages.Previewing, {});
 
       const response = await maybeMock.request<AgentCreateResponse>('POST', url, config);
@@ -252,12 +251,11 @@ export class Agent {
       throw messages.createError('missingAgentName');
     }
 
-    const creatingCtx = {
+    logCtx(getLogger(), 'debug', 'Creating agent', {
       agentName: config.agentSettings?.agentName,
       agentApiName: config.agentSettings?.agentApiName,
       projectPath: project.getPath(),
-    };
-    getLogger().debug(msgCtx('Creating agent', creatingCtx), creatingCtx);
+    });
     await Lifecycle.getInstance().emit(AgentCreateLifecycleStages.Creating, {});
     config.agentSettings.agentApiName ??= generateApiName(config.agentSettings?.agentName);
     const response = await maybeMock.request<AgentCreateResponse>('POST', url, config);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { inspect } from 'node:util';
 import * as path from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
 import { Connection, generateApiName, Lifecycle, Logger, Messages, SfError, SfProject } from '@salesforce/core';
@@ -34,7 +33,7 @@ import {
   ScriptAgentOptions,
 } from './types';
 import { MaybeMock } from './maybe-mock';
-import { decodeHtmlEntities, findLocalAgents } from './utils';
+import { decodeHtmlEntities, findLocalAgents, msgCtx } from './utils';
 import { ScriptAgent } from './agents/scriptAgent';
 import { ProductionAgent } from './agents/productionAgent';
 import { managerFor } from './connectionManager';
@@ -236,7 +235,13 @@ export class Agent {
 
     // When previewing agent creation just return the response.
     if (!config.saveAgent) {
-      getLogger().debug(`Previewing agent creation using config: ${inspect(config)} in project: ${project.getPath()}`);
+      const previewCtx = {
+        agentName: config.agentSettings?.agentName,
+        agentApiName: config.agentSettings?.agentApiName,
+        saveAgent: config.saveAgent ?? false,
+        projectPath: project.getPath(),
+      };
+      getLogger().debug(msgCtx('Previewing agent creation', previewCtx), previewCtx);
       await Lifecycle.getInstance().emit(AgentCreateLifecycleStages.Previewing, {});
 
       const response = await maybeMock.request<AgentCreateResponse>('POST', url, config);
@@ -247,7 +252,12 @@ export class Agent {
       throw messages.createError('missingAgentName');
     }
 
-    getLogger().debug(`Creating agent using config: ${inspect(config)} in project: ${project.getPath()}`);
+    const creatingCtx = {
+      agentName: config.agentSettings?.agentName,
+      agentApiName: config.agentSettings?.agentApiName,
+      projectPath: project.getPath(),
+    };
+    getLogger().debug(msgCtx('Creating agent', creatingCtx), creatingCtx);
     await Lifecycle.getInstance().emit(AgentCreateLifecycleStages.Creating, {});
     config.agentSettings.agentApiName ??= generateApiName(config.agentSettings?.agentName);
     const response = await maybeMock.request<AgentCreateResponse>('POST', url, config);

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -17,7 +17,8 @@
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { Connection, Lifecycle, SfError } from '@salesforce/core';
-import { CtxLogger, getHttpStatusCode } from './utils';
+import { getHttpStatusCode } from './utils';
+import { CtxLogger } from './ctxLogger';
 import {
   type DataLibrarySummary,
   type DataLibraryDetail,

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -16,7 +16,8 @@
 
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
-import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
+import { getHttpStatusCode, msgCtx } from './utils';
 import {
   type DataLibrarySummary,
   type DataLibraryDetail,
@@ -27,6 +28,14 @@ import {
   type FileAddResult,
   type FileListResponse,
 } from './dataLibraryTypes.js';
+
+let logger: Logger;
+const getLogger = (): Logger => {
+  if (!logger) {
+    logger = Logger.childFromRoot('AgentDataLibrary');
+  }
+  return logger;
+};
 
 export { type DataLibrarySummary, type DataLibraryDetail, type IndexingStatusResponse, type CreateLibraryInput, type UpdateLibraryInput, type UploadResult, type FileAddResult, type FileListResponse } from './dataLibraryTypes.js';
 
@@ -56,6 +65,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { sourceType: options?.sourceType, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library list request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_failed' });
       throw wrapped;
     }
@@ -72,6 +83,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { sourceType: input.groundingSource?.sourceType, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library create request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_create_failed' });
       throw wrapped;
     }
@@ -110,6 +123,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library get request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_get_failed' });
       throw wrapped;
     }
@@ -125,6 +140,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library update request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_update_failed' });
       throw wrapped;
     }
@@ -138,6 +155,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library delete request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_delete_failed' });
       throw wrapped;
     }
@@ -159,6 +178,13 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = {
+        libraryId,
+        includeArtifacts: options?.includeArtifacts ?? false,
+        statusCode: getHttpStatusCode(error),
+        err: wrapped,
+      };
+      getLogger().debug(msgCtx('Data library status request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_status_failed' });
       throw wrapped;
     }
@@ -197,6 +223,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library list-files request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_files_failed' });
       throw wrapped;
     }
@@ -210,6 +238,8 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { libraryId, fileId, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('Data library file-delete request failed', ctx), ctx);
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_delete_failed' });
       throw wrapped;
     }

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -16,8 +16,8 @@
 
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
-import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
-import { getHttpStatusCode, logCtx } from './utils';
+import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import { CtxLogger, getHttpStatusCode } from './utils';
 import {
   type DataLibrarySummary,
   type DataLibraryDetail,
@@ -29,10 +29,10 @@ import {
   type FileListResponse,
 } from './dataLibraryTypes.js';
 
-let logger: Logger;
-const getLogger = (): Logger => {
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
   if (!logger) {
-    logger = Logger.childFromRoot('AgentDataLibrary');
+    logger = CtxLogger.child('AgentDataLibrary');
   }
   return logger;
 };
@@ -65,7 +65,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library list request failed', {
+      getLogger().debug('Data library list request failed', {
         sourceType: options?.sourceType,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -87,7 +87,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library create request failed', {
+      getLogger().debug('Data library create request failed', {
         sourceType: input.groundingSource?.sourceType,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -131,7 +131,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library get request failed', {
+      getLogger().debug('Data library get request failed', {
         libraryId,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -152,7 +152,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library update request failed', {
+      getLogger().debug('Data library update request failed', {
         libraryId,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -171,7 +171,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library delete request failed', {
+      getLogger().debug('Data library delete request failed', {
         libraryId,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -198,7 +198,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library status request failed', {
+      getLogger().debug('Data library status request failed', {
         libraryId,
         includeArtifacts: options?.includeArtifacts ?? false,
         statusCode: getHttpStatusCode(error),
@@ -243,7 +243,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library list-files request failed', {
+      getLogger().debug('Data library list-files request failed', {
         libraryId,
         statusCode: getHttpStatusCode(error),
         errName: wrapped.name,
@@ -262,7 +262,7 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Data library file-delete request failed', {
+      getLogger().debug('Data library file-delete request failed', {
         libraryId,
         fileId,
         statusCode: getHttpStatusCode(error),

--- a/src/agentDataLibrary.ts
+++ b/src/agentDataLibrary.ts
@@ -17,7 +17,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
-import { getHttpStatusCode, msgCtx } from './utils';
+import { getHttpStatusCode, logCtx } from './utils';
 import {
   type DataLibrarySummary,
   type DataLibraryDetail,
@@ -65,8 +65,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { sourceType: options?.sourceType, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library list request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library list request failed', {
+        sourceType: options?.sourceType,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_failed' });
       throw wrapped;
     }
@@ -83,8 +87,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { sourceType: input.groundingSource?.sourceType, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library create request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library create request failed', {
+        sourceType: input.groundingSource?.sourceType,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_create_failed' });
       throw wrapped;
     }
@@ -123,8 +131,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library get request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library get request failed', {
+        libraryId,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_get_failed' });
       throw wrapped;
     }
@@ -140,8 +152,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library update request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library update request failed', {
+        libraryId,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_update_failed' });
       throw wrapped;
     }
@@ -155,8 +171,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library delete request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library delete request failed', {
+        libraryId,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_delete_failed' });
       throw wrapped;
     }
@@ -178,13 +198,13 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = {
+      logCtx(getLogger(), 'debug', 'Data library status request failed', {
         libraryId,
         includeArtifacts: options?.includeArtifacts ?? false,
         statusCode: getHttpStatusCode(error),
-        err: wrapped,
-      };
-      getLogger().debug(msgCtx('Data library status request failed', ctx), ctx);
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_status_failed' });
       throw wrapped;
     }
@@ -223,8 +243,12 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library list-files request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library list-files request failed', {
+        libraryId,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_list_files_failed' });
       throw wrapped;
     }
@@ -238,8 +262,13 @@ export class AgentDataLibrary {
       });
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { libraryId, fileId, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('Data library file-delete request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'Data library file-delete request failed', {
+        libraryId,
+        fileId,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_adl_file_delete_failed' });
       throw wrapped;
     }

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -23,7 +23,8 @@ import { Duration, env } from '@salesforce/kit';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
-import { CtxLogger, findAuthoringBundle } from '../utils';
+import { findAuthoringBundle } from '../utils';
+import { CtxLogger } from '../ctxLogger';
 import { managerFor } from '../connectionManager';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -23,7 +23,7 @@ import { Duration, env } from '@salesforce/kit';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
-import { findAuthoringBundle, msgCtx } from '../utils';
+import { findAuthoringBundle, logCtx } from '../utils';
 import { managerFor } from '../connectionManager';
 
 Messages.importMessagesDirectory(__dirname);
@@ -99,10 +99,7 @@ export class ScriptAgentPublisher {
    * @returns Promise<PublishAgent> The publish response
    */
   public async publishAgentJson(): Promise<PublishAgent> {
-    getLogger().debug(
-      msgCtx('Publishing agent', { developerName: this.developerName }),
-      { developerName: this.developerName }
-    );
+    logCtx(getLogger(), 'debug', 'Publishing agent', { developerName: this.developerName });
 
     const manager = await managerFor(this.connection);
 
@@ -215,11 +212,9 @@ export class ScriptAgentPublisher {
 
     const retrieveTimeout = getMetadataPollTimeout();
     const retrieveStart = Date.now();
-    const retrievePollCtx = { timeoutMinutes: retrieveTimeout.minutes };
-    getLogger().debug(msgCtx('Polling for agent metadata retrieve', retrievePollCtx), retrievePollCtx);
+    logCtx(getLogger(), 'debug', 'Polling for agent metadata retrieve', { timeoutMinutes: retrieveTimeout.minutes });
     const retrieveResult = await retrieve.pollStatus({ timeout: retrieveTimeout });
-    const retrieveDoneCtx = { durationMs: Date.now() - retrieveStart };
-    getLogger().debug(msgCtx('Agent metadata retrieve poll completed', retrieveDoneCtx), retrieveDoneCtx);
+    logCtx(getLogger(), 'debug', 'Agent metadata retrieve poll completed', { durationMs: Date.now() - retrieveStart });
 
     if (!retrieveResult.response?.success) {
       const errMessages = JSON.stringify(retrieveResult.response?.messages) ?? 'unknown';
@@ -249,8 +244,10 @@ export class ScriptAgentPublisher {
     };
     const target = `${this.developerName}.${botVersionName}`;
     authoringBundle.AiAuthoringBundle.target = target;
-    const targetCtx = { target, bundleMetaPath: this.bundleMetaPath };
-    getLogger().debug(msgCtx('Setting target on authoring bundle meta.xml', targetCtx), targetCtx);
+    logCtx(getLogger(), 'debug', 'Setting target on authoring bundle meta.xml', {
+      target,
+      bundleMetaPath: this.bundleMetaPath,
+    });
     const xmlBuilder = new XMLBuilder({
       ignoreAttributes: false,
       format: true,
@@ -266,11 +263,9 @@ export class ScriptAgentPublisher {
     });
     const deployTimeout = getMetadataPollTimeout();
     const deployStart = Date.now();
-    const deployPollCtx = { timeoutMinutes: deployTimeout.minutes };
-    getLogger().debug(msgCtx('Polling for authoring bundle deploy', deployPollCtx), deployPollCtx);
+    logCtx(getLogger(), 'debug', 'Polling for authoring bundle deploy', { timeoutMinutes: deployTimeout.minutes });
     const deployResult = await deploy.pollStatus({ timeout: deployTimeout });
-    const deployDoneCtx = { durationMs: Date.now() - deployStart };
-    getLogger().debug(msgCtx('Authoring bundle deploy poll completed', deployDoneCtx), deployDoneCtx);
+    logCtx(getLogger(), 'debug', 'Authoring bundle deploy poll completed', { durationMs: Date.now() - deployStart });
 
     // 3.remove the target from the local authoring bundle meta.xml file
     delete authoringBundle.AiAuthoringBundle.target;
@@ -302,15 +297,15 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ Id: string }>(
         `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentApiName}'`
       );
-      const publishedCtx = { agentApiName, botId: queryResult.Id };
-      getLogger().debug(msgCtx('Agent is already published', publishedCtx), publishedCtx);
+      logCtx(getLogger(), 'debug', 'Agent is already published', { agentApiName, botId: queryResult.Id });
       return queryResult.Id;
     } catch (error) {
-      const notPublishedCtx = { agentApiName, err: SfError.wrap(error) };
-      getLogger().debug(
-        msgCtx('Error querying BotDefinition; treating agent as not yet published', notPublishedCtx),
-        notPublishedCtx
-      );
+      const wrapped = SfError.wrap(error);
+      logCtx(getLogger(), 'debug', 'Error querying BotDefinition; treating agent as not yet published', {
+        agentApiName,
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       return undefined;
     }
   }
@@ -327,8 +322,10 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ DeveloperName: string }>(
         `SELECT DeveloperName FROM BotVersion WHERE Id='${botVersionId}'`
       );
-      const versionCtx = { botVersionId, developerName: queryResult.DeveloperName };
-      getLogger().debug(msgCtx('Resolved bot version developer name', versionCtx), versionCtx);
+      logCtx(getLogger(), 'debug', 'Resolved bot version developer name', {
+        botVersionId,
+        developerName: queryResult.DeveloperName,
+      });
       return queryResult.DeveloperName;
     } catch {
       const err = messages.createError('findBotVersionError', [botVersionId]);

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -18,21 +18,21 @@ import * as path from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
-import { Connection, Logger, Messages, SfError, SfProject } from '@salesforce/core';
+import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
 import { Duration, env } from '@salesforce/kit';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
-import { findAuthoringBundle, logCtx } from '../utils';
+import { CtxLogger, findAuthoringBundle } from '../utils';
 import { managerFor } from '../connectionManager';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'agentPublisher');
 
-let logger: Logger;
-const getLogger = (): Logger => {
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
   if (!logger) {
-    logger = Logger.childFromRoot('AgentPublisher');
+    logger = CtxLogger.child('AgentPublisher');
   }
   return logger;
 };
@@ -99,7 +99,7 @@ export class ScriptAgentPublisher {
    * @returns Promise<PublishAgent> The publish response
    */
   public async publishAgentJson(): Promise<PublishAgent> {
-    logCtx(getLogger(), 'debug', 'Publishing agent', { developerName: this.developerName });
+    getLogger().debug('Publishing agent', { developerName: this.developerName });
 
     const manager = await managerFor(this.connection);
 
@@ -212,9 +212,9 @@ export class ScriptAgentPublisher {
 
     const retrieveTimeout = getMetadataPollTimeout();
     const retrieveStart = Date.now();
-    logCtx(getLogger(), 'debug', 'Polling for agent metadata retrieve', { timeoutMinutes: retrieveTimeout.minutes });
+    getLogger().debug('Polling for agent metadata retrieve', { timeoutMinutes: retrieveTimeout.minutes });
     const retrieveResult = await retrieve.pollStatus({ timeout: retrieveTimeout });
-    logCtx(getLogger(), 'debug', 'Agent metadata retrieve poll completed', { durationMs: Date.now() - retrieveStart });
+    getLogger().debug('Agent metadata retrieve poll completed', { durationMs: Date.now() - retrieveStart });
 
     if (!retrieveResult.response?.success) {
       const errMessages = JSON.stringify(retrieveResult.response?.messages) ?? 'unknown';
@@ -244,7 +244,7 @@ export class ScriptAgentPublisher {
     };
     const target = `${this.developerName}.${botVersionName}`;
     authoringBundle.AiAuthoringBundle.target = target;
-    logCtx(getLogger(), 'debug', 'Setting target on authoring bundle meta.xml', {
+    getLogger().debug('Setting target on authoring bundle meta.xml', {
       target,
       bundleMetaPath: this.bundleMetaPath,
     });
@@ -263,9 +263,9 @@ export class ScriptAgentPublisher {
     });
     const deployTimeout = getMetadataPollTimeout();
     const deployStart = Date.now();
-    logCtx(getLogger(), 'debug', 'Polling for authoring bundle deploy', { timeoutMinutes: deployTimeout.minutes });
+    getLogger().debug('Polling for authoring bundle deploy', { timeoutMinutes: deployTimeout.minutes });
     const deployResult = await deploy.pollStatus({ timeout: deployTimeout });
-    logCtx(getLogger(), 'debug', 'Authoring bundle deploy poll completed', { durationMs: Date.now() - deployStart });
+    getLogger().debug('Authoring bundle deploy poll completed', { durationMs: Date.now() - deployStart });
 
     // 3.remove the target from the local authoring bundle meta.xml file
     delete authoringBundle.AiAuthoringBundle.target;
@@ -297,11 +297,11 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ Id: string }>(
         `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentApiName}'`
       );
-      logCtx(getLogger(), 'debug', 'Agent is already published', { agentApiName, botId: queryResult.Id });
+      getLogger().debug('Agent is already published', { agentApiName, botId: queryResult.Id });
       return queryResult.Id;
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'Error querying BotDefinition; treating agent as not yet published', {
+      getLogger().debug('Error querying BotDefinition; treating agent as not yet published', {
         agentApiName,
         errName: wrapped.name,
         errMsg: wrapped.message,
@@ -322,7 +322,7 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ DeveloperName: string }>(
         `SELECT DeveloperName FROM BotVersion WHERE Id='${botVersionId}'`
       );
-      logCtx(getLogger(), 'debug', 'Resolved bot version developer name', {
+      getLogger().debug('Resolved bot version developer name', {
         botVersionId,
         developerName: queryResult.DeveloperName,
       });

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -23,7 +23,7 @@ import { Duration, env } from '@salesforce/kit';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
 import { MaybeMock } from '../maybe-mock';
 import { type AgentJson, type PublishAgent, type PublishAgentJsonResponse } from '../types';
-import { findAuthoringBundle } from '../utils';
+import { findAuthoringBundle, msgCtx } from '../utils';
 import { managerFor } from '../connectionManager';
 
 Messages.importMessagesDirectory(__dirname);
@@ -99,7 +99,10 @@ export class ScriptAgentPublisher {
    * @returns Promise<PublishAgent> The publish response
    */
   public async publishAgentJson(): Promise<PublishAgent> {
-    getLogger().debug('Publishing Agent');
+    getLogger().debug(
+      msgCtx('Publishing agent', { developerName: this.developerName }),
+      { developerName: this.developerName }
+    );
 
     const manager = await managerFor(this.connection);
 
@@ -212,9 +215,11 @@ export class ScriptAgentPublisher {
 
     const retrieveTimeout = getMetadataPollTimeout();
     const retrieveStart = Date.now();
-    getLogger().debug(`Polling for agent metadata retrieve (timeout: ${retrieveTimeout.minutes} min)`);
+    const retrievePollCtx = { timeoutMinutes: retrieveTimeout.minutes };
+    getLogger().debug(msgCtx('Polling for agent metadata retrieve', retrievePollCtx), retrievePollCtx);
     const retrieveResult = await retrieve.pollStatus({ timeout: retrieveTimeout });
-    getLogger().debug(`Agent metadata retrieve poll completed in ${Date.now() - retrieveStart} ms`);
+    const retrieveDoneCtx = { durationMs: Date.now() - retrieveStart };
+    getLogger().debug(msgCtx('Agent metadata retrieve poll completed', retrieveDoneCtx), retrieveDoneCtx);
 
     if (!retrieveResult.response?.success) {
       const errMessages = JSON.stringify(retrieveResult.response?.messages) ?? 'unknown';
@@ -244,7 +249,8 @@ export class ScriptAgentPublisher {
     };
     const target = `${this.developerName}.${botVersionName}`;
     authoringBundle.AiAuthoringBundle.target = target;
-    getLogger().debug(`Setting target to ${target} in ${this.bundleMetaPath}`);
+    const targetCtx = { target, bundleMetaPath: this.bundleMetaPath };
+    getLogger().debug(msgCtx('Setting target on authoring bundle meta.xml', targetCtx), targetCtx);
     const xmlBuilder = new XMLBuilder({
       ignoreAttributes: false,
       format: true,
@@ -260,9 +266,11 @@ export class ScriptAgentPublisher {
     });
     const deployTimeout = getMetadataPollTimeout();
     const deployStart = Date.now();
-    getLogger().debug(`Polling for authoring bundle deploy (timeout: ${deployTimeout.minutes} min)`);
+    const deployPollCtx = { timeoutMinutes: deployTimeout.minutes };
+    getLogger().debug(msgCtx('Polling for authoring bundle deploy', deployPollCtx), deployPollCtx);
     const deployResult = await deploy.pollStatus({ timeout: deployTimeout });
-    getLogger().debug(`Authoring bundle deploy poll completed in ${Date.now() - deployStart} ms`);
+    const deployDoneCtx = { durationMs: Date.now() - deployStart };
+    getLogger().debug(msgCtx('Authoring bundle deploy poll completed', deployDoneCtx), deployDoneCtx);
 
     // 3.remove the target from the local authoring bundle meta.xml file
     delete authoringBundle.AiAuthoringBundle.target;
@@ -294,10 +302,15 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ Id: string }>(
         `SELECT Id FROM BotDefinition WHERE DeveloperName='${agentApiName}'`
       );
-      getLogger().debug(`Agent with developer name ${agentApiName} and id ${queryResult.Id} is already published.`);
+      const publishedCtx = { agentApiName, botId: queryResult.Id };
+      getLogger().debug(msgCtx('Agent is already published', publishedCtx), publishedCtx);
       return queryResult.Id;
     } catch (error) {
-      getLogger().debug(`Error reading agent metadata: ${JSON.stringify(error)}`);
+      const notPublishedCtx = { agentApiName, err: SfError.wrap(error) };
+      getLogger().debug(
+        msgCtx('Error querying BotDefinition; treating agent as not yet published', notPublishedCtx),
+        notPublishedCtx
+      );
       return undefined;
     }
   }
@@ -314,7 +327,8 @@ export class ScriptAgentPublisher {
       const queryResult = await standardConn.singleRecordQuery<{ DeveloperName: string }>(
         `SELECT DeveloperName FROM BotVersion WHERE Id='${botVersionId}'`
       );
-      getLogger().debug(`Bot version with id ${botVersionId} is ${queryResult.DeveloperName}.`);
+      const versionCtx = { botVersionId, developerName: queryResult.DeveloperName };
+      getLogger().debug(msgCtx('Resolved bot version developer name', versionCtx), versionCtx);
       return queryResult.DeveloperName;
     } catch {
       const err = messages.createError('findBotVersionError', [botVersionId]);

--- a/src/agents/scriptAgentPublisher.ts
+++ b/src/agents/scriptAgentPublisher.ts
@@ -190,11 +190,11 @@ export class ScriptAgentPublisher {
     const defaultPackagePath = path.resolve(this.project.getDefaultPackage().path);
 
     const useNewFormat = supportsAiAgentDefinition(standardConn);
-    getLogger().debug(
-      `Retrieving agent ${this.developerName} using ${
-        useNewFormat ? 'new AiAgentDefinition' : 'legacy Bot/GenAiPlanner'
-      } format (org API v${standardConn.getApiVersion()})`
-    );
+    getLogger().debug('Retrieving agent metadata', {
+      developerName: this.developerName,
+      format: useNewFormat ? 'AiAgentDefinition' : 'Bot/GenAiPlanner',
+      orgApiVersion: standardConn.getApiVersion(),
+    });
     const metadataEntries = useNewFormat
       ? [
           `AiAgentDefinition:${this.developerName}`,
@@ -247,15 +247,16 @@ export class ScriptAgentPublisher {
     // nothing, producing a success:true retrieve that wrote zero agent files. Surface that.
     const fileResponses = retrieveResult.getFileResponses();
     const resolvedTypes = [...new Set(fileResponses.map((f) => f.type))];
-    getLogger().debug(
-      `Agent metadata retrieve resolved ${fileResponses.length} component(s) of type(s): ${
-        resolvedTypes.join(', ') || 'none'
-      }`
-    );
+    getLogger().debug('Agent metadata retrieve resolved components', {
+      developerName: this.developerName,
+      componentCount: fileResponses.length,
+      types: resolvedTypes,
+    });
     if (useNewFormat && fileResponses.length === 0) {
-      getLogger().warn(
-        `New-format retrieve for ${this.developerName} resolved zero components — org (API v${standardConn.getApiVersion()}) may have the AiAgentDefinition feature flag disabled.`
-      );
+      getLogger().warn('New-format retrieve resolved zero components; org may have the AiAgentDefinition feature flag disabled', {
+        developerName: this.developerName,
+        orgApiVersion: standardConn.getApiVersion(),
+      });
     }
   }
 

--- a/src/apexUtils.ts
+++ b/src/apexUtils.ts
@@ -16,17 +16,17 @@
 
 import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
-import { Connection, Logger, Messages } from '@salesforce/core';
+import { Connection, Messages } from '@salesforce/core';
 import { type ApexLog, type TraceFlag } from '@salesforce/types/tooling';
-import { logCtx, sanitizeFilename } from './utils';
+import { CtxLogger, sanitizeFilename } from './utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'apexUtils');
 
-let logger: Logger;
-const getLogger = (): Logger => {
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
   if (!logger) {
-    logger = Logger.childFromRoot('AgentApexDebug');
+    logger = CtxLogger.child('AgentApexDebug');
   }
   return logger;
 };
@@ -51,7 +51,7 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
     'SELECT Id, Application, DurationMilliseconds, Location, LogLength, LogUserId, LogUser.Name, Operation, Request, StartTime, Status FROM ApexLog ORDER BY StartTime DESC';
   const queryResult = await connection.tooling.query<Record<string, ApexLog>>(query);
   if (queryResult.records.length) {
-    logCtx(getLogger(), 'debug', 'Found apex debug logs', { count: queryResult.records.length });
+    getLogger().debug('Found apex debug logs', { count: queryResult.records.length });
     for (const apexLog of queryResult.records) {
       const startTime = new Date(apexLog.StartTime as unknown as string).getTime();
       if (startTime >= start && startTime <= end) {
@@ -61,7 +61,7 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
   } else {
     // Guard against a NaN/invalid timestamp: toISOString() throws where the log line must not.
     const toIso = (n: number): string => (Number.isFinite(n) ? new Date(n).toISOString() : 'invalid');
-    logCtx(getLogger(), 'debug', 'No apex debug logs found in the requested time window', {
+    getLogger().debug('No apex debug logs found in the requested time window', {
       start: toIso(start),
       end: toIso(end),
     });
@@ -77,7 +77,7 @@ export const writeDebugLog = async (connection: Connection, log: ApexLog, output
   // eslint-disable-next-line no-underscore-dangle
   const url = `${connection.tooling._baseUrl()}/sobjects/ApexLog/${logId}/Body`;
   const logContent = await connection.tooling.request<string>(url);
-  logCtx(getLogger(), 'debug', 'Writing apex debug log to file', { logId, logFile });
+  getLogger().debug('Writing apex debug log to file', { logId, logFile });
   return writeFile(logFile, logContent);
 };
 
@@ -112,7 +112,7 @@ export const createTraceFlag = async (connection: Connection, userId: string): P
   if (!result.success) {
     throw messages.createError('traceFlagCreationError', [userId]);
   } else {
-    logCtx(getLogger(), 'debug', 'Created new apex TraceFlag', { userId, expirationDate });
+    getLogger().debug('Created new apex TraceFlag', { userId, expirationDate });
   }
 };
 
@@ -135,7 +135,7 @@ export const findTraceFlag = async (connection: Connection, userId: string): Pro
   if (traceFlagResult.totalSize > 0) {
     const traceFlag = traceFlagResult.records[0] as unknown as ApexTraceFlag;
     if (traceFlag.ExpirationDate && new Date(traceFlag.ExpirationDate) > new Date()) {
-      logCtx(getLogger(), 'debug', 'Using existing apex TraceFlag in the org', {
+      getLogger().debug('Using existing apex TraceFlag in the org', {
         userId,
         expirationDate: traceFlag.ExpirationDate,
       });

--- a/src/apexUtils.ts
+++ b/src/apexUtils.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { Connection, Logger, Messages } from '@salesforce/core';
 import { type ApexLog, type TraceFlag } from '@salesforce/types/tooling';
-import { sanitizeFilename } from './utils';
+import { msgCtx, sanitizeFilename } from './utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'apexUtils');
@@ -51,7 +51,8 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
     'SELECT Id, Application, DurationMilliseconds, Location, LogLength, LogUserId, LogUser.Name, Operation, Request, StartTime, Status FROM ApexLog ORDER BY StartTime DESC';
   const queryResult = await connection.tooling.query<Record<string, ApexLog>>(query);
   if (queryResult.records.length) {
-    getLogger().debug(`Found ${queryResult.records.length} apex debug logs.`);
+    const foundCtx = { count: queryResult.records.length };
+    getLogger().debug(msgCtx('Found apex debug logs', foundCtx), foundCtx);
     for (const apexLog of queryResult.records) {
       const startTime = new Date(apexLog.StartTime as unknown as string).getTime();
       if (startTime >= start && startTime <= end) {
@@ -59,9 +60,8 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
       }
     }
   } else {
-    getLogger().debug(
-      `No debug logs found between ${new Date(start).toDateString()} and ${new Date(end).toDateString()}`
-    );
+    const windowCtx = { start: new Date(start).toISOString(), end: new Date(end).toISOString() };
+    getLogger().debug(msgCtx('No apex debug logs found in the requested time window', windowCtx), windowCtx);
   }
 };
 
@@ -74,7 +74,7 @@ export const writeDebugLog = async (connection: Connection, log: ApexLog, output
   // eslint-disable-next-line no-underscore-dangle
   const url = `${connection.tooling._baseUrl()}/sobjects/ApexLog/${logId}/Body`;
   const logContent = await connection.tooling.request<string>(url);
-  getLogger().debug(`Writing apex debug log to file: ${logFile}`);
+  getLogger().debug(msgCtx('Writing apex debug log to file', { logId, logFile }), { logId, logFile });
   return writeFile(logFile, logContent);
 };
 
@@ -109,7 +109,7 @@ export const createTraceFlag = async (connection: Connection, userId: string): P
   if (!result.success) {
     throw messages.createError('traceFlagCreationError', [userId]);
   } else {
-    getLogger().debug(`Created new apexTraceFlag for userId: ${userId} with ExpirationDate of ${expirationDate}`);
+    getLogger().debug(msgCtx('Created new apex TraceFlag', { userId, expirationDate }), { userId, expirationDate });
   }
 };
 
@@ -132,7 +132,8 @@ export const findTraceFlag = async (connection: Connection, userId: string): Pro
   if (traceFlagResult.totalSize > 0) {
     const traceFlag = traceFlagResult.records[0] as unknown as ApexTraceFlag;
     if (traceFlag.ExpirationDate && new Date(traceFlag.ExpirationDate) > new Date()) {
-      getLogger().debug(`Using apexTraceFlag in the org with ExpirationDate of ${traceFlag.ExpirationDate}`);
+      const existingCtx = { userId, expirationDate: traceFlag.ExpirationDate };
+      getLogger().debug(msgCtx('Using existing apex TraceFlag in the org', existingCtx), existingCtx);
       return traceFlag;
     }
   }

--- a/src/apexUtils.ts
+++ b/src/apexUtils.ts
@@ -18,7 +18,8 @@ import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { Connection, Messages } from '@salesforce/core';
 import { type ApexLog, type TraceFlag } from '@salesforce/types/tooling';
-import { CtxLogger, sanitizeFilename } from './utils';
+import { sanitizeFilename } from './utils';
+import { CtxLogger } from './ctxLogger';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'apexUtils');

--- a/src/apexUtils.ts
+++ b/src/apexUtils.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { Connection, Logger, Messages } from '@salesforce/core';
 import { type ApexLog, type TraceFlag } from '@salesforce/types/tooling';
-import { msgCtx, sanitizeFilename } from './utils';
+import { logCtx, sanitizeFilename } from './utils';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/agents', 'apexUtils');
@@ -51,8 +51,7 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
     'SELECT Id, Application, DurationMilliseconds, Location, LogLength, LogUserId, LogUser.Name, Operation, Request, StartTime, Status FROM ApexLog ORDER BY StartTime DESC';
   const queryResult = await connection.tooling.query<Record<string, ApexLog>>(query);
   if (queryResult.records.length) {
-    const foundCtx = { count: queryResult.records.length };
-    getLogger().debug(msgCtx('Found apex debug logs', foundCtx), foundCtx);
+    logCtx(getLogger(), 'debug', 'Found apex debug logs', { count: queryResult.records.length });
     for (const apexLog of queryResult.records) {
       const startTime = new Date(apexLog.StartTime as unknown as string).getTime();
       if (startTime >= start && startTime <= end) {
@@ -60,8 +59,12 @@ export const getDebugLog = async (connection: Connection, start: number, end: nu
       }
     }
   } else {
-    const windowCtx = { start: new Date(start).toISOString(), end: new Date(end).toISOString() };
-    getLogger().debug(msgCtx('No apex debug logs found in the requested time window', windowCtx), windowCtx);
+    // Guard against a NaN/invalid timestamp: toISOString() throws where the log line must not.
+    const toIso = (n: number): string => (Number.isFinite(n) ? new Date(n).toISOString() : 'invalid');
+    logCtx(getLogger(), 'debug', 'No apex debug logs found in the requested time window', {
+      start: toIso(start),
+      end: toIso(end),
+    });
   }
 };
 
@@ -74,7 +77,7 @@ export const writeDebugLog = async (connection: Connection, log: ApexLog, output
   // eslint-disable-next-line no-underscore-dangle
   const url = `${connection.tooling._baseUrl()}/sobjects/ApexLog/${logId}/Body`;
   const logContent = await connection.tooling.request<string>(url);
-  getLogger().debug(msgCtx('Writing apex debug log to file', { logId, logFile }), { logId, logFile });
+  logCtx(getLogger(), 'debug', 'Writing apex debug log to file', { logId, logFile });
   return writeFile(logFile, logContent);
 };
 
@@ -109,7 +112,7 @@ export const createTraceFlag = async (connection: Connection, userId: string): P
   if (!result.success) {
     throw messages.createError('traceFlagCreationError', [userId]);
   } else {
-    getLogger().debug(msgCtx('Created new apex TraceFlag', { userId, expirationDate }), { userId, expirationDate });
+    logCtx(getLogger(), 'debug', 'Created new apex TraceFlag', { userId, expirationDate });
   }
 };
 
@@ -132,8 +135,10 @@ export const findTraceFlag = async (connection: Connection, userId: string): Pro
   if (traceFlagResult.totalSize > 0) {
     const traceFlag = traceFlagResult.records[0] as unknown as ApexTraceFlag;
     if (traceFlag.ExpirationDate && new Date(traceFlag.ExpirationDate) > new Date()) {
-      const existingCtx = { userId, expirationDate: traceFlag.ExpirationDate };
-      getLogger().debug(msgCtx('Using existing apex TraceFlag in the org', existingCtx), existingCtx);
+      logCtx(getLogger(), 'debug', 'Using existing apex TraceFlag in the org', {
+        userId,
+        expirationDate: traceFlag.ExpirationDate,
+      });
       return traceFlag;
     }
   }

--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -15,7 +15,8 @@
  */
 
 import { Connection, Lifecycle, SfError } from '@salesforce/core';
-import { CtxLogger, getHttpStatusCode } from './utils';
+import { getHttpStatusCode } from './utils';
+import { CtxLogger } from './ctxLogger';
 import {
   type ListMcpServersOptions,
   type McpServerCollection,

--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -15,7 +15,7 @@
  */
 
 import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
-import { getHttpStatusCode, msgCtx } from './utils';
+import { getHttpStatusCode, logCtx } from './utils';
 import {
   type ListMcpServersOptions,
   type McpServerCollection,
@@ -153,8 +153,14 @@ export class ApiCatalog {
       result = await connection.request<T>(req);
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      const ctx = { op, method, url, statusCode: getHttpStatusCode(error), err: wrapped };
-      getLogger().debug(msgCtx('API Catalog request failed', ctx), ctx);
+      logCtx(getLogger(), 'debug', 'API Catalog request failed', {
+        op,
+        method,
+        url,
+        statusCode: getHttpStatusCode(error),
+        errName: wrapped.name,
+        errMsg: wrapped.message,
+      });
       await ApiCatalog.emitTelemetry(`api_catalog_${op}_failed`);
       throw wrapped;
     }

--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
-import { getHttpStatusCode, logCtx } from './utils';
+import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import { CtxLogger, getHttpStatusCode } from './utils';
 import {
   type ListMcpServersOptions,
   type McpServerCollection,
@@ -30,10 +30,10 @@ import {
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
-let logger: Logger;
-const getLogger = (): Logger => {
+let logger: CtxLogger;
+const getLogger = (): CtxLogger => {
   if (!logger) {
-    logger = Logger.childFromRoot('ApiCatalog');
+    logger = CtxLogger.child('ApiCatalog');
   }
   return logger;
 };
@@ -153,7 +153,7 @@ export class ApiCatalog {
       result = await connection.request<T>(req);
     } catch (error) {
       const wrapped = SfError.wrap(error);
-      logCtx(getLogger(), 'debug', 'API Catalog request failed', {
+      getLogger().debug('API Catalog request failed', {
         op,
         method,
         url,

--- a/src/apiCatalog.ts
+++ b/src/apiCatalog.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Connection, Lifecycle, SfError } from '@salesforce/core';
+import { Connection, Lifecycle, Logger, SfError } from '@salesforce/core';
+import { getHttpStatusCode, msgCtx } from './utils';
 import {
   type ListMcpServersOptions,
   type McpServerCollection,
@@ -28,6 +29,14 @@ import {
 } from './apiCatalogTypes.js';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+let logger: Logger;
+const getLogger = (): Logger => {
+  if (!logger) {
+    logger = Logger.childFromRoot('ApiCatalog');
+  }
+  return logger;
+};
 
 function base(connection: Connection): string {
   return `/services/data/v${String(connection.version)}/api-catalog`;
@@ -144,6 +153,8 @@ export class ApiCatalog {
       result = await connection.request<T>(req);
     } catch (error) {
       const wrapped = SfError.wrap(error);
+      const ctx = { op, method, url, statusCode: getHttpStatusCode(error), err: wrapped };
+      getLogger().debug(msgCtx('API Catalog request failed', ctx), ctx);
       await ApiCatalog.emitTelemetry(`api_catalog_${op}_failed`);
       throw wrapped;
     }

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -15,7 +15,7 @@
  */
 
 import { AuthInfo, Connection, Logger, SfError } from '@salesforce/core';
-import { msgCtx, useNamedUserJwt } from './utils';
+import { logCtx, useNamedUserJwt } from './utils';
 
 /**
  * Result of JWT validation
@@ -90,17 +90,17 @@ export class ConnectionManager {
       });
     }
 
-    logger.debug(msgCtx('Creating ConnectionManager', { username }), { username });
+    logCtx(logger, 'debug', 'Creating ConnectionManager', { username });
 
     // Build two fresh, independent connections — one for org operations, one for SFAP JWT.
     // Building from username (not from the caller's connection object) guarantees the
     // caller's connection is not mutated by the JWT upgrade.
     const standardConn = await this.createConnectionFromUsername(username);
     const jwtSeed = await this.createConnectionFromUsername(username);
-    logger.debug(msgCtx('Standard and JWT seed connections created', { username }), { username });
+    logCtx(logger, 'debug', 'Standard and JWT seed connections created', { username });
 
     const jwtConn = await this.createAndValidateJwtConnection(jwtSeed, logger);
-    logger.debug(msgCtx('JWT connection created and validated', { username }), { username });
+    logCtx(logger, 'debug', 'JWT connection created and validated', { username });
 
     return new ConnectionManager(jwtConn, standardConn);
   }
@@ -121,16 +121,17 @@ export class ConnectionManager {
    */
   private static async createAndValidateJwtConnection(connection: Connection, logger: Logger): Promise<Connection> {
     const upgraded = await useNamedUserJwt(connection);
-    const upgradedCtx = { username: upgraded.getUsername() ?? undefined };
-    logger.debug(msgCtx('Connection upgraded to JWT', upgradedCtx), upgradedCtx);
+    logCtx(logger, 'debug', 'Connection upgraded to JWT', { username: upgraded.getUsername() ?? undefined });
 
     const validation = this.validateJwt(upgraded.accessToken ?? undefined);
 
     if (!validation.isValid) {
       // Breadcrumb only — the thrown InvalidJwtToken SfError below carries the full
       // validation detail + actions and is the single ERROR record for the caller.
-      const failCtx = { missingFields: validation.missingFields, isExpired: validation.isExpired };
-      logger.debug(msgCtx('JWT validation failed; throwing InvalidJwtToken', failCtx), failCtx);
+      logCtx(logger, 'debug', 'JWT validation failed; throwing InvalidJwtToken', {
+        missingFields: validation.missingFields,
+        isExpired: validation.isExpired,
+      });
       const actions = ['Ensure your Connected App has the correct scopes: chatbot_api, sfap_api, web'];
       if (validation.missingFields.length > 0) {
         actions.push(`JWT missing required fields: ${validation.missingFields.join(', ')}`);
@@ -154,16 +155,16 @@ export class ConnectionManager {
 
     if (!validation.hasRequiredFields) {
       // Degraded but proceeding — SFAP calls made with this token may fail downstream.
-      const degradedCtx = { missingFields: validation.missingFields };
-      logger.warn(msgCtx('JWT missing some expected fields; proceeding, SFAP requests may fail', degradedCtx), degradedCtx);
+      logCtx(logger, 'warn', 'JWT missing some expected fields; proceeding, SFAP requests may fail', {
+        missingFields: validation.missingFields,
+      });
     }
 
-    const passCtx = {
+    logCtx(logger, 'debug', 'JWT validation passed', {
       hasRequiredFields: validation.hasRequiredFields,
       expiresAt: validation.expiresAt,
       scopes: validation.scopes,
-    };
-    logger.debug(msgCtx('JWT validation passed', passCtx), passCtx);
+    });
 
     return upgraded;
   }

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -15,7 +15,7 @@
  */
 
 import { AuthInfo, Connection, Logger, SfError } from '@salesforce/core';
-import { useNamedUserJwt } from './utils';
+import { msgCtx, useNamedUserJwt } from './utils';
 
 /**
  * Result of JWT validation
@@ -90,17 +90,17 @@ export class ConnectionManager {
       });
     }
 
-    logger.debug(`Creating ConnectionManager for user: ${username}`);
+    logger.debug(msgCtx('Creating ConnectionManager', { username }), { username });
 
     // Build two fresh, independent connections — one for org operations, one for SFAP JWT.
     // Building from username (not from the caller's connection object) guarantees the
     // caller's connection is not mutated by the JWT upgrade.
     const standardConn = await this.createConnectionFromUsername(username);
     const jwtSeed = await this.createConnectionFromUsername(username);
-    logger.debug('Standard and JWT seed connections created');
+    logger.debug(msgCtx('Standard and JWT seed connections created', { username }), { username });
 
     const jwtConn = await this.createAndValidateJwtConnection(jwtSeed, logger);
-    logger.debug('JWT connection created and validated');
+    logger.debug(msgCtx('JWT connection created and validated', { username }), { username });
 
     return new ConnectionManager(jwtConn, standardConn);
   }
@@ -121,12 +121,16 @@ export class ConnectionManager {
    */
   private static async createAndValidateJwtConnection(connection: Connection, logger: Logger): Promise<Connection> {
     const upgraded = await useNamedUserJwt(connection);
-    logger.debug('Connection upgraded to JWT');
+    const upgradedCtx = { username: upgraded.getUsername() ?? undefined };
+    logger.debug(msgCtx('Connection upgraded to JWT', upgradedCtx), upgradedCtx);
 
     const validation = this.validateJwt(upgraded.accessToken ?? undefined);
 
     if (!validation.isValid) {
-      logger.error('JWT validation failed:', validation);
+      // Breadcrumb only — the thrown InvalidJwtToken SfError below carries the full
+      // validation detail + actions and is the single ERROR record for the caller.
+      const failCtx = { missingFields: validation.missingFields, isExpired: validation.isExpired };
+      logger.debug(msgCtx('JWT validation failed; throwing InvalidJwtToken', failCtx), failCtx);
       const actions = ['Ensure your Connected App has the correct scopes: chatbot_api, sfap_api, web'];
       if (validation.missingFields.length > 0) {
         actions.push(`JWT missing required fields: ${validation.missingFields.join(', ')}`);
@@ -149,14 +153,17 @@ export class ConnectionManager {
     }
 
     if (!validation.hasRequiredFields) {
-      logger.warn('JWT missing some expected fields:', validation.missingFields);
+      // Degraded but proceeding — SFAP calls made with this token may fail downstream.
+      const degradedCtx = { missingFields: validation.missingFields };
+      logger.warn(msgCtx('JWT missing some expected fields; proceeding, SFAP requests may fail', degradedCtx), degradedCtx);
     }
 
-    logger.debug('JWT validation passed', {
+    const passCtx = {
       hasRequiredFields: validation.hasRequiredFields,
       expiresAt: validation.expiresAt,
       scopes: validation.scopes,
-    });
+    };
+    logger.debug(msgCtx('JWT validation passed', passCtx), passCtx);
 
     return upgraded;
   }

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -15,7 +15,8 @@
  */
 
 import { AuthInfo, Connection, SfError } from '@salesforce/core';
-import { CtxLogger, useNamedUserJwt } from './utils';
+import { useNamedUserJwt } from './utils';
+import { CtxLogger } from './ctxLogger';
 
 /**
  * Result of JWT validation

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { AuthInfo, Connection, Logger, SfError } from '@salesforce/core';
-import { logCtx, useNamedUserJwt } from './utils';
+import { AuthInfo, Connection, SfError } from '@salesforce/core';
+import { CtxLogger, useNamedUserJwt } from './utils';
 
 /**
  * Result of JWT validation
@@ -80,7 +80,7 @@ export class ConnectionManager {
    * @throws {SfError} If JWT creation or validation fails, or if the connection has no username
    */
   public static async create(connection: Connection): Promise<ConnectionManager> {
-    const logger = Logger.childFromRoot('ConnectionManager');
+    const logger = CtxLogger.child('ConnectionManager');
     const username = connection.getUsername();
 
     if (!username) {
@@ -90,17 +90,17 @@ export class ConnectionManager {
       });
     }
 
-    logCtx(logger, 'debug', 'Creating ConnectionManager', { username });
+    logger.debug('Creating ConnectionManager', { username });
 
     // Build two fresh, independent connections — one for org operations, one for SFAP JWT.
     // Building from username (not from the caller's connection object) guarantees the
     // caller's connection is not mutated by the JWT upgrade.
     const standardConn = await this.createConnectionFromUsername(username);
     const jwtSeed = await this.createConnectionFromUsername(username);
-    logCtx(logger, 'debug', 'Standard and JWT seed connections created', { username });
+    logger.debug('Standard and JWT seed connections created', { username });
 
     const jwtConn = await this.createAndValidateJwtConnection(jwtSeed, logger);
-    logCtx(logger, 'debug', 'JWT connection created and validated', { username });
+    logger.debug('JWT connection created and validated', { username });
 
     return new ConnectionManager(jwtConn, standardConn);
   }
@@ -119,16 +119,16 @@ export class ConnectionManager {
    * The connection passed in is mutated (its accessToken is replaced with the JWT) — callers
    * must pass a fresh, isolated Connection rather than a connection they care about.
    */
-  private static async createAndValidateJwtConnection(connection: Connection, logger: Logger): Promise<Connection> {
+  private static async createAndValidateJwtConnection(connection: Connection, logger: CtxLogger): Promise<Connection> {
     const upgraded = await useNamedUserJwt(connection);
-    logCtx(logger, 'debug', 'Connection upgraded to JWT', { username: upgraded.getUsername() ?? undefined });
+    logger.debug('Connection upgraded to JWT', { username: upgraded.getUsername() ?? undefined });
 
     const validation = this.validateJwt(upgraded.accessToken ?? undefined);
 
     if (!validation.isValid) {
       // Breadcrumb only — the thrown InvalidJwtToken SfError below carries the full
       // validation detail + actions and is the single ERROR record for the caller.
-      logCtx(logger, 'debug', 'JWT validation failed; throwing InvalidJwtToken', {
+      logger.debug('JWT validation failed; throwing InvalidJwtToken', {
         missingFields: validation.missingFields,
         isExpired: validation.isExpired,
       });
@@ -155,12 +155,12 @@ export class ConnectionManager {
 
     if (!validation.hasRequiredFields) {
       // Degraded but proceeding — SFAP calls made with this token may fail downstream.
-      logCtx(logger, 'warn', 'JWT missing some expected fields; proceeding, SFAP requests may fail', {
+      logger.warn('JWT missing some expected fields; proceeding, SFAP requests may fail', {
         missingFields: validation.missingFields,
       });
     }
 
-    logCtx(logger, 'debug', 'JWT validation passed', {
+    logger.debug('JWT validation passed', {
       hasRequiredFields: validation.hasRequiredFields,
       expiresAt: validation.expiresAt,
       scopes: validation.scopes,

--- a/src/ctxLogger.ts
+++ b/src/ctxLogger.ts
@@ -25,14 +25,14 @@ import { Logger } from '@salesforce/core';
  *
  * Rendering rules:
  * - Non-primitive values (e.g. Error objects) and null/undefined/empty-string/empty-array
- *   are omitted — they add no readable signal. Log a primitive projection instead (e.g.
- *   `errName`/`errMsg` rather than the whole error).
+ * are omitted — they add no readable signal. Log a primitive projection instead (e.g.
+ * `errName`/`errMsg` rather than the whole error).
  * - Arrays are joined with `;` and Dates rendered as ISO.
  * - Control characters (CR/LF/tab) are collapsed to a single space so a field value can
- *   never inject a second apparent log line (CWE-117 log forging).
+ * never inject a second apparent log line (CWE-117 log forging).
  * - A rendered value containing the pair separator `,` or the message separator `|` is
- *   quoted so the pair stays unambiguous to a reader (the intra-array `;` is expected and
- *   does not trigger quoting).
+ * quoted so the pair stays unambiguous to a reader (the intra-array `;` is expected and
+ * does not trigger quoting).
  */
 const renderLogCtx = (fields: Record<string, unknown>): string =>
   Object.entries(fields)

--- a/src/ctxLogger.ts
+++ b/src/ctxLogger.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Logger } from '@salesforce/core';
+
+/**
+ * Render structured log fields as a `key=value, key=value` string for the `msg-ctx`
+ * logging convention (a static message prefix, then ` | `, then this rendering). The
+ * same field names are used here as in the structured fields object. This produces a
+ * best-effort, human-readable breadcrumb; the structured fields object remains the
+ * authoritative, machine-parseable source of truth.
+ *
+ * Rendering rules:
+ * - Non-primitive values (e.g. Error objects) and null/undefined/empty-string/empty-array
+ *   are omitted — they add no readable signal. Log a primitive projection instead (e.g.
+ *   `errName`/`errMsg` rather than the whole error).
+ * - Arrays are joined with `;` and Dates rendered as ISO.
+ * - Control characters (CR/LF/tab) are collapsed to a single space so a field value can
+ *   never inject a second apparent log line (CWE-117 log forging).
+ * - A rendered value containing the pair separator `,` or the message separator `|` is
+ *   quoted so the pair stays unambiguous to a reader (the intra-array `;` is expected and
+ *   does not trigger quoting).
+ */
+const renderLogCtx = (fields: Record<string, unknown>): string =>
+  Object.entries(fields)
+    .filter(
+      ([, v]) =>
+        v != null &&
+        v !== '' &&
+        (typeof v !== 'object' || (Array.isArray(v) && v.length > 0) || v instanceof Date)
+    )
+    .map(([k, v]) => {
+      const raw = Array.isArray(v) ? v.join(';') : v instanceof Date ? v.toISOString() : String(v);
+      const sanitized = raw.replace(/[\r\n\t]+/g, ' ');
+      const rendered = /[,|]/.test(sanitized) ? `"${sanitized}"` : sanitized;
+      return `${k}=${rendered}`;
+    })
+    .join(', ');
+
+/**
+ * Build a `msg-ctx` log message: the static `message` prefix followed by ` | ` and the
+ * rendered context. When no field renders to context, the bare message is returned so
+ * there is no dangling ` | `. Prefer a {@link CtxLogger} instance, whose level methods
+ * render and log in one call so the fields object is passed exactly once and cannot drift
+ * from the message.
+ */
+export const msgCtx = (message: string, fields: Record<string, unknown>): string => {
+  const ctx = renderLogCtx(fields);
+  return ctx ? `${message} | ${ctx}` : message;
+};
+
+/**
+ * A thin wrapper around a `@salesforce/core` {@link Logger} that emits `msg-ctx` log lines.
+ *
+ * Each level method renders `fields` into the message prefix AND passes the same `fields`
+ * object as the logger's structured-fields argument, so the human-readable rendering and
+ * the structured source-of-truth are guaranteed identical — eliminating the drift that a
+ * manual `logger.debug(msgCtx(m, ctx), ctx)` two-arg call risks.
+ *
+ * Construct one per component with {@link CtxLogger.child}, mirroring `Logger.childFromRoot`,
+ * then call it like an ordinary logger:
+ *
+ * ```ts
+ * const logger = CtxLogger.child('AgentPublisher');
+ * logger.debug('Publishing agent', { developerName });
+ * logger.warn('Failed to trigger indexing', { libraryId, errName, errMsg });
+ * ```
+ */
+export class CtxLogger {
+  public constructor(private readonly logger: Logger) {}
+
+  /** Create a `CtxLogger` backed by a named child of the root logger. */
+  public static child(name: string): CtxLogger {
+    return new CtxLogger(Logger.childFromRoot(name));
+  }
+
+  public trace(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.trace(msgCtx(message, fields), fields);
+  }
+
+  public debug(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.debug(msgCtx(message, fields), fields);
+  }
+
+  public info(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.info(msgCtx(message, fields), fields);
+  }
+
+  public warn(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.warn(msgCtx(message, fields), fields);
+  }
+
+  public error(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.error(msgCtx(message, fields), fields);
+  }
+}

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -17,12 +17,12 @@
 import { join, resolve } from 'node:path';
 import { type Stats, statSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
-import { Connection, Logger, SfError } from '@salesforce/core';
+import { Connection, SfError } from '@salesforce/core';
 import { env } from '@salesforce/kit';
 // Type-only import: erased at compile time. Only used for the `nock.Body`
 // constraint on the generic type parameter.
 import type nock from 'nock';
-import { logCtx, requestWithEndpointFallback } from './utils';
+import { CtxLogger, requestWithEndpointFallback } from './utils';
 
 type HttpHeaders = {
   [name: string]: string;
@@ -85,7 +85,7 @@ async function readDirectory<T extends nock.Body>(path: string): Promise<T[] | u
   return (await Promise.all(promises)).filter((r): r is T => !!r);
 }
 
-async function readResponses<T extends nock.Body>(mockDir: string, url: string, logger: Logger): Promise<T[]> {
+async function readResponses<T extends nock.Body>(mockDir: string, url: string, logger: CtxLogger): Promise<T[]> {
   const mockResponseName = url.replace(/\//g, '_').replace(/:/g, '_').replace(/^_/, '').split('?')[0];
   const mockResponsePath = join(mockDir, mockResponseName);
 
@@ -94,19 +94,19 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     await Promise.all([
       readJson(`${mockResponsePath}.json`)
         .then((r) => {
-          logCtx(logger, 'debug', 'Found JSON mock file', { mockResponsePath: `${mockResponsePath}.json` });
+          logger.debug('Found JSON mock file', { mockResponsePath: `${mockResponsePath}.json` });
           return r;
         })
         .catch(() => undefined),
       readPlainText(mockResponsePath)
         .then((r) => {
-          logCtx(logger, 'debug', 'Found plain text mock file', { mockResponsePath });
+          logger.debug('Found plain text mock file', { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
       readDirectory(mockResponsePath)
         .then((r) => {
-          logCtx(logger, 'debug', 'Found directory of mock files', { mockResponsePath });
+          logger.debug('Found directory of mock files', { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
@@ -121,7 +121,7 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     });
   }
 
-  logCtx(logger, 'debug', 'Loaded mock responses', { mockResponsePath, count: responses.length });
+  logger.debug('Loaded mock responses', { mockResponsePath, count: responses.length });
 
   return responses;
 }
@@ -136,10 +136,10 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
 export class MaybeMock {
   private mockDir = getMockDir();
   private mockCallCounts = new Map<string, number>();
-  private logger: Logger;
+  private logger: CtxLogger;
 
   public constructor(private connection: Connection) {
-    this.logger = Logger.childFromRoot(this.constructor.name);
+    this.logger = CtxLogger.child(this.constructor.name);
   }
 
   /**
@@ -158,7 +158,7 @@ export class MaybeMock {
     headers: HttpHeaders = {}
   ): Promise<T> {
     if (this.mockDir) {
-      logCtx(this.logger, 'debug', 'Mocking request', { method, url, mockDir: this.mockDir });
+      this.logger.debug('Mocking request', { method, url, mockDir: this.mockDir });
       const responses = await readResponses<T>(this.mockDir, url, this.logger);
       // Return mock responses directly — nock cannot intercept jsforce's undici-based
       // HTTP transport, so we short-circuit here. For polling scenarios with multiple
@@ -169,7 +169,7 @@ export class MaybeMock {
       return responses[Math.min(callIndex, responses.length - 1)];
     }
 
-    logCtx(this.logger, 'debug', 'Making request', { method, url });
+    this.logger.debug('Making request', { method, url });
 
     // For api.salesforce.com URLs, use endpoint fallback
     const isApiSalesforceUrl = url.includes('https://api.salesforce.com');

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -22,7 +22,7 @@ import { env } from '@salesforce/kit';
 // Type-only import: erased at compile time. Only used for the `nock.Body`
 // constraint on the generic type parameter.
 import type nock from 'nock';
-import { msgCtx, requestWithEndpointFallback } from './utils';
+import { logCtx, requestWithEndpointFallback } from './utils';
 
 type HttpHeaders = {
   [name: string]: string;
@@ -94,22 +94,19 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     await Promise.all([
       readJson(`${mockResponsePath}.json`)
         .then((r) => {
-          logger.debug(
-            msgCtx('Found JSON mock file', { mockResponsePath: `${mockResponsePath}.json` }),
-            { mockResponsePath: `${mockResponsePath}.json` }
-          );
+          logCtx(logger, 'debug', 'Found JSON mock file', { mockResponsePath: `${mockResponsePath}.json` });
           return r;
         })
         .catch(() => undefined),
       readPlainText(mockResponsePath)
         .then((r) => {
-          logger.debug(msgCtx('Found plain text mock file', { mockResponsePath }), { mockResponsePath });
+          logCtx(logger, 'debug', 'Found plain text mock file', { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
       readDirectory(mockResponsePath)
         .then((r) => {
-          logger.debug(msgCtx('Found directory of mock files', { mockResponsePath }), { mockResponsePath });
+          logCtx(logger, 'debug', 'Found directory of mock files', { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
@@ -124,10 +121,7 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     });
   }
 
-  logger.debug(
-    msgCtx('Loaded mock responses', { mockResponsePath, count: responses.length }),
-    { mockResponsePath, count: responses.length }
-  );
+  logCtx(logger, 'debug', 'Loaded mock responses', { mockResponsePath, count: responses.length });
 
   return responses;
 }
@@ -164,10 +158,7 @@ export class MaybeMock {
     headers: HttpHeaders = {}
   ): Promise<T> {
     if (this.mockDir) {
-      this.logger.debug(
-        msgCtx('Mocking request', { method, url, mockDir: this.mockDir }),
-        { method, url, mockDir: this.mockDir }
-      );
+      logCtx(this.logger, 'debug', 'Mocking request', { method, url, mockDir: this.mockDir });
       const responses = await readResponses<T>(this.mockDir, url, this.logger);
       // Return mock responses directly — nock cannot intercept jsforce's undici-based
       // HTTP transport, so we short-circuit here. For polling scenarios with multiple
@@ -178,7 +169,7 @@ export class MaybeMock {
       return responses[Math.min(callIndex, responses.length - 1)];
     }
 
-    this.logger.debug(msgCtx('Making request', { method, url }), { method, url });
+    logCtx(this.logger, 'debug', 'Making request', { method, url });
 
     // For api.salesforce.com URLs, use endpoint fallback
     const isApiSalesforceUrl = url.includes('https://api.salesforce.com');

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -22,7 +22,8 @@ import { env } from '@salesforce/kit';
 // Type-only import: erased at compile time. Only used for the `nock.Body`
 // constraint on the generic type parameter.
 import type nock from 'nock';
-import { CtxLogger, requestWithEndpointFallback } from './utils';
+import { requestWithEndpointFallback } from './utils';
+import { CtxLogger } from './ctxLogger';
 
 type HttpHeaders = {
   [name: string]: string;

--- a/src/maybe-mock.ts
+++ b/src/maybe-mock.ts
@@ -22,7 +22,7 @@ import { env } from '@salesforce/kit';
 // Type-only import: erased at compile time. Only used for the `nock.Body`
 // constraint on the generic type parameter.
 import type nock from 'nock';
-import { requestWithEndpointFallback } from './utils';
+import { msgCtx, requestWithEndpointFallback } from './utils';
 
 type HttpHeaders = {
   [name: string]: string;
@@ -94,19 +94,22 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     await Promise.all([
       readJson(`${mockResponsePath}.json`)
         .then((r) => {
-          logger.debug(`Found JSON mock file: ${mockResponsePath}.json`);
+          logger.debug(
+            msgCtx('Found JSON mock file', { mockResponsePath: `${mockResponsePath}.json` }),
+            { mockResponsePath: `${mockResponsePath}.json` }
+          );
           return r;
         })
         .catch(() => undefined),
       readPlainText(mockResponsePath)
         .then((r) => {
-          logger.debug(`Found plain text mock file: ${mockResponsePath}`);
+          logger.debug(msgCtx('Found plain text mock file', { mockResponsePath }), { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
       readDirectory(mockResponsePath)
         .then((r) => {
-          logger.debug(`Found directory of mock files: ${mockResponsePath}`);
+          logger.debug(msgCtx('Found directory of mock files', { mockResponsePath }), { mockResponsePath });
           return r;
         })
         .catch(() => undefined),
@@ -121,7 +124,10 @@ async function readResponses<T extends nock.Body>(mockDir: string, url: string, 
     });
   }
 
-  logger.debug(`Using responses: ${responses.map((r) => JSON.stringify(r)).join(', ')}`);
+  logger.debug(
+    msgCtx('Loaded mock responses', { mockResponsePath, count: responses.length }),
+    { mockResponsePath, count: responses.length }
+  );
 
   return responses;
 }
@@ -158,7 +164,10 @@ export class MaybeMock {
     headers: HttpHeaders = {}
   ): Promise<T> {
     if (this.mockDir) {
-      this.logger.debug(`Mocking ${method} request to ${url} using ${this.mockDir}`);
+      this.logger.debug(
+        msgCtx('Mocking request', { method, url, mockDir: this.mockDir }),
+        { method, url, mockDir: this.mockDir }
+      );
       const responses = await readResponses<T>(this.mockDir, url, this.logger);
       // Return mock responses directly — nock cannot intercept jsforce's undici-based
       // HTTP transport, so we short-circuit here. For polling scenarios with multiple
@@ -169,7 +178,7 @@ export class MaybeMock {
       return responses[Math.min(callIndex, responses.length - 1)];
     }
 
-    this.logger.debug(`Making ${method} request to ${url}`);
+    this.logger.debug(msgCtx('Making request', { method, url }), { method, url });
 
     // For api.salesforce.com URLs, use endpoint fallback
     const isApiSalesforceUrl = url.includes('https://api.salesforce.com');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -671,30 +671,62 @@ export function getHttpStatusCode(err: unknown): number | undefined {
 /**
  * Render structured log fields as a `key=value, key=value` string for the `msg-ctx`
  * logging convention (a static message prefix, then ` | `, then this rendering). The
- * same field names are used here as in the structured fields object. Non-primitive
- * values (e.g. Error objects) and null/undefined are omitted from the rendering — they
- * stay in the structured fields as the source of truth. Arrays are joined with `;` and
- * Dates rendered as ISO so neither collides with the `, ` pair separator.
+ * same field names are used here as in the structured fields object. This produces a
+ * best-effort, human-readable breadcrumb; the structured fields object remains the
+ * authoritative, machine-parseable source of truth.
+ *
+ * Rendering rules:
+ * - Non-primitive values (e.g. Error objects) and null/undefined/empty-string/empty-array
+ *   are omitted — they add no readable signal. Log a primitive projection instead (e.g.
+ *   `errName`/`errMsg` rather than the whole error).
+ * - Arrays are joined with `;` and Dates rendered as ISO.
+ * - Control characters (CR/LF/tab) are collapsed to a single space so a field value can
+ *   never inject a second apparent log line (CWE-117 log forging).
+ * - A rendered value containing the pair separator `,` or the message separator `|` is
+ *   quoted so the pair stays unambiguous to a reader (the intra-array `;` is expected and
+ *   does not trigger quoting).
  */
 const renderLogCtx = (fields: Record<string, unknown>): string =>
   Object.entries(fields)
-    .filter(([, v]) => v != null && (typeof v !== 'object' || Array.isArray(v) || v instanceof Date))
+    .filter(
+      ([, v]) =>
+        v != null &&
+        v !== '' &&
+        (typeof v !== 'object' || (Array.isArray(v) && v.length > 0) || v instanceof Date)
+    )
     .map(([k, v]) => {
-      const rendered = Array.isArray(v) ? v.join(';') : v instanceof Date ? v.toISOString() : String(v);
+      const raw = Array.isArray(v) ? v.join(';') : v instanceof Date ? v.toISOString() : String(v);
+      const sanitized = raw.replace(/[\r\n\t]+/g, ' ');
+      const rendered = /[,|]/.test(sanitized) ? `"${sanitized}"` : sanitized;
       return `${k}=${rendered}`;
     })
     .join(', ');
 
 /**
  * Build a `msg-ctx` log message: the static `message` prefix followed by ` | ` and the
- * rendered context. Pass the SAME `fields` object as the logger's structured-fields
- * argument so the human-readable rendering and the structured source-of-truth never
- * drift, e.g. `logger.debug(msgCtx('Request failed', ctx), ctx)`. When no field renders
- * to context, the bare message is returned so there is no dangling ` | `.
+ * rendered context. When no field renders to context, the bare message is returned so
+ * there is no dangling ` | `. Prefer {@link logCtx}, which renders and logs in one call
+ * so the fields object is passed exactly once and cannot drift from the message.
  */
 export const msgCtx = (message: string, fields: Record<string, unknown>): string => {
   const ctx = renderLogCtx(fields);
   return ctx ? `${message} | ${ctx}` : message;
+};
+
+/**
+ * Emit a `msg-ctx` log line in a single call: renders `fields` into the message prefix
+ * AND passes the same `fields` object as the logger's structured-fields argument, so the
+ * human-readable rendering and the structured source-of-truth are guaranteed identical —
+ * eliminating the drift that a manual `logger.debug(msgCtx(m, ctx), ctx)` two-arg call
+ * risks. Use this at every call site, e.g. `logCtx(getLogger(), 'debug', 'Request failed', ctx)`.
+ */
+export const logCtx = (
+  logger: Logger,
+  level: 'trace' | 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  fields: Record<string, unknown>
+): void => {
+  logger[level](msgCtx(message, fields), fields);
 };
 
 /**
@@ -772,8 +804,10 @@ export async function requestWithEndpointFallback<T>(
       );
     } catch (error) {
       const statusCode = getHttpStatusCode(error);
-      const ctx = { url: modifiedUrl, statusCode: statusCode ?? 'unknown' };
-      logger.debug(msgCtx('Agent API request failed for endpoint', ctx), ctx);
+      logCtx(logger, 'debug', 'Agent API request failed for endpoint', {
+        url: modifiedUrl,
+        statusCode: statusCode ?? 'unknown',
+      });
       if (statusCode === 404) {
         lastError = error;
         continue; // Try next endpoint
@@ -784,7 +818,7 @@ export async function requestWithEndpointFallback<T>(
   }
 
   // All endpoints failed with 404
-  logger.debug(msgCtx('All Agent API endpoints returned 404', { attemptedEndpoints }), { attemptedEndpoints });
+  logCtx(logger, 'debug', 'All Agent API endpoints returned 404', { attemptedEndpoints });
   throw SfError.create({
     name: 'AgentApiNotFound',
     message: `Unable to access the Salesforce Agent APIs. Ensure the user '${

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -705,8 +705,9 @@ const renderLogCtx = (fields: Record<string, unknown>): string =>
 /**
  * Build a `msg-ctx` log message: the static `message` prefix followed by ` | ` and the
  * rendered context. When no field renders to context, the bare message is returned so
- * there is no dangling ` | `. Prefer {@link logCtx}, which renders and logs in one call
- * so the fields object is passed exactly once and cannot drift from the message.
+ * there is no dangling ` | `. Prefer a {@link CtxLogger} instance, whose level methods
+ * render and log in one call so the fields object is passed exactly once and cannot drift
+ * from the message.
  */
 export const msgCtx = (message: string, fields: Record<string, unknown>): string => {
   const ctx = renderLogCtx(fields);
@@ -714,20 +715,50 @@ export const msgCtx = (message: string, fields: Record<string, unknown>): string
 };
 
 /**
- * Emit a `msg-ctx` log line in a single call: renders `fields` into the message prefix
- * AND passes the same `fields` object as the logger's structured-fields argument, so the
- * human-readable rendering and the structured source-of-truth are guaranteed identical —
- * eliminating the drift that a manual `logger.debug(msgCtx(m, ctx), ctx)` two-arg call
- * risks. Use this at every call site, e.g. `logCtx(getLogger(), 'debug', 'Request failed', ctx)`.
+ * A thin wrapper around a `@salesforce/core` {@link Logger} that emits `msg-ctx` log lines.
+ *
+ * Each level method renders `fields` into the message prefix AND passes the same `fields`
+ * object as the logger's structured-fields argument, so the human-readable rendering and
+ * the structured source-of-truth are guaranteed identical — eliminating the drift that a
+ * manual `logger.debug(msgCtx(m, ctx), ctx)` two-arg call risks.
+ *
+ * Construct one per component with {@link CtxLogger.child}, mirroring `Logger.childFromRoot`,
+ * then call it like an ordinary logger:
+ *
+ * ```ts
+ * const logger = CtxLogger.child('AgentPublisher');
+ * logger.debug('Publishing agent', { developerName });
+ * logger.warn('Failed to trigger indexing', { libraryId, errName, errMsg });
+ * ```
  */
-export const logCtx = (
-  logger: Logger,
-  level: 'trace' | 'debug' | 'info' | 'warn' | 'error',
-  message: string,
-  fields: Record<string, unknown>
-): void => {
-  logger[level](msgCtx(message, fields), fields);
-};
+export class CtxLogger {
+  public constructor(private readonly logger: Logger) {}
+
+  /** Create a `CtxLogger` backed by a named child of the root logger. */
+  public static child(name: string): CtxLogger {
+    return new CtxLogger(Logger.childFromRoot(name));
+  }
+
+  public trace(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.trace(msgCtx(message, fields), fields);
+  }
+
+  public debug(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.debug(msgCtx(message, fields), fields);
+  }
+
+  public info(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.info(msgCtx(message, fields), fields);
+  }
+
+  public warn(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.warn(msgCtx(message, fields), fields);
+  }
+
+  public error(message: string, fields: Record<string, unknown> = {}): void {
+    this.logger.error(msgCtx(message, fields), fields);
+  }
+}
 
 /**
  * Internal implementation with circular reference tracking
@@ -781,7 +812,7 @@ export async function requestWithEndpointFallback<T>(
 ): Promise<T> {
   const endpoints = ['', 'test.', 'dev.']; // Try production, test, dev in that order
   const attemptedEndpoints: string[] = [];
-  const logger = Logger.childFromRoot('AgentApiRequest');
+  const logger = CtxLogger.child('AgentApiRequest');
 
   let lastError: unknown;
 
@@ -804,7 +835,7 @@ export async function requestWithEndpointFallback<T>(
       );
     } catch (error) {
       const statusCode = getHttpStatusCode(error);
-      logCtx(logger, 'debug', 'Agent API request failed for endpoint', {
+      logger.debug('Agent API request failed for endpoint', {
         url: modifiedUrl,
         statusCode: statusCode ?? 'unknown',
       });
@@ -818,7 +849,7 @@ export async function requestWithEndpointFallback<T>(
   }
 
   // All endpoints failed with 404
-  logCtx(logger, 'debug', 'All Agent API endpoints returned 404', { attemptedEndpoints });
+  logger.debug('All Agent API endpoints returned 404', { attemptedEndpoints });
   throw SfError.create({
     name: 'AgentApiNotFound',
     message: `Unable to access the Salesforce Agent APIs. Ensure the user '${

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,9 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { appendFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { Connection, Logger, SfError, SfProject } from '@salesforce/core';
+import { Connection, SfError, SfProject } from '@salesforce/core';
 import { AvailableDefinition, NamedUserJwtResponse, type PlannerResponse, PreviewMetadata } from './types';
+import { CtxLogger } from './ctxLogger';
 
 export const metric = ['completeness', 'coherence', 'conciseness', 'output_latency_milliseconds'] as const;
 
@@ -666,98 +667,6 @@ export const logTurnToHistory = async (
  */
 export function getHttpStatusCode(err: unknown): number | undefined {
   return getHttpStatusCodeInternal(err, new Set());
-}
-
-/**
- * Render structured log fields as a `key=value, key=value` string for the `msg-ctx`
- * logging convention (a static message prefix, then ` | `, then this rendering). The
- * same field names are used here as in the structured fields object. This produces a
- * best-effort, human-readable breadcrumb; the structured fields object remains the
- * authoritative, machine-parseable source of truth.
- *
- * Rendering rules:
- * - Non-primitive values (e.g. Error objects) and null/undefined/empty-string/empty-array
- *   are omitted — they add no readable signal. Log a primitive projection instead (e.g.
- *   `errName`/`errMsg` rather than the whole error).
- * - Arrays are joined with `;` and Dates rendered as ISO.
- * - Control characters (CR/LF/tab) are collapsed to a single space so a field value can
- *   never inject a second apparent log line (CWE-117 log forging).
- * - A rendered value containing the pair separator `,` or the message separator `|` is
- *   quoted so the pair stays unambiguous to a reader (the intra-array `;` is expected and
- *   does not trigger quoting).
- */
-const renderLogCtx = (fields: Record<string, unknown>): string =>
-  Object.entries(fields)
-    .filter(
-      ([, v]) =>
-        v != null &&
-        v !== '' &&
-        (typeof v !== 'object' || (Array.isArray(v) && v.length > 0) || v instanceof Date)
-    )
-    .map(([k, v]) => {
-      const raw = Array.isArray(v) ? v.join(';') : v instanceof Date ? v.toISOString() : String(v);
-      const sanitized = raw.replace(/[\r\n\t]+/g, ' ');
-      const rendered = /[,|]/.test(sanitized) ? `"${sanitized}"` : sanitized;
-      return `${k}=${rendered}`;
-    })
-    .join(', ');
-
-/**
- * Build a `msg-ctx` log message: the static `message` prefix followed by ` | ` and the
- * rendered context. When no field renders to context, the bare message is returned so
- * there is no dangling ` | `. Prefer a {@link CtxLogger} instance, whose level methods
- * render and log in one call so the fields object is passed exactly once and cannot drift
- * from the message.
- */
-export const msgCtx = (message: string, fields: Record<string, unknown>): string => {
-  const ctx = renderLogCtx(fields);
-  return ctx ? `${message} | ${ctx}` : message;
-};
-
-/**
- * A thin wrapper around a `@salesforce/core` {@link Logger} that emits `msg-ctx` log lines.
- *
- * Each level method renders `fields` into the message prefix AND passes the same `fields`
- * object as the logger's structured-fields argument, so the human-readable rendering and
- * the structured source-of-truth are guaranteed identical — eliminating the drift that a
- * manual `logger.debug(msgCtx(m, ctx), ctx)` two-arg call risks.
- *
- * Construct one per component with {@link CtxLogger.child}, mirroring `Logger.childFromRoot`,
- * then call it like an ordinary logger:
- *
- * ```ts
- * const logger = CtxLogger.child('AgentPublisher');
- * logger.debug('Publishing agent', { developerName });
- * logger.warn('Failed to trigger indexing', { libraryId, errName, errMsg });
- * ```
- */
-export class CtxLogger {
-  public constructor(private readonly logger: Logger) {}
-
-  /** Create a `CtxLogger` backed by a named child of the root logger. */
-  public static child(name: string): CtxLogger {
-    return new CtxLogger(Logger.childFromRoot(name));
-  }
-
-  public trace(message: string, fields: Record<string, unknown> = {}): void {
-    this.logger.trace(msgCtx(message, fields), fields);
-  }
-
-  public debug(message: string, fields: Record<string, unknown> = {}): void {
-    this.logger.debug(msgCtx(message, fields), fields);
-  }
-
-  public info(message: string, fields: Record<string, unknown> = {}): void {
-    this.logger.info(msgCtx(message, fields), fields);
-  }
-
-  public warn(message: string, fields: Record<string, unknown> = {}): void {
-    this.logger.warn(msgCtx(message, fields), fields);
-  }
-
-  public error(message: string, fields: Record<string, unknown> = {}): void {
-    this.logger.error(msgCtx(message, fields), fields);
-  }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -669,6 +669,35 @@ export function getHttpStatusCode(err: unknown): number | undefined {
 }
 
 /**
+ * Render structured log fields as a `key=value, key=value` string for the `msg-ctx`
+ * logging convention (a static message prefix, then ` | `, then this rendering). The
+ * same field names are used here as in the structured fields object. Non-primitive
+ * values (e.g. Error objects) and null/undefined are omitted from the rendering — they
+ * stay in the structured fields as the source of truth. Arrays are joined with `;` and
+ * Dates rendered as ISO so neither collides with the `, ` pair separator.
+ */
+const renderLogCtx = (fields: Record<string, unknown>): string =>
+  Object.entries(fields)
+    .filter(([, v]) => v != null && (typeof v !== 'object' || Array.isArray(v) || v instanceof Date))
+    .map(([k, v]) => {
+      const rendered = Array.isArray(v) ? v.join(';') : v instanceof Date ? v.toISOString() : String(v);
+      return `${k}=${rendered}`;
+    })
+    .join(', ');
+
+/**
+ * Build a `msg-ctx` log message: the static `message` prefix followed by ` | ` and the
+ * rendered context. Pass the SAME `fields` object as the logger's structured-fields
+ * argument so the human-readable rendering and the structured source-of-truth never
+ * drift, e.g. `logger.debug(msgCtx('Request failed', ctx), ctx)`. When no field renders
+ * to context, the bare message is returned so there is no dangling ` | `.
+ */
+export const msgCtx = (message: string, fields: Record<string, unknown>): string => {
+  const ctx = renderLogCtx(fields);
+  return ctx ? `${message} | ${ctx}` : message;
+};
+
+/**
  * Internal implementation with circular reference tracking
  */
 function getHttpStatusCodeInternal(err: unknown, visited: Set<unknown>): number | undefined {
@@ -743,7 +772,8 @@ export async function requestWithEndpointFallback<T>(
       );
     } catch (error) {
       const statusCode = getHttpStatusCode(error);
-      logger.debug(`Request failed for url ${modifiedUrl} with status code ${statusCode ?? 'unknown'}`);
+      const ctx = { url: modifiedUrl, statusCode: statusCode ?? 'unknown' };
+      logger.debug(msgCtx('Agent API request failed for endpoint', ctx), ctx);
       if (statusCode === 404) {
         lastError = error;
         continue; // Try next endpoint
@@ -754,7 +784,7 @@ export async function requestWithEndpointFallback<T>(
   }
 
   // All endpoints failed with 404
-  logger.debug(`Attempted endpoints: ${attemptedEndpoints.join(', ')}`);
+  logger.debug(msgCtx('All Agent API endpoints returned 404', { attemptedEndpoints }), { attemptedEndpoints });
   throw SfError.create({
     name: 'AgentApiNotFound',
     message: `Unable to access the Salesforce Agent APIs. Ensure the user '${

--- a/test/ctxLogger.test.ts
+++ b/test/ctxLogger.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { Logger } from '@salesforce/core';
+import { CtxLogger, msgCtx } from '../src/ctxLogger';
+
+describe('msgCtx', () => {
+  it('appends rendered context after " | " and keeps the static prefix', () => {
+    expect(msgCtx('Retry limit exceeded', { retryCount: 3, maxRetries: 3 })).to.equal(
+      'Retry limit exceeded | retryCount=3, maxRetries=3'
+    );
+  });
+
+  it('returns the bare message when no field renders to context', () => {
+    expect(msgCtx('Nothing to see', { err: new Error('boom'), missing: undefined, empty: '' })).to.equal(
+      'Nothing to see'
+    );
+  });
+
+  it('omits null, undefined, empty strings, empty arrays, and non-primitive objects', () => {
+    expect(msgCtx('m', { a: [], b: '', c: null, d: undefined, e: { nested: 1 }, f: 1 })).to.equal('m | f=1');
+  });
+
+  it('joins arrays with ";" and renders Dates as ISO', () => {
+    const when = new Date('2026-01-02T03:04:05.000Z');
+    expect(msgCtx('m', { items: ['a', 'b'], when })).to.equal('m | items=a;b, when=2026-01-02T03:04:05.000Z');
+  });
+
+  it('collapses CR/LF/tab so a value cannot forge a second log line (CWE-117)', () => {
+    const rendered = msgCtx('m', { agentName: 'Acme\n2026 INFO forged' });
+    expect(rendered).to.not.match(/[\r\n\t]/);
+    expect(rendered).to.equal('m | agentName=Acme 2026 INFO forged');
+  });
+
+  it('quotes values that contain a separator so the pair stays unambiguous', () => {
+    expect(msgCtx('m', { url: 'x?a=1,b=2' })).to.equal('m | url="x?a=1,b=2"');
+  });
+});
+
+describe('CtxLogger', () => {
+  type Call = { level: string; args: unknown[] };
+
+  const makeLogger = (): { calls: Call[]; ctx: CtxLogger } => {
+    const calls: Call[] = [];
+    const record =
+      (level: string) =>
+      (...args: unknown[]): void => {
+        calls.push({ level, args });
+      };
+    const fake = {
+      trace: record('trace'),
+      debug: record('debug'),
+      info: record('info'),
+      warn: record('warn'),
+      error: record('error'),
+    };
+    return { calls, ctx: new CtxLogger(fake as unknown as Logger) };
+  };
+
+  it('forwards to the matching level with the rendered message and the same fields object', () => {
+    const { calls, ctx } = makeLogger();
+    const fields = { url: 'x?a=1,b=2', statusCode: 404 };
+
+    ctx.warn('Request failed', fields);
+
+    expect(calls).to.have.lengthOf(1);
+    expect(calls[0].level).to.equal('warn');
+    // First arg is the rendered msg-ctx string...
+    expect(calls[0].args[0]).to.equal('Request failed | url="x?a=1,b=2", statusCode=404');
+    // ...and the SAME fields object is passed through as the structured source of truth.
+    expect(calls[0].args[1]).to.equal(fields);
+  });
+
+  it('routes each level to its own underlying method', () => {
+    const { calls, ctx } = makeLogger();
+    ctx.trace('t');
+    ctx.debug('d');
+    ctx.info('i');
+    ctx.error('e');
+    expect(calls.map((c) => c.level)).to.deep.equal(['trace', 'debug', 'info', 'error']);
+  });
+
+  it('logs a bare message with an empty fields object when fields are omitted', () => {
+    const { calls, ctx } = makeLogger();
+    ctx.debug('No context here');
+    expect(calls[0].args[0]).to.equal('No context here');
+    expect(calls[0].args[1]).to.deep.equal({});
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -20,9 +20,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
-import { Connection, Logger, SfError, SfProject } from '@salesforce/core';
+import { Connection, SfError, SfProject } from '@salesforce/core';
 import {
-  CtxLogger,
   requestWithEndpointFallback,
   useNamedUserJwt,
   detectTestRunnerFromId,
@@ -39,7 +38,6 @@ import {
   readTurnIndex,
   writeTraceToHistory,
   getHistoryDir,
-  msgCtx,
   type TurnIndex,
   type TraceFileInfo,
 } from '../src/utils';
@@ -1213,88 +1211,4 @@ describe('readTurnIndex', () => {
   });
 
   after(() => void ctx);
-});
-
-describe('msgCtx', () => {
-  it('appends rendered context after " | " and keeps the static prefix', () => {
-    expect(msgCtx('Retry limit exceeded', { retryCount: 3, maxRetries: 3 })).to.equal(
-      'Retry limit exceeded | retryCount=3, maxRetries=3'
-    );
-  });
-
-  it('returns the bare message when no field renders to context', () => {
-    expect(msgCtx('Nothing to see', { err: new Error('boom'), missing: undefined, empty: '' })).to.equal(
-      'Nothing to see'
-    );
-  });
-
-  it('omits null, undefined, empty strings, empty arrays, and non-primitive objects', () => {
-    expect(msgCtx('m', { a: [], b: '', c: null, d: undefined, e: { nested: 1 }, f: 1 })).to.equal('m | f=1');
-  });
-
-  it('joins arrays with ";" and renders Dates as ISO', () => {
-    const when = new Date('2026-01-02T03:04:05.000Z');
-    expect(msgCtx('m', { items: ['a', 'b'], when })).to.equal('m | items=a;b, when=2026-01-02T03:04:05.000Z');
-  });
-
-  it('collapses CR/LF/tab so a value cannot forge a second log line (CWE-117)', () => {
-    const rendered = msgCtx('m', { agentName: 'Acme\n2026 INFO forged' });
-    expect(rendered).to.not.match(/[\r\n\t]/);
-    expect(rendered).to.equal('m | agentName=Acme 2026 INFO forged');
-  });
-
-  it('quotes values that contain a separator so the pair stays unambiguous', () => {
-    expect(msgCtx('m', { url: 'x?a=1,b=2' })).to.equal('m | url="x?a=1,b=2"');
-  });
-});
-
-describe('CtxLogger', () => {
-  type Call = { level: string; args: unknown[] };
-
-  const makeLogger = (): { calls: Call[]; ctx: CtxLogger } => {
-    const calls: Call[] = [];
-    const record =
-      (level: string) =>
-      (...args: unknown[]): void => {
-        calls.push({ level, args });
-      };
-    const fake = {
-      trace: record('trace'),
-      debug: record('debug'),
-      info: record('info'),
-      warn: record('warn'),
-      error: record('error'),
-    };
-    return { calls, ctx: new CtxLogger(fake as unknown as Logger) };
-  };
-
-  it('forwards to the matching level with the rendered message and the same fields object', () => {
-    const { calls, ctx } = makeLogger();
-    const fields = { url: 'x?a=1,b=2', statusCode: 404 };
-
-    ctx.warn('Request failed', fields);
-
-    expect(calls).to.have.lengthOf(1);
-    expect(calls[0].level).to.equal('warn');
-    // First arg is the rendered msg-ctx string...
-    expect(calls[0].args[0]).to.equal('Request failed | url="x?a=1,b=2", statusCode=404');
-    // ...and the SAME fields object is passed through as the structured source of truth.
-    expect(calls[0].args[1]).to.equal(fields);
-  });
-
-  it('routes each level to its own underlying method', () => {
-    const { calls, ctx } = makeLogger();
-    ctx.trace('t');
-    ctx.debug('d');
-    ctx.info('i');
-    ctx.error('e');
-    expect(calls.map((c) => c.level)).to.deep.equal(['trace', 'debug', 'info', 'error']);
-  });
-
-  it('logs a bare message with an empty fields object when fields are omitted', () => {
-    const { calls, ctx } = makeLogger();
-    ctx.debug('No context here');
-    expect(calls[0].args[0]).to.equal('No context here');
-    expect(calls[0].args[1]).to.deep.equal({});
-  });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -38,6 +38,7 @@ import {
   readTurnIndex,
   writeTraceToHistory,
   getHistoryDir,
+  msgCtx,
   type TurnIndex,
   type TraceFileInfo,
 } from '../src/utils';
@@ -1211,4 +1212,37 @@ describe('readTurnIndex', () => {
   });
 
   after(() => void ctx);
+});
+
+describe('msgCtx', () => {
+  it('appends rendered context after " | " and keeps the static prefix', () => {
+    expect(msgCtx('Retry limit exceeded', { retryCount: 3, maxRetries: 3 })).to.equal(
+      'Retry limit exceeded | retryCount=3, maxRetries=3'
+    );
+  });
+
+  it('returns the bare message when no field renders to context', () => {
+    expect(msgCtx('Nothing to see', { err: new Error('boom'), missing: undefined, empty: '' })).to.equal(
+      'Nothing to see'
+    );
+  });
+
+  it('omits null, undefined, empty strings, empty arrays, and non-primitive objects', () => {
+    expect(msgCtx('m', { a: [], b: '', c: null, d: undefined, e: { nested: 1 }, f: 1 })).to.equal('m | f=1');
+  });
+
+  it('joins arrays with ";" and renders Dates as ISO', () => {
+    const when = new Date('2026-01-02T03:04:05.000Z');
+    expect(msgCtx('m', { items: ['a', 'b'], when })).to.equal('m | items=a;b, when=2026-01-02T03:04:05.000Z');
+  });
+
+  it('collapses CR/LF/tab so a value cannot forge a second log line (CWE-117)', () => {
+    const rendered = msgCtx('m', { agentName: 'Acme\n2026 INFO forged' });
+    expect(rendered).to.not.match(/[\r\n\t]/);
+    expect(rendered).to.equal('m | agentName=Acme 2026 INFO forged');
+  });
+
+  it('quotes values that contain a separator so the pair stays unambiguous', () => {
+    expect(msgCtx('m', { url: 'x?a=1,b=2' })).to.equal('m | url="x?a=1,b=2"');
+  });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -20,8 +20,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
-import { Connection, SfError, SfProject } from '@salesforce/core';
+import { Connection, Logger, SfError, SfProject } from '@salesforce/core';
 import {
+  CtxLogger,
   requestWithEndpointFallback,
   useNamedUserJwt,
   detectTestRunnerFromId,
@@ -1244,5 +1245,56 @@ describe('msgCtx', () => {
 
   it('quotes values that contain a separator so the pair stays unambiguous', () => {
     expect(msgCtx('m', { url: 'x?a=1,b=2' })).to.equal('m | url="x?a=1,b=2"');
+  });
+});
+
+describe('CtxLogger', () => {
+  type Call = { level: string; args: unknown[] };
+
+  const makeLogger = (): { calls: Call[]; ctx: CtxLogger } => {
+    const calls: Call[] = [];
+    const record =
+      (level: string) =>
+      (...args: unknown[]): void => {
+        calls.push({ level, args });
+      };
+    const fake = {
+      trace: record('trace'),
+      debug: record('debug'),
+      info: record('info'),
+      warn: record('warn'),
+      error: record('error'),
+    };
+    return { calls, ctx: new CtxLogger(fake as unknown as Logger) };
+  };
+
+  it('forwards to the matching level with the rendered message and the same fields object', () => {
+    const { calls, ctx } = makeLogger();
+    const fields = { url: 'x?a=1,b=2', statusCode: 404 };
+
+    ctx.warn('Request failed', fields);
+
+    expect(calls).to.have.lengthOf(1);
+    expect(calls[0].level).to.equal('warn');
+    // First arg is the rendered msg-ctx string...
+    expect(calls[0].args[0]).to.equal('Request failed | url="x?a=1,b=2", statusCode=404');
+    // ...and the SAME fields object is passed through as the structured source of truth.
+    expect(calls[0].args[1]).to.equal(fields);
+  });
+
+  it('routes each level to its own underlying method', () => {
+    const { calls, ctx } = makeLogger();
+    ctx.trace('t');
+    ctx.debug('d');
+    ctx.info('i');
+    ctx.error('e');
+    expect(calls.map((c) => c.level)).to.deep.equal(['trace', 'debug', 'info', 'error']);
+  });
+
+  it('logs a bare message with an empty fields object when fields are omitted', () => {
+    const { calls, ctx } = makeLogger();
+    ctx.debug('No context here');
+    expect(calls[0].args[0]).to.equal('No context here');
+    expect(calls[0].args[1]).to.deep.equal({});
   });
 });


### PR DESCRIPTION
## What

Standardizes logging across the library to the **msg-ctx** convention: each log message is a static prefix followed by ` | ` and a `key=value` context rendering, while the structured fields object is **still emitted** as the source of truth.

Example:
```ts
const ctx = { libraryId, statusCode: getHttpStatusCode(error), err: wrapped };
getLogger().debug(msgCtx('Data library get request failed', ctx), ctx);
// message: "Data library get request failed | libraryId=..., statusCode=404"
// fields:  { libraryId, statusCode, err }
```

## How

- New shared `msgCtx(message, fields)` helper in `src/utils.ts`. The same `fields` object is passed to both `msgCtx()` and the logger's structured-fields argument so the human-readable rendering and the structured source-of-truth never drift.
- The renderer omits Error objects / null / undefined from the message string (they stay in the fields), joins arrays with `;`, and renders Dates as ISO — so nothing collides with the `, ` separator and there is no dangling ` | ` when no field renders.
- Converted every log call site in: `agent`, `agentDataLibrary`, `apiCatalog`, `connectionManager`, `apexUtils`, `maybe-mock`, and `scriptAgentPublisher`.

## Verification

- `yarn tsc -b` — passes
- `yarn mocha` — 413 passing, 1 pending, 0 failing

_Note: `yarn lint` is currently broken by a pre-existing `eslint.config.mjs` "config is not iterable" environment issue, unrelated to these changes._