### PR TITLE
feat: add PROMPT subject support for NGT (Agentforce Studio) test creation @W-23524165@

### DIFF
--- a/messages/agentTest.md
+++ b/messages/agentTest.md
@@ -73,3 +73,15 @@ NGT test case %s, input %s has a `promptInput` entry missing a non-blank `refere
 # ngtPromptInputMissingValue
 
 NGT test case %s, input %s: promptInput '%s' requires a non-blank `value`.
+
+# ngtUnknownScorerName
+
+NGT test case %s: unknown scorer name '%s'. The deploy will be validated by the server.
+
+# ngtScorerUnsupportedForSubject
+
+NGT test case %s: scorer '%s' is not supported for subject type '%s'. The deploy will be validated by the server.
+
+# ngtUnknownSubjectType
+
+NGT test spec has an unrecognized `subjectType` '%s'. Must be one of: AGENT, PROMPT.

--- a/messages/agentTest.md
+++ b/messages/agentTest.md
@@ -61,3 +61,15 @@ Both an AiEvaluationDefinition and an AiTestingDefinition exist for '%s' in the 
 # ngtSpecCannotProduceLegacyMetadata
 
 This AgentTest holds an NGT (`NgtTestSpec`) spec but `getMetadata()` returns the legacy `AiEvaluationDefinition` shape. Use `convertToTestingMetadata` + `buildTestingMetadataXml` to serialize an NGT spec to its `AiTestingDefinition` XML.
+
+# ngtPromptInputSetEmpty
+
+NGT test case %s, input %s must define at least one entry under `promptInput:`.
+
+# ngtPromptInputMissingReferenceName
+
+NGT test case %s, input %s has a `promptInput` entry missing a non-blank `referenceName`.
+
+# ngtPromptInputMissingValue
+
+NGT test case %s, input %s: promptInput '%s' requires a non-blank `value`.

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -153,8 +153,10 @@ export class AgentTest {
 
     if (testRunner === 'agentforce-studio') {
       const ngtSpec = parse(rawSpec) as NgtTestSpec;
-      const isMultiAgent =
-        ngtSpec.subjectType === 'PROMPT' ? false : await fetchIsMultiAgent(connection, ngtSpec.subjectName);
+      const isMultiAgent = await dispatchBySubjectType(ngtSpec, {
+        AGENT: (s) => fetchIsMultiAgent(connection, s.subjectName),
+        PROMPT: () => Promise.resolve(false),
+      });
       validateNgtSpec(ngtSpec, { isMultiAgent });
       await lifecycle.emit(AgentTestCreateLifecycleStages.CreatingLocalMetadata, {});
 
@@ -568,17 +570,33 @@ const buildMetadataXml = (data: AiEvaluationDefinition): string => {
  * error at a time. Emits a Lifecycle warning (does not throw) for unknown
  * scorer names — Core's MD validator catches those at deploy time.
  */
+/** Routes a subjectType-discriminated value to its AGENT or PROMPT handler. */
+const dispatchBySubjectType = <U extends { subjectType: 'AGENT' | 'PROMPT' }, R>(
+  value: U,
+  handlers: {
+    AGENT: (v: Extract<U, { subjectType: 'AGENT' }>) => R;
+    PROMPT: (v: Extract<U, { subjectType: 'PROMPT' }>) => R;
+  }
+): R => {
+  if (value.subjectType === 'AGENT') {
+    return handlers.AGENT(value as Extract<U, { subjectType: 'AGENT' }>);
+  }
+  return handlers.PROMPT(value as Extract<U, { subjectType: 'PROMPT' }>);
+};
+
 export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean }): void => {
   if (!spec.testCases || spec.testCases.length === 0) {
     throw ngtError('ngtMissingTestCases');
   }
 
-  if (spec.subjectType === 'PROMPT') {
-    validatePromptTestCases(spec.testCases);
-    return;
-  }
+  dispatchBySubjectType(spec, {
+    AGENT: (s) => validateAgentTestCases(s.testCases, ctx),
+    PROMPT: (s) => validatePromptTestCases(s.testCases),
+  });
+};
 
-  spec.testCases.forEach((testCase, tcIdx) => {
+const validateAgentTestCases = (testCases: NgtTestCase[], ctx: { isMultiAgent: boolean }): void => {
+  testCases.forEach((testCase, tcIdx) => {
     if (!testCase.inputs || testCase.inputs.length === 0) {
       throw ngtError('ngtTestCaseMissingInputs', [tcIdx + 1]);
     }
@@ -586,7 +604,7 @@ export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean 
       throw ngtError('ngtTestCaseMissingScorers', [tcIdx + 1]);
     }
 
-    validateScorers(testCase.scorers, tcIdx);
+    validateScorers(testCase.scorers, tcIdx, 'AGENT');
 
     const hasTaskResolution = testCase.scorers.some((s) => s.name === 'task_resolution');
     if (hasTaskResolution) {
@@ -618,8 +636,8 @@ export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean 
   });
 };
 
-/** Shared by both subject types: unknown-name warning + needsExpected check. */
-const validateScorers = (scorers: NgtTestCaseScorer[], tcIdx: number): void => {
+/** Shared by both subject types: unknown-name warning + subject-scoping warning + needsExpected check. */
+const validateScorers = (scorers: NgtTestCaseScorer[], tcIdx: number, subjectType: NgtTestSpec['subjectType']): void => {
   scorers.forEach((scorer) => {
     if (!isNgtScorerName(scorer.name)) {
       const unknownName = String(scorer.name);
@@ -629,6 +647,11 @@ const validateScorers = (scorers: NgtTestCaseScorer[], tcIdx: number): void => {
       return;
     }
     const entry = NgtScorerCatalog[scorer.name];
+    if (!entry.supportedSubjects.includes(subjectType)) {
+      void Lifecycle.getInstance().emitWarning(
+        `Scorer '${scorer.name}' is not supported for subject type '${subjectType}'. The deploy will be validated by the server.`
+      );
+    }
     if (entry.needsExpected && (scorer.expected === undefined || scorer.expected === '')) {
       throw ngtError('ngtScorerMissingExpected', [scorer.name, tcIdx + 1]);
     }
@@ -652,7 +675,7 @@ const validatePromptTestCases = (testCases: NgtPromptTestCase[]): void => {
       throw ngtError('ngtTestCaseMissingScorers', [tcIdx + 1]);
     }
 
-    validateScorers(testCase.scorers, tcIdx);
+    validateScorers(testCase.scorers, tcIdx, 'PROMPT');
 
     testCase.inputs.forEach((inputSet, inputIdx) => {
       if (!inputSet.promptInput || inputSet.promptInput.length === 0) {
@@ -694,30 +717,15 @@ const fetchIsMultiAgent = async (connection: Connection, subjectName: string): P
  *
  * Must be called after `validateNgtSpec`.
  */
-export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition => {
-  if (spec.subjectType === 'PROMPT') {
-    const testCases: AiPromptTestCase[] = [];
-    let counter = 1;
-    for (const tc of spec.testCases) {
-      const sharedScorers = tc.scorers.map(toScorerXml);
-      for (const inputSet of tc.inputs) {
-        testCases.push({
-          number: counter++,
-          inputs: toPromptInputsXml(inputSet),
-          scorer: sharedScorers,
-        });
-      }
-    }
-    return {
-      ...(spec.description && { description: spec.description }),
-      name: spec.name,
-      subjectName: spec.subjectName,
-      subjectType: 'PROMPT',
-      ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
-      testCase: testCases,
-    };
-  }
+export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition =>
+  dispatchBySubjectType<NgtTestSpec, AiTestingDefinition>(spec, {
+    AGENT: convertToTestingMetadataAgent,
+    PROMPT: convertToTestingMetadataPrompt,
+  });
 
+const convertToTestingMetadataAgent = (
+  spec: Extract<NgtTestSpec, { subjectType: 'AGENT' }>
+): Extract<AiTestingDefinition, { subjectType: 'AGENT' }> => {
   const testCases: AiTestCase[] = [];
   let counter = 1;
   for (const tc of spec.testCases) {
@@ -735,6 +743,31 @@ export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition
     name: spec.name,
     subjectName: spec.subjectName,
     subjectType: 'AGENT',
+    ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
+    testCase: testCases,
+  };
+};
+
+const convertToTestingMetadataPrompt = (
+  spec: Extract<NgtTestSpec, { subjectType: 'PROMPT' }>
+): Extract<AiTestingDefinition, { subjectType: 'PROMPT' }> => {
+  const testCases: AiPromptTestCase[] = [];
+  let counter = 1;
+  for (const tc of spec.testCases) {
+    const sharedScorers = tc.scorers.map(toScorerXml);
+    for (const inputSet of tc.inputs) {
+      testCases.push({
+        number: counter++,
+        inputs: toPromptInputsXml(inputSet),
+        scorer: sharedScorers,
+      });
+    }
+  }
+  return {
+    ...(spec.description && { description: spec.description }),
+    name: spec.name,
+    subjectName: spec.subjectName,
+    subjectType: 'PROMPT',
     ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
     testCase: testCases,
   };
@@ -843,30 +876,40 @@ export const parseNgtMetadataXml = (xml: string): AiTestingDefinition => {
  * Inverse of {@link convertToTestingMetadata}; collapses contiguous test cases that share
  * an identical scorer set into a single multi-input case.
  */
-export const convertToNgtSpec = (data: AiTestingDefinition): NgtTestSpec => {
-  if (data.subjectType === 'PROMPT') {
-    const flatCases = ensureArray(data.testCase).map((tc) => parsePromptTestCaseXml(tc));
-    const collapsedCases = collapseContiguousTestCases(flatCases);
+export const convertToNgtSpec = (data: AiTestingDefinition): NgtTestSpec =>
+  dispatchBySubjectType<AiTestingDefinition, NgtTestSpec>(data, {
+    AGENT: convertToNgtSpecAgent,
+    PROMPT: convertToNgtSpecPrompt,
+  });
 
-    const spec: NgtTestSpec = {
-      name: String(data.name),
-      subjectType: 'PROMPT',
-      subjectName: String(data.subjectName),
-      testCases: collapsedCases,
-    };
-    if (data.description !== undefined && data.description !== '') spec.description = String(data.description);
-    if (data.subjectVersion !== undefined && data.subjectVersion !== '') {
-      spec.subjectVersion = String(data.subjectVersion);
-    }
-    return spec;
-  }
-
+const convertToNgtSpecAgent = (
+  data: Extract<AiTestingDefinition, { subjectType: 'AGENT' }>
+): Extract<NgtTestSpec, { subjectType: 'AGENT' }> => {
   const flatCases = ensureArray(data.testCase).map((tc) => parseTestCaseXml(tc));
   const collapsedCases = collapseContiguousTestCases(flatCases);
 
-  const spec: NgtTestSpec = {
+  const spec: Extract<NgtTestSpec, { subjectType: 'AGENT' }> = {
     name: String(data.name),
     subjectType: 'AGENT',
+    subjectName: String(data.subjectName),
+    testCases: collapsedCases,
+  };
+  if (data.description !== undefined && data.description !== '') spec.description = String(data.description);
+  if (data.subjectVersion !== undefined && data.subjectVersion !== '') {
+    spec.subjectVersion = String(data.subjectVersion);
+  }
+  return spec;
+};
+
+const convertToNgtSpecPrompt = (
+  data: Extract<AiTestingDefinition, { subjectType: 'PROMPT' }>
+): Extract<NgtTestSpec, { subjectType: 'PROMPT' }> => {
+  const flatCases = ensureArray(data.testCase).map((tc) => parsePromptTestCaseXml(tc));
+  const collapsedCases = collapseContiguousTestCases(flatCases);
+
+  const spec: Extract<NgtTestSpec, { subjectType: 'PROMPT' }> = {
+    name: String(data.name),
+    subjectType: 'PROMPT',
     subjectName: String(data.subjectName),
     testCases: collapsedCases,
   };

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -578,10 +578,10 @@ const dispatchBySubjectType = <U extends { subjectType: 'AGENT' | 'PROMPT' }, R>
     PROMPT: (v: Extract<U, { subjectType: 'PROMPT' }>) => R;
   }
 ): R => {
-  if (value.subjectType === 'AGENT') {
-    return handlers.AGENT(value as Extract<U, { subjectType: 'AGENT' }>);
+  if (value.subjectType === 'PROMPT') {
+    return handlers.PROMPT(value as Extract<U, { subjectType: 'PROMPT' }>);
   }
-  return handlers.PROMPT(value as Extract<U, { subjectType: 'PROMPT' }>);
+  return handlers.AGENT(value as Extract<U, { subjectType: 'AGENT' }>);
 };
 
 export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean }): void => {

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -578,10 +578,14 @@ const dispatchBySubjectType = <U extends { subjectType: 'AGENT' | 'PROMPT' }, R>
     PROMPT: (v: Extract<U, { subjectType: 'PROMPT' }>) => R;
   }
 ): R => {
-  if (value.subjectType === 'PROMPT') {
+  const subjectType: unknown = value.subjectType;
+  if (subjectType === 'PROMPT') {
     return handlers.PROMPT(value as Extract<U, { subjectType: 'PROMPT' }>);
   }
-  return handlers.AGENT(value as Extract<U, { subjectType: 'AGENT' }>);
+  if (subjectType === 'AGENT') {
+    return handlers.AGENT(value as Extract<U, { subjectType: 'AGENT' }>);
+  }
+  throw ngtError('ngtUnknownSubjectType', [String(subjectType)]);
 };
 
 export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean }): void => {

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -585,6 +585,11 @@ const dispatchBySubjectType = <U extends { subjectType: 'AGENT' | 'PROMPT' }, R>
 };
 
 export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean }): void => {
+  const subjectType: unknown = spec.subjectType;
+  if (subjectType !== 'AGENT' && subjectType !== 'PROMPT') {
+    throw ngtError('ngtUnknownSubjectType', [String(subjectType)]);
+  }
+
   if (!spec.testCases || spec.testCases.length === 0) {
     throw ngtError('ngtMissingTestCases');
   }
@@ -641,15 +646,13 @@ const validateScorers = (scorers: NgtTestCaseScorer[], tcIdx: number, subjectTyp
   scorers.forEach((scorer) => {
     if (!isNgtScorerName(scorer.name)) {
       const unknownName = String(scorer.name);
-      void Lifecycle.getInstance().emitWarning(
-        `Unknown NGT scorer name '${unknownName}'. The deploy will be validated by the server.`
-      );
+      void Lifecycle.getInstance().emitWarning(messages.getMessage('ngtUnknownScorerName', [tcIdx + 1, unknownName]));
       return;
     }
     const entry = NgtScorerCatalog[scorer.name];
     if (!entry.supportedSubjects.includes(subjectType)) {
       void Lifecycle.getInstance().emitWarning(
-        `Scorer '${scorer.name}' is not supported for subject type '${subjectType}'. The deploy will be validated by the server.`
+        messages.getMessage('ngtScorerUnsupportedForSubject', [tcIdx + 1, scorer.name, subjectType])
       );
     }
     if (entry.needsExpected && (scorer.expected === undefined || scorer.expected === '')) {
@@ -682,7 +685,7 @@ const validatePromptTestCases = (testCases: NgtPromptTestCase[]): void => {
         throw ngtError('ngtPromptInputSetEmpty', [tcIdx + 1, inputIdx + 1]);
       }
       inputSet.promptInput.forEach((pi) => {
-        if (!pi?.referenceName?.trim()) {
+        if (pi?.referenceName === undefined || pi.referenceName === null || !String(pi.referenceName).trim()) {
           throw ngtError('ngtPromptInputMissingReferenceName', [tcIdx + 1, inputIdx + 1]);
         }
         if (pi.value === undefined || pi.value === null || !String(pi.value).trim()) {
@@ -803,8 +806,8 @@ const toInputsXml = (input: NgtTestCaseInput): AiTestCase['inputs'] => {
 
 const toPromptInputsXml = (inputSet: NgtPromptInputSet): AiTestCasePromptInputXml => ({
   promptInput: inputSet.promptInput.map((pi) => ({
-    referenceName: pi.referenceName,
-    value: pi.value,
+    referenceName: String(pi.referenceName),
+    value: String(pi.value),
   })),
 });
 
@@ -946,8 +949,8 @@ const parseTestCaseXml = (tc: AiTestCase): NgtTestCase => {
 
 const parsePromptTestCaseXml = (tc: AiPromptTestCase): NgtPromptTestCase => {
   const promptInput = ensureArray(tc.inputs?.promptInput).map((pi) => ({
-    referenceName: String(pi.referenceName),
-    value: String(pi.value),
+    referenceName: String(pi.referenceName ?? ''),
+    value: String(pi.value ?? ''),
   }));
   const scorers = ensureArray(tc.scorer).map((s) => parseScorerXml(s));
   return { inputs: [{ promptInput }], scorers };

--- a/src/agentTest.ts
+++ b/src/agentTest.ts
@@ -29,6 +29,8 @@ import {
   AiTestCaseScorer,
   AiTestingDefinition,
   AiConversationTurnXml,
+  AiPromptTestCase,
+  AiTestCasePromptInputXml,
   TestSpec,
   MetadataExpectation,
   NgtTestSpec,
@@ -36,6 +38,8 @@ import {
   NgtTestCaseInput,
   NgtTestCaseScorer,
   NgtConversationTurn,
+  NgtPromptInputSet,
+  NgtPromptTestCase,
 } from './types.js';
 import { isNgtScorerName, NgtScorerCatalog } from './ngtScorerCatalog';
 import { metric, sanitizeFilename, TestRunnerType } from './utils';
@@ -149,7 +153,8 @@ export class AgentTest {
 
     if (testRunner === 'agentforce-studio') {
       const ngtSpec = parse(rawSpec) as NgtTestSpec;
-      const isMultiAgent = await fetchIsMultiAgent(connection, ngtSpec.subjectName);
+      const isMultiAgent =
+        ngtSpec.subjectType === 'PROMPT' ? false : await fetchIsMultiAgent(connection, ngtSpec.subjectName);
       validateNgtSpec(ngtSpec, { isMultiAgent });
       await lifecycle.emit(AgentTestCreateLifecycleStages.CreatingLocalMetadata, {});
 
@@ -367,7 +372,7 @@ const isNgtSpec = (spec: TestSpec | NgtTestSpec): spec is NgtTestSpec =>
 
 /** Discriminate between `AiEvaluationDefinition` and `AiTestingDefinition` at runtime. */
 const isNgtMetadata = (data: AiEvaluationDefinition | AiTestingDefinition): data is AiTestingDefinition => {
-  const cases = ensureArray((data as AiTestingDefinition).testCase);
+  const cases = ensureArray((data as AiTestingDefinition).testCase as AiTestCase[]);
   if (cases.length === 0) return false;
   return 'scorer' in cases[0];
 };
@@ -568,6 +573,11 @@ export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean 
     throw ngtError('ngtMissingTestCases');
   }
 
+  if (spec.subjectType === 'PROMPT') {
+    validatePromptTestCases(spec.testCases);
+    return;
+  }
+
   spec.testCases.forEach((testCase, tcIdx) => {
     if (!testCase.inputs || testCase.inputs.length === 0) {
       throw ngtError('ngtTestCaseMissingInputs', [tcIdx + 1]);
@@ -576,19 +586,7 @@ export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean 
       throw ngtError('ngtTestCaseMissingScorers', [tcIdx + 1]);
     }
 
-    testCase.scorers.forEach((scorer) => {
-      if (!isNgtScorerName(scorer.name)) {
-        const unknownName = String(scorer.name);
-        void Lifecycle.getInstance().emitWarning(
-          `Unknown NGT scorer name '${unknownName}'. The deploy will be validated by the server.`
-        );
-        return;
-      }
-      const entry = NgtScorerCatalog[scorer.name];
-      if (entry.needsExpected && (scorer.expected === undefined || scorer.expected === '')) {
-        throw ngtError('ngtScorerMissingExpected', [scorer.name, tcIdx + 1]);
-      }
-    });
+    validateScorers(testCase.scorers, tcIdx);
 
     const hasTaskResolution = testCase.scorers.some((s) => s.name === 'task_resolution');
     if (hasTaskResolution) {
@@ -620,6 +618,58 @@ export const validateNgtSpec = (spec: NgtTestSpec, ctx: { isMultiAgent: boolean 
   });
 };
 
+/** Shared by both subject types: unknown-name warning + needsExpected check. */
+const validateScorers = (scorers: NgtTestCaseScorer[], tcIdx: number): void => {
+  scorers.forEach((scorer) => {
+    if (!isNgtScorerName(scorer.name)) {
+      const unknownName = String(scorer.name);
+      void Lifecycle.getInstance().emitWarning(
+        `Unknown NGT scorer name '${unknownName}'. The deploy will be validated by the server.`
+      );
+      return;
+    }
+    const entry = NgtScorerCatalog[scorer.name];
+    if (entry.needsExpected && (scorer.expected === undefined || scorer.expected === '')) {
+      throw ngtError('ngtScorerMissingExpected', [scorer.name, tcIdx + 1]);
+    }
+  });
+};
+
+/**
+ * PROMPT-only structural + content validation. Mirrors Core's
+ * `PromptSubjectMetadataHandler.validateInputContent`: skips the AGENT-only
+ * multi-agent-handoff, task_resolution+conversationHistory, and
+ * conversationHistory-index checks (none of those concepts exist on
+ * `NgtPromptInputSet`), and adds a check that every `promptInput` entry has a
+ * non-blank `referenceName` and `value`.
+ */
+const validatePromptTestCases = (testCases: NgtPromptTestCase[]): void => {
+  testCases.forEach((testCase, tcIdx) => {
+    if (!testCase.inputs || testCase.inputs.length === 0) {
+      throw ngtError('ngtTestCaseMissingInputs', [tcIdx + 1]);
+    }
+    if (!testCase.scorers || testCase.scorers.length === 0) {
+      throw ngtError('ngtTestCaseMissingScorers', [tcIdx + 1]);
+    }
+
+    validateScorers(testCase.scorers, tcIdx);
+
+    testCase.inputs.forEach((inputSet, inputIdx) => {
+      if (!inputSet.promptInput || inputSet.promptInput.length === 0) {
+        throw ngtError('ngtPromptInputSetEmpty', [tcIdx + 1, inputIdx + 1]);
+      }
+      inputSet.promptInput.forEach((pi) => {
+        if (!pi?.referenceName?.trim()) {
+          throw ngtError('ngtPromptInputMissingReferenceName', [tcIdx + 1, inputIdx + 1]);
+        }
+        if (pi.value === undefined || pi.value === null || !String(pi.value).trim()) {
+          throw ngtError('ngtPromptInputMissingValue', [tcIdx + 1, inputIdx + 1, pi.referenceName]);
+        }
+      });
+    });
+  });
+};
+
 const ngtError = (key: string, tokens: Array<string | number> = []): SfError => {
   const message = messages.getMessage(key, tokens);
   return new SfError(message, key);
@@ -645,6 +695,29 @@ const fetchIsMultiAgent = async (connection: Connection, subjectName: string): P
  * Must be called after `validateNgtSpec`.
  */
 export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition => {
+  if (spec.subjectType === 'PROMPT') {
+    const testCases: AiPromptTestCase[] = [];
+    let counter = 1;
+    for (const tc of spec.testCases) {
+      const sharedScorers = tc.scorers.map(toScorerXml);
+      for (const inputSet of tc.inputs) {
+        testCases.push({
+          number: counter++,
+          inputs: toPromptInputsXml(inputSet),
+          scorer: sharedScorers,
+        });
+      }
+    }
+    return {
+      ...(spec.description && { description: spec.description }),
+      name: spec.name,
+      subjectName: spec.subjectName,
+      subjectType: 'PROMPT',
+      ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
+      testCase: testCases,
+    };
+  }
+
   const testCases: AiTestCase[] = [];
   let counter = 1;
   for (const tc of spec.testCases) {
@@ -661,7 +734,7 @@ export const convertToTestingMetadata = (spec: NgtTestSpec): AiTestingDefinition
     ...(spec.description && { description: spec.description }),
     name: spec.name,
     subjectName: spec.subjectName,
-    subjectType: spec.subjectType,
+    subjectType: 'AGENT',
     ...(spec.subjectVersion && { subjectVersion: spec.subjectVersion }),
     testCase: testCases,
   };
@@ -694,6 +767,13 @@ const toInputsXml = (input: NgtTestCaseInput): AiTestCase['inputs'] => {
   }
   return inputs;
 };
+
+const toPromptInputsXml = (inputSet: NgtPromptInputSet): AiTestCasePromptInputXml => ({
+  promptInput: inputSet.promptInput.map((pi) => ({
+    referenceName: pi.referenceName,
+    value: pi.value,
+  })),
+});
 
 /** Serialize an `AiTestingDefinition` to source-format XML. Mirrors `buildMetadataXml`. */
 export const buildTestingMetadataXml = (data: AiTestingDefinition): string => {
@@ -737,7 +817,11 @@ export const parseNgtMetadataXml = (xml: string): AiTestingDefinition => {
       ignoreAttributes: false,
       attributeNamePrefix: '$',
       isArray: (name): boolean =>
-        name === 'testCase' || name === 'scorer' || name === 'contextVariable' || name === 'conversationHistory',
+        name === 'testCase' ||
+        name === 'scorer' ||
+        name === 'contextVariable' ||
+        name === 'conversationHistory' ||
+        name === 'promptInput',
       processEntities: true,
       htmlEntities: true,
     });
@@ -760,12 +844,29 @@ export const parseNgtMetadataXml = (xml: string): AiTestingDefinition => {
  * an identical scorer set into a single multi-input case.
  */
 export const convertToNgtSpec = (data: AiTestingDefinition): NgtTestSpec => {
+  if (data.subjectType === 'PROMPT') {
+    const flatCases = ensureArray(data.testCase).map((tc) => parsePromptTestCaseXml(tc));
+    const collapsedCases = collapseContiguousTestCases(flatCases);
+
+    const spec: NgtTestSpec = {
+      name: String(data.name),
+      subjectType: 'PROMPT',
+      subjectName: String(data.subjectName),
+      testCases: collapsedCases,
+    };
+    if (data.description !== undefined && data.description !== '') spec.description = String(data.description);
+    if (data.subjectVersion !== undefined && data.subjectVersion !== '') {
+      spec.subjectVersion = String(data.subjectVersion);
+    }
+    return spec;
+  }
+
   const flatCases = ensureArray(data.testCase).map((tc) => parseTestCaseXml(tc));
   const collapsedCases = collapseContiguousTestCases(flatCases);
 
   const spec: NgtTestSpec = {
     name: String(data.name),
-    subjectType: data.subjectType,
+    subjectType: 'AGENT',
     subjectName: String(data.subjectName),
     testCases: collapsedCases,
   };
@@ -798,6 +899,15 @@ const parseTestCaseXml = (tc: AiTestCase): NgtTestCase => {
   const scorers = ensureArray(tc.scorer).map((s) => parseScorerXml(s));
 
   return { inputs: [input], scorers };
+};
+
+const parsePromptTestCaseXml = (tc: AiPromptTestCase): NgtPromptTestCase => {
+  const promptInput = ensureArray(tc.inputs?.promptInput).map((pi) => ({
+    referenceName: String(pi.referenceName),
+    value: String(pi.value),
+  }));
+  const scorers = ensureArray(tc.scorer).map((s) => parseScorerXml(s));
+  return { inputs: [{ promptInput }], scorers };
 };
 
 const parseConversationTurnXml = (
@@ -847,11 +957,15 @@ const parseScorerXml = (scorer: AiTestCaseScorer): NgtTestCaseScorer => {
 
 /**
  * Collapse contiguous test cases that share an identical (ordered) scorer set
- * into a single `NgtTestCase` with multiple `inputs[]`. Inverts the multi-input
- * fan-out applied by `convertToTestingMetadata`.
+ * into a single test case with multiple `inputs[]`. Inverts the multi-input
+ * fan-out applied by `convertToTestingMetadata`. Generic over the input-slot
+ * shape (`NgtTestCaseInput` for AGENT, `NgtPromptInputSet` for PROMPT) — the
+ * logic never inspects what's inside `inputs[]`, only the scorer set.
  */
-const collapseContiguousTestCases = (cases: NgtTestCase[]): NgtTestCase[] => {
-  const out: NgtTestCase[] = [];
+const collapseContiguousTestCases = <T extends { inputs: unknown[]; scorers: NgtTestCaseScorer[] }>(
+  cases: T[]
+): T[] => {
+  const out: T[] = [];
   for (const tc of cases) {
     const prev = out[out.length - 1];
     if (prev && scorerSetsEqual(prev.scorers, tc.scorers)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,11 +74,16 @@ export {
   type NgtTestCaseScorer,
   type NgtContextVar,
   type NgtConversationTurn,
+  type NgtPromptTestCase,
+  type NgtPromptInputSet,
+  type NgtPromptTestCaseInput,
   type AiTestingDefinition,
   type AiTestCase,
   type AiTestCaseInputXml,
   type AiTestCaseScorer,
   type AiConversationTurnXml,
+  type AiPromptTestCase,
+  type AiTestCasePromptInputXml,
 
   // Agentforce Studio Testing Types
   type AgentforceStudioTestStartResponse,

--- a/src/ngtScorerCatalog.ts
+++ b/src/ngtScorerCatalog.ts
@@ -58,21 +58,28 @@ export type NgtScorerEntry = {
   needsExpected: boolean;
   grade: NgtScorerGrade;
   requiresConversationHistory?: true;
+  /** Subject types this scorer is valid for. Used to warn when a spec uses a scorer outside this list. */
+  supportedSubjects: ReadonlyArray<'AGENT' | 'PROMPT'>;
 };
 
 /* eslint-disable camelcase */
 export const NgtScorerCatalog: Readonly<Record<KnownNgtScorerName, NgtScorerEntry>> = {
-  topic_sequence_match: { needsExpected: true, grade: 'PASS_FAIL' },
-  action_sequence_match: { needsExpected: true, grade: 'PASS_FAIL' },
-  agent_handoff_match: { needsExpected: true, grade: 'PASS_FAIL' },
-  bot_response_rating: { needsExpected: true, grade: 'LLM_PASS_FAIL' },
-  response_match: { needsExpected: true, grade: 'LLM_PASS_FAIL' },
-  coherence: { needsExpected: false, grade: 'LLM_0_100' },
-  conciseness: { needsExpected: false, grade: 'LLM_0_100' },
-  factuality: { needsExpected: false, grade: 'LLM_0_100' },
-  completeness: { needsExpected: false, grade: 'LLM_0_100' },
-  task_resolution: { needsExpected: false, grade: 'LLM_0_5', requiresConversationHistory: true },
-  output_latency_milliseconds: { needsExpected: false, grade: 'NUMERIC' },
+  topic_sequence_match: { needsExpected: true, grade: 'PASS_FAIL', supportedSubjects: ['AGENT'] },
+  action_sequence_match: { needsExpected: true, grade: 'PASS_FAIL', supportedSubjects: ['AGENT'] },
+  agent_handoff_match: { needsExpected: true, grade: 'PASS_FAIL', supportedSubjects: ['AGENT'] },
+  bot_response_rating: { needsExpected: true, grade: 'LLM_PASS_FAIL', supportedSubjects: ['AGENT'] },
+  response_match: { needsExpected: true, grade: 'LLM_PASS_FAIL', supportedSubjects: ['AGENT', 'PROMPT'] },
+  coherence: { needsExpected: false, grade: 'LLM_0_100', supportedSubjects: ['AGENT', 'PROMPT'] },
+  conciseness: { needsExpected: false, grade: 'LLM_0_100', supportedSubjects: ['AGENT', 'PROMPT'] },
+  factuality: { needsExpected: false, grade: 'LLM_0_100', supportedSubjects: ['AGENT', 'PROMPT'] },
+  completeness: { needsExpected: false, grade: 'LLM_0_100', supportedSubjects: ['AGENT', 'PROMPT'] },
+  task_resolution: {
+    needsExpected: false,
+    grade: 'LLM_0_5',
+    requiresConversationHistory: true,
+    supportedSubjects: ['AGENT'],
+  },
+  output_latency_milliseconds: { needsExpected: false, grade: 'NUMERIC', supportedSubjects: ['AGENT'] },
 } as const;
 /* eslint-enable camelcase */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -582,14 +582,41 @@ export type NgtTestCase = {
   scorers: NgtTestCaseScorer[];
 };
 
-export type NgtTestSpec = {
-  name: string;
-  description?: string;
-  subjectType: 'AGENT';
-  subjectName: string;
-  subjectVersion?: string;
-  testCases: NgtTestCase[];
+// PROMPT-subject authoring (YAML) types. One `NgtPromptInputSet` = one template
+// invocation (all input slots it needs, filled together); `NgtPromptTestCase.inputs`
+// is an array of invocations that fan out 1:1 into XML <testCase> elements sharing
+// one scorer set — mirrors AGENT's NgtTestCase.inputs[] fan-out.
+export type NgtPromptTestCaseInput = {
+  referenceName: string;
+  value: string;
 };
+
+export type NgtPromptInputSet = {
+  promptInput: NgtPromptTestCaseInput[];
+};
+
+export type NgtPromptTestCase = {
+  inputs: NgtPromptInputSet[];
+  scorers: NgtTestCaseScorer[];
+};
+
+export type NgtTestSpec =
+  | {
+      name: string;
+      description?: string;
+      subjectType: 'AGENT';
+      subjectName: string;
+      subjectVersion?: string;
+      testCases: NgtTestCase[];
+    }
+  | {
+      name: string;
+      description?: string;
+      subjectType: 'PROMPT';
+      subjectName: string;
+      subjectVersion?: string;
+      testCases: NgtPromptTestCase[];
+    };
 
 // Metadata (XML) types for AiTestingDefinition.
 
@@ -616,14 +643,35 @@ export type AiTestCase = {
   scorer: AiTestCaseScorer[];
 };
 
-export type AiTestingDefinition = {
-  description?: string;
-  name: string;
-  subjectName: string;
-  subjectType: 'AGENT';
-  subjectVersion?: string;
-  testCase: AiTestCase[];
+// PROMPT-subject metadata (XML) types. `AiTestCasePromptInputXml` maps to the
+// `<inputs>` element of one <testCase>; `promptInput` is its repeatable child.
+export type AiTestCasePromptInputXml = {
+  promptInput: Array<{ referenceName: string; value: string }>;
 };
+
+export type AiPromptTestCase = {
+  number: number;
+  inputs: AiTestCasePromptInputXml;
+  scorer: AiTestCaseScorer[];
+};
+
+export type AiTestingDefinition =
+  | {
+      description?: string;
+      name: string;
+      subjectName: string;
+      subjectType: 'AGENT';
+      subjectVersion?: string;
+      testCase: AiTestCase[];
+    }
+  | {
+      description?: string;
+      name: string;
+      subjectName: string;
+      subjectType: 'PROMPT';
+      subjectVersion?: string;
+      testCase: AiPromptTestCase[];
+    };
 
 // ====================================================
 //               Agent Preview Types

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -1139,7 +1139,7 @@ testCases:
         }),
       };
       const mockComponentSet = { deploy: sinon.stub().resolves(mockDeploy) };
-      componentSetBuildStub.resolves(mockComponentSet as never);
+      componentSetBuildStub.resolves(mockComponentSet);
 
       const result = await AgentTest.create(connection, 'MyPromptTest', 'spec.yaml', {
         outputDir: 'tmp',

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -29,7 +29,7 @@ import {
   buildTestingMetadataXml,
   parseNgtMetadataXml,
 } from '../src/agentTest';
-import type { NgtTestSpec, AiTestCaseInputXml, NgtTestCaseInput } from '../src/types';
+import type { NgtTestSpec, AiTestCaseInputXml, NgtTestCaseInput, AiTestingDefinition } from '../src/types';
 
 /**
  * Normalize a serialized XML string for comparison:
@@ -490,7 +490,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(normalizeXml(actual)).to.equal(normalizeXml(expected));
     });
 
-    it('regression: an unrecognized subjectType (e.g. a typo) falls back to the AGENT shape, not PROMPT', () => {
+    it('throws for an unrecognized subjectType (e.g. a typo), from both converters', () => {
       // Cast through unknown to bypass static typing; models a hand-edited YAML with a typo'd subjectType.
       const spec = {
         name: 'Typo',
@@ -498,8 +498,8 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         subjectName: 'SomeBot',
         testCases: [{ inputs: [{ utterance: 'hi' }], scorers: [{ name: 'coherence' }] }],
       } as unknown as NgtTestSpec;
-      const def = convertToTestingMetadata(spec);
-      expect(def.subjectType).to.equal('AGENT');
+      expect(() => convertToTestingMetadata(spec)).to.throw(/unrecognized `subjectType`/);
+      expect(() => convertToNgtSpec(spec as unknown as AiTestingDefinition)).to.throw(/unrecognized `subjectType`/);
     });
 
     it('PROMPT subject: matches the expected XML fixture (multi-invocation fan-out, multi-slot promptInput)', async () => {

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -88,6 +88,19 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(() => validateNgtSpec(baseSpec(), { isMultiAgent: false })).to.not.throw();
     });
 
+    it('throws ngtUnknownSubjectType for a typo\'d subjectType (e.g. "PROMT"), naming the offending value', () => {
+      // Cast through unknown to bypass static typing; models a hand-edited YAML with a typo'd subjectType.
+      const spec = { ...baseSpec(), subjectType: 'PROMT' } as unknown as NgtTestSpec;
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtUnknownSubjectType');
+        expect((err as SfError).message).to.include('PROMT');
+      }
+    });
+
     it('throws ngtMissingTestCases when testCases is empty', () => {
       const spec = baseSpec();
       spec.testCases = [];
@@ -168,7 +181,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
       expect(lifecycleSpy.called).to.be.true;
       const allWarnArgs = lifecycleSpy.getCalls().flatMap((c) => c.args.map(String));
-      expect(allWarnArgs.some((a) => a.includes('made_up_scorer'))).to.be.true;
+      expect(allWarnArgs.some((a) => a.includes('made_up_scorer') && a.includes('test case 1'))).to.be.true;
     });
 
     it('throws ngtTaskResolutionRequiresConversationHistory when task_resolution lacks conversationHistory', () => {
@@ -389,6 +402,18 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       }
     });
 
+    it('does not throw a raw TypeError when referenceName is a non-string (e.g. unquoted numeric YAML) — coerces and passes like `value` already does', () => {
+      const spec = basePromptSpec();
+      // Cast through unknown to bypass static typing; models unquoted numeric YAML (referenceName: 123).
+      // Before the fix, `pi.referenceName?.trim()` threw a raw TypeError here (numbers have no .trim).
+      // 123 stringifies to a non-blank "123", so — mirroring how `value` already coerces numeric input —
+      // this is a legitimate reference name and validation must pass cleanly, not throw at all.
+      spec.testCases[0].inputs = [
+        { promptInput: [{ referenceName: 123 as unknown as string, value: 'x' }] },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
     it('throws ngtPromptInputMissingValue when a promptInput entry has a blank value', () => {
       const spec = basePromptSpec();
       spec.testCases[0].inputs = [{ promptInput: [{ referenceName: 'CaseDescription', value: '   ' }] }];
@@ -422,7 +447,9 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
       expect(lifecycleSpy.called).to.be.true;
       const allWarnArgs = lifecycleSpy.getCalls().flatMap((c) => c.args.map(String));
-      expect(allWarnArgs.some((a) => a.includes('topic_sequence_match') && a.includes('PROMPT'))).to.be.true;
+      expect(
+        allWarnArgs.some((a) => a.includes('topic_sequence_match') && a.includes('PROMPT') && a.includes('test case 1'))
+      ).to.be.true;
     });
 
     it('does not emit a subject-scoping warning for any of the 5 PROMPT-supported scorers', () => {
@@ -548,6 +575,36 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         { referenceName: 'CaseDescription', value: 'case text' },
         { referenceName: 'CustomerTone', value: 'angry' },
       ]);
+    });
+
+    it('PROMPT subject: a numeric `value`/`referenceName` is coerced to a string by the converter itself, not left as a number for the XML builder to coerce', () => {
+      const spec = {
+        name: 'PromptNumericValue',
+        subjectType: 'PROMPT',
+        subjectName: 'MyPrompt',
+        testCases: [
+          {
+            // Cast through unknown to bypass static typing; models parsed YAML `value: 42`.
+            inputs: [{ promptInput: [{ referenceName: 'RetryCount' as unknown as string, value: 42 as unknown as string }] }],
+            scorers: [{ name: 'coherence' }],
+          },
+        ],
+      } as unknown as NgtTestSpec;
+
+      const def = convertToTestingMetadata(spec);
+      if (def.subjectType !== 'PROMPT') throw new Error('unreachable');
+      // Asserted on `def` directly (pre-serialization): fast-xml-parser's XMLBuilder auto-stringifies
+      // numbers regardless, so checking the rendered XML string here would pass even without the fix.
+      expect(def.testCase[0].inputs.promptInput[0].value).to.equal('42');
+      expect(def.testCase[0].inputs.promptInput[0].value).to.be.a('string');
+
+      const xml = buildTestingMetadataXml(def);
+      expect(xml).to.include('<value>42</value>');
+
+      const reparsed = convertToNgtSpec(parseNgtMetadataXml(xml));
+      if (reparsed.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(reparsed.testCases[0].inputs[0].promptInput[0].value).to.equal('42');
+      expect(reparsed.testCases[0].inputs[0].promptInput[0].value).to.be.a('string');
     });
 
     it('multi-input fan-out: one inputs[] with 3 entries → 3 <testCase> elements, shared scorers, globally numbered', () => {
@@ -835,6 +892,25 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       const spec = parseToSpec(xml);
       if (spec.subjectType !== 'PROMPT') throw new Error('unreachable');
       expect(spec.testCases[0].inputs[0].promptInput).to.deep.equal([{ referenceName: 'Case', value: 'only one slot' }]);
+    });
+
+    it('PROMPT subject: a promptInput missing <value> or <referenceName> parses to an empty string, not the literal "undefined"', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>PROMPT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs>\n' +
+        '    <promptInput><referenceName>Case</referenceName></promptInput>\n' +
+        '    <promptInput><value>orphan value</value></promptInput>\n' +
+        '  </inputs>\n' +
+        '    <scorer><name>coherence</name></scorer></testCase>\n' +
+        '</AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      if (spec.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(spec.testCases[0].inputs[0].promptInput).to.deep.equal([
+        { referenceName: 'Case', value: '' },
+        { referenceName: '', value: 'orphan value' },
+      ]);
     });
 
     it('preserves all 11 catalog scorers across the canonical fixture (presence + expected shape)', async () => {

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -463,6 +463,18 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       expect(normalizeXml(actual)).to.equal(normalizeXml(expected));
     });
 
+    it('regression: an unrecognized subjectType (e.g. a typo) falls back to the AGENT shape, not PROMPT', () => {
+      // Cast through unknown to bypass static typing; models a hand-edited YAML with a typo'd subjectType.
+      const spec = {
+        name: 'Typo',
+        subjectType: 'PROMT',
+        subjectName: 'SomeBot',
+        testCases: [{ inputs: [{ utterance: 'hi' }], scorers: [{ name: 'coherence' }] }],
+      } as unknown as NgtTestSpec;
+      const def = convertToTestingMetadata(spec);
+      expect(def.subjectType).to.equal('AGENT');
+    });
+
     it('PROMPT subject: matches the expected XML fixture (multi-invocation fan-out, multi-slot promptInput)', async () => {
       const yamlPath = join(__dirname, 'fixtures', 'ngt-prompt-spec-summarize-case.yaml');
       const xmlPath = join(__dirname, 'fixtures', 'ngt-prompt-xml-summarize-case.xml');

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -29,7 +29,7 @@ import {
   buildTestingMetadataXml,
   parseNgtMetadataXml,
 } from '../src/agentTest';
-import type { NgtTestSpec } from '../src/types';
+import type { NgtTestSpec, AiTestCaseInputXml, NgtTestCaseInput } from '../src/types';
 
 /**
  * Normalize a serialized XML string for comparison:
@@ -269,6 +269,126 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
   });
 
   // -------------------------------------------------------------------------
+  // validateNgtSpec — PROMPT subject
+  // -------------------------------------------------------------------------
+  describe('validateNgtSpec — PROMPT subject', () => {
+    /** Smallest legal PROMPT spec. Tests mutate copies of this. */
+    const basePromptSpec = (): NgtTestSpec => ({
+      name: 'PromptSuite',
+      subjectType: 'PROMPT',
+      subjectName: 'MyPrompt',
+      subjectVersion: 'v3',
+      testCases: [
+        {
+          inputs: [{ promptInput: [{ referenceName: 'CaseDescription', value: 'a case' }] }],
+          scorers: [{ name: 'coherence' }],
+        },
+      ],
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('passes for a minimal valid PROMPT spec', () => {
+      expect(() => validateNgtSpec(basePromptSpec(), { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('throws ngtTestCaseMissingInputs when a PROMPT test case has empty inputs[]', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].inputs = [];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtTestCaseMissingInputs');
+      }
+    });
+
+    it('throws ngtTestCaseMissingScorers when a PROMPT test case has empty scorers[]', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].scorers = [];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtTestCaseMissingScorers');
+      }
+    });
+
+    it('throws ngtScorerMissingExpected when a needsExpected scorer omits expected (PROMPT)', () => {
+      const spec = basePromptSpec();
+      // response_match is needsExpected:true (LLM_PASS_FAIL)
+      spec.testCases[0].scorers = [{ name: 'response_match' }];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtScorerMissingExpected');
+        expect((err as SfError).message).to.include('response_match');
+      }
+    });
+
+    it('passes when a quality scorer (needsExpected:false) omits expected (PROMPT)', () => {
+      const spec = basePromptSpec();
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('throws ngtPromptInputSetEmpty when an inputs[] entry has an empty promptInput[]', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].inputs = [{ promptInput: [] }];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtPromptInputSetEmpty');
+      }
+    });
+
+    it('throws ngtPromptInputMissingReferenceName when a promptInput entry has a blank referenceName', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].inputs = [{ promptInput: [{ referenceName: '', value: 'x' }] }];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtPromptInputMissingReferenceName');
+      }
+    });
+
+    it('throws ngtPromptInputMissingValue when a promptInput entry has a blank value', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].inputs = [{ promptInput: [{ referenceName: 'CaseDescription', value: '   ' }] }];
+      try {
+        validateNgtSpec(spec, { isMultiAgent: false });
+        expect.fail('expected validateNgtSpec to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(SfError);
+        expect((err as SfError).name).to.equal('ngtPromptInputMissingValue');
+        expect((err as SfError).message).to.include('CaseDescription');
+      }
+    });
+
+    it('does NOT apply the multi-agent handoff rule to PROMPT (structurally AGENT-only)', () => {
+      const spec = basePromptSpec();
+      // No agent_handoff_match scorer anywhere — would throw ngtMultiAgentMissingHandoff for AGENT.
+      expect(() => validateNgtSpec(spec, { isMultiAgent: true })).to.not.throw();
+    });
+
+    it('does NOT apply the task_resolution/conversationHistory rule to PROMPT (structurally AGENT-only)', () => {
+      const spec = basePromptSpec();
+      spec.testCases[0].scorers = [{ name: 'task_resolution' }];
+      // No conversationHistory concept exists on NgtPromptInputSet — would throw for AGENT.
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // convertToTestingMetadata — pure converter (and buildTestingMetadataXml)
   // -------------------------------------------------------------------------
   describe('convertToTestingMetadata + buildTestingMetadataXml', () => {
@@ -289,6 +409,81 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       const expected = await fs.readFile(xmlPath, 'utf-8');
 
       expect(normalizeXml(actual)).to.equal(normalizeXml(expected));
+    });
+
+    it('PROMPT subject: matches the expected XML fixture (multi-invocation fan-out, multi-slot promptInput)', async () => {
+      const yamlPath = join(__dirname, 'fixtures', 'ngt-prompt-spec-summarize-case.yaml');
+      const xmlPath = join(__dirname, 'fixtures', 'ngt-prompt-xml-summarize-case.xml');
+
+      const { parse } = await import('yaml');
+      const spec = parse(await fs.readFile(yamlPath, 'utf-8')) as NgtTestSpec;
+
+      const def = convertToTestingMetadata(spec);
+      const actual = buildTestingMetadataXml(def);
+      const expected = await fs.readFile(xmlPath, 'utf-8');
+
+      expect(normalizeXml(actual)).to.equal(normalizeXml(expected));
+    });
+
+    it('PROMPT subject: fans out N invocations to N <testCase> elements sharing one scorer set, globally numbered', () => {
+      const spec: NgtTestSpec = {
+        name: 'PromptFanOut',
+        subjectType: 'PROMPT',
+        subjectName: 'MyPrompt',
+        subjectVersion: 'v3',
+        testCases: [
+          {
+            inputs: [
+              { promptInput: [{ referenceName: 'CaseDescription', value: 'case A' }] },
+              { promptInput: [{ referenceName: 'CaseDescription', value: 'case B' }] },
+            ],
+            scorers: [{ name: 'coherence' }, { name: 'response_match', expected: 'a good summary' }],
+          },
+        ],
+      };
+
+      const def = convertToTestingMetadata(spec);
+      expect(def.subjectType).to.equal('PROMPT');
+      if (def.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(def.testCase).to.have.length(2);
+      expect(def.testCase.map((tc) => tc.number)).to.deep.equal([1, 2]);
+      def.testCase.forEach((tc) => {
+        expect(tc.scorer.map((s) => s.name)).to.deep.equal(['coherence', 'response_match']);
+        expect(tc.scorer.map((s) => s.expectedValue)).to.deep.equal([undefined, 'a good summary']);
+      });
+      expect(def.testCase.map((tc) => tc.inputs.promptInput.map((pi) => pi.value))).to.deep.equal([
+        ['case A'],
+        ['case B'],
+      ]);
+    });
+
+    it('PROMPT subject: one invocation with multiple promptInput slots maps to one <testCase> with multiple <promptInput>', () => {
+      const spec: NgtTestSpec = {
+        name: 'PromptMultiSlot',
+        subjectType: 'PROMPT',
+        subjectName: 'MyPrompt',
+        testCases: [
+          {
+            inputs: [
+              {
+                promptInput: [
+                  { referenceName: 'CaseDescription', value: 'case text' },
+                  { referenceName: 'CustomerTone', value: 'angry' },
+                ],
+              },
+            ],
+            scorers: [{ name: 'factuality' }],
+          },
+        ],
+      };
+
+      const def = convertToTestingMetadata(spec);
+      if (def.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(def.testCase).to.have.length(1);
+      expect(def.testCase[0].inputs.promptInput).to.deep.equal([
+        { referenceName: 'CaseDescription', value: 'case text' },
+        { referenceName: 'CustomerTone', value: 'angry' },
+      ]);
     });
 
     it('multi-input fan-out: one inputs[] with 3 entries → 3 <testCase> elements, shared scorers, globally numbered', () => {
@@ -326,7 +521,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         ]);
       });
       // Utterances are distributed 1-per-testCase in input order.
-      expect(def.testCase.map((tc) => tc.inputs.utterance)).to.deep.equal([
+      expect(def.testCase.map((tc) => (tc.inputs as AiTestCaseInputXml).utterance)).to.deep.equal([
         "What's the status of order #12345?",
         'Where is my order 12345',
         'Tell me about order #12345',
@@ -443,7 +638,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         ],
       };
       const def = convertToTestingMetadata(spec);
-      const turns = def.testCase[0].inputs.conversationHistory!;
+      const turns = (def.testCase[0].inputs as AiTestCaseInputXml).conversationHistory!;
       expect(turns.map((t) => t.index)).to.deep.equal([0, 1, 2]);
     });
 
@@ -468,7 +663,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         ],
       };
       const def = convertToTestingMetadata(spec);
-      const turns = def.testCase[0].inputs.conversationHistory!;
+      const turns = (def.testCase[0].inputs as AiTestCaseInputXml).conversationHistory!;
       expect(turns.map((t) => t.index)).to.deep.equal([7, 8]);
     });
   });
@@ -509,6 +704,73 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       const synthesizedXml = buildTestingMetadataXml(convertToTestingMetadata(sourceSpec));
       const reparsed = parseToSpec(synthesizedXml);
       expect(reparsed).to.deep.equal(parsed);
+    });
+
+    it('PROMPT subject: round-trips the canonical fixture and collapses fanned-out testCases back into 2 cases', async () => {
+      const yamlPath = join(__dirname, 'fixtures', 'ngt-prompt-spec-summarize-case.yaml');
+      const xmlPath = join(__dirname, 'fixtures', 'ngt-prompt-xml-summarize-case.xml');
+
+      const { parse } = await import('yaml');
+      const sourceSpec = parse(await fs.readFile(yamlPath, 'utf-8')) as NgtTestSpec;
+
+      const xml = await fs.readFile(xmlPath, 'utf-8');
+      const parsed = parseToSpec(xml);
+
+      expect(parsed.name).to.equal(sourceSpec.name);
+      expect(parsed.description).to.equal(sourceSpec.description);
+      expect(parsed.subjectName).to.equal(sourceSpec.subjectName);
+      expect(parsed.subjectType).to.equal('PROMPT');
+      expect(parsed.subjectVersion).to.equal(sourceSpec.subjectVersion);
+
+      // 3 XML <testCase> elements collapse back to 2 YAML testCases: the first
+      // 2 XML testCases share an identical scorer set (factuality/completeness/response_match)
+      // and collapse into 1 case with 2 invocations; the 3rd (coherence-only) stays separate.
+      expect(parsed.testCases).to.have.length(2);
+      if (parsed.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(parsed.testCases[0].inputs).to.have.length(2);
+      expect(parsed.testCases[0].inputs.map((i) => i.promptInput.map((pi) => pi.value))).to.deep.equal([
+        ['Customer reports login failures since yesterday.', 'frustrated'],
+        ['Customer asks how to reset their password.', 'neutral'],
+      ]);
+      expect(parsed.testCases[1].inputs).to.have.length(1);
+
+      // Convert source → metadata → xml → parse and compare structurally (matches the AGENT test's pattern).
+      const synthesizedXml = buildTestingMetadataXml(convertToTestingMetadata(sourceSpec));
+      const reparsed = parseToSpec(synthesizedXml);
+      expect(reparsed).to.deep.equal(parsed);
+    });
+
+    it('PROMPT subject: does NOT collapse adjacent test cases when scorer sets differ', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>PROMPT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs>\n' +
+        '    <promptInput><referenceName>Case</referenceName><value>v1</value></promptInput>\n' +
+        '  </inputs>\n' +
+        '    <scorer><name>coherence</name></scorer></testCase>\n' +
+        '  <testCase><number>2</number><inputs>\n' +
+        '    <promptInput><referenceName>Case</referenceName><value>v2</value></promptInput>\n' +
+        '  </inputs>\n' +
+        '    <scorer><name>factuality</name></scorer></testCase>\n' +
+        '</AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      expect(spec.testCases).to.have.length(2);
+    });
+
+    it('PROMPT subject: a single-slot promptInput round-trips as an array of length 1 (isArray predicate covers promptInput)', () => {
+      const xml =
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+        '  <name>S</name><subjectName>A</subjectName><subjectType>PROMPT</subjectType>\n' +
+        '  <testCase><number>1</number><inputs>\n' +
+        '    <promptInput><referenceName>Case</referenceName><value>only one slot</value></promptInput>\n' +
+        '  </inputs>\n' +
+        '    <scorer><name>coherence</name></scorer></testCase>\n' +
+        '</AiTestingDefinition>\n';
+      const spec = parseToSpec(xml);
+      if (spec.subjectType !== 'PROMPT') throw new Error('unreachable');
+      expect(spec.testCases[0].inputs[0].promptInput).to.deep.equal([{ referenceName: 'Case', value: 'only one slot' }]);
     });
 
     it('preserves all 11 catalog scorers across the canonical fixture (presence + expected shape)', async () => {
@@ -562,7 +824,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         '</AiTestingDefinition>\n';
       const spec = parseToSpec(xml);
       expect(spec.testCases).to.have.length(1);
-      expect(spec.testCases[0].inputs.map((i) => i.utterance)).to.deep.equal(['u1', 'u2', 'u3']);
+      expect((spec.testCases[0].inputs as NgtTestCaseInput[]).map((i) => i.utterance)).to.deep.equal(['u1', 'u2', 'u3']);
       expect(spec.testCases[0].scorers).to.deep.equal([{ name: 'topic_sequence_match', expected: 'T' }]);
     });
 
@@ -594,7 +856,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         '  <scorer><name>task_resolution</name></scorer>\n' +
         '  </testCase></AiTestingDefinition>\n';
       const spec = parseToSpec(xml);
-      const input = spec.testCases[0].inputs[0];
+      const input = spec.testCases[0].inputs[0] as NgtTestCaseInput;
       expect(input.contextVariables).to.deep.equal([{ name: 'RoutableId', value: '0Mw' }]);
       expect(input.conversationHistory).to.deep.equal([
         { role: 'user', message: 'a' },
@@ -614,7 +876,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
         '  </inputs>\n' +
         '  <scorer><name>task_resolution</name></scorer></testCase></AiTestingDefinition>\n';
       const spec = parseToSpec(xml);
-      const turns = spec.testCases[0].inputs[0].conversationHistory!;
+      const turns = (spec.testCases[0].inputs[0] as NgtTestCaseInput).conversationHistory!;
       expect(turns.map((t) => t.index)).to.deep.equal([7, 8]);
     });
 
@@ -737,7 +999,7 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
 
       // NGT shape: testCases[].inputs is an array, scorers is the marker.
       expect(spec.testCases[0]).to.have.property('scorers');
-      expect(spec.testCases[0].inputs[0].utterance).to.equal('u');
+      expect((spec.testCases[0].inputs[0] as NgtTestCaseInput).utterance).to.equal('u');
     });
 
     it('mdPath with <AiEvaluationDefinition> root → still returns legacy TestSpec (regression)', async () => {
@@ -849,6 +1111,62 @@ testCases:
       expect(componentSetBuildStub.calledOnce).to.be.true;
       expect(mockComponentSet.deploy.calledOnce).to.be.true;
       expect(mkdirStub.calledOnce).to.be.true;
+    });
+
+    const promptYamlSpec = `name: PromptSuite
+description: NGT prompt minimal
+subjectType: PROMPT
+subjectName: MyPrompt
+subjectVersion: v3
+testCases:
+  - inputs:
+      - promptInput:
+          - referenceName: CaseDescription
+            value: a case
+    scorers:
+      - name: coherence
+`;
+
+    it('PROMPT subject: does not call BotDefinition.IsMultiAgent, and deploys the correct filename', async () => {
+      readFileStub.resolves(promptYamlSpec);
+      const metadataReadStub = sinon.stub(connection.metadata, 'read');
+
+      const mockDeploy = {
+        onUpdate: sinon.stub(),
+        onFinish: sinon.stub(),
+        pollStatus: sinon.stub().resolves({
+          response: { success: true, details: { componentFailures: [] } },
+        }),
+      };
+      const mockComponentSet = { deploy: sinon.stub().resolves(mockDeploy) };
+      componentSetBuildStub.resolves(mockComponentSet as never);
+
+      const result = await AgentTest.create(connection, 'MyPromptTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: false,
+        testRunner: 'agentforce-studio',
+      } as never);
+
+      expect(metadataReadStub.called, 'BotDefinition.IsMultiAgent must not be looked up for a PROMPT subject').to.be
+        .false;
+      expect(result.path).to.match(/MyPromptTest\.aiTestingDefinition-meta\.xml$/);
+      expect(componentSetBuildStub.calledOnce).to.be.true;
+      expect(mockComponentSet.deploy.calledOnce).to.be.true;
+    });
+
+    it('PROMPT subject preview: writes a subjectType=PROMPT AiTestingDefinition XML with promptInput elements', async () => {
+      readFileStub.resolves(promptYamlSpec);
+
+      const { contents } = await AgentTest.create(connection, 'MyPromptTest', 'spec.yaml', {
+        outputDir: 'tmp',
+        preview: true,
+        testRunner: 'agentforce-studio',
+      } as never);
+
+      expect(contents).to.include('<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">');
+      expect(contents).to.include('<subjectType>PROMPT</subjectType>');
+      expect(contents).to.include('<promptInput>');
+      expect(contents).to.include('<referenceName>CaseDescription</referenceName>');
     });
 
     // Regression guard: omitting testRunner must route through the legacy path,

--- a/test/agentTestNgt.test.ts
+++ b/test/agentTestNgt.test.ts
@@ -266,6 +266,34 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       ];
       expect(() => validateNgtSpec(noneSet, { isMultiAgent: false })).to.not.throw();
     });
+
+    it('does not emit a subject-scoping warning for any catalog scorer on AGENT', () => {
+      const lifecycleSpy = sinon.spy(Lifecycle.prototype, 'emitWarning');
+      const spec = baseSpec();
+      spec.testCases[0].scorers = [
+        { name: 'topic_sequence_match', expected: 'GeneralCRM' },
+        { name: 'action_sequence_match', expected: 'a' },
+        { name: 'agent_handoff_match', expected: 'CheckoutAgent' },
+        { name: 'bot_response_rating', expected: 'a friendly greeting' },
+        { name: 'response_match', expected: 'x' },
+        { name: 'coherence' },
+        { name: 'conciseness' },
+        { name: 'factuality' },
+        { name: 'completeness' },
+        { name: 'output_latency_milliseconds' },
+      ];
+      spec.testCases[0].inputs = [
+        {
+          utterance: 'hello',
+          conversationHistory: [
+            { role: 'user', message: 'first' },
+            { role: 'agent', message: 'sure', topic: 'GeneralCRM' },
+          ],
+        },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+      expect(lifecycleSpy.called).to.be.false;
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -385,6 +413,30 @@ describe('AgentTest NGT (Agentforce Studio) create surface', () => {
       spec.testCases[0].scorers = [{ name: 'task_resolution' }];
       // No conversationHistory concept exists on NgtPromptInputSet — would throw for AGENT.
       expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+    });
+
+    it('emits a subject-scoping Lifecycle warn event for an AGENT-only scorer used on PROMPT (does not throw)', () => {
+      const lifecycleSpy = sinon.spy(Lifecycle.prototype, 'emitWarning');
+      const spec = basePromptSpec();
+      spec.testCases[0].scorers = [{ name: 'topic_sequence_match', expected: 'GeneralCRM' }];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+      expect(lifecycleSpy.called).to.be.true;
+      const allWarnArgs = lifecycleSpy.getCalls().flatMap((c) => c.args.map(String));
+      expect(allWarnArgs.some((a) => a.includes('topic_sequence_match') && a.includes('PROMPT'))).to.be.true;
+    });
+
+    it('does not emit a subject-scoping warning for any of the 5 PROMPT-supported scorers', () => {
+      const lifecycleSpy = sinon.spy(Lifecycle.prototype, 'emitWarning');
+      const spec = basePromptSpec();
+      spec.testCases[0].scorers = [
+        { name: 'coherence' },
+        { name: 'conciseness' },
+        { name: 'factuality' },
+        { name: 'completeness' },
+        { name: 'response_match', expected: 'x' },
+      ];
+      expect(() => validateNgtSpec(spec, { isMultiAgent: false })).to.not.throw();
+      expect(lifecycleSpy.called).to.be.false;
     });
   });
 

--- a/test/fixtures/ngt-prompt-spec-summarize-case.yaml
+++ b/test/fixtures/ngt-prompt-spec-summarize-case.yaml
@@ -1,0 +1,33 @@
+# Canonical PROMPT-subject fixture for W-23524165.
+# Exercises: multi-invocation fan-out (test case 1 has 2 invocations -> 2 XML
+# <testCase> elements sharing one scorer set) and multi-slot promptInput
+# (each invocation fills 2 template input slots). Test case 2 is a
+# single-invocation, single-slot case with a quality scorer (no <expectedValue>).
+name: SummarizeCasePromptSuite
+description: Validates the SummarizeCase prompt template.
+subjectType: PROMPT
+subjectName: SummarizeCasePrompt
+subjectVersion: v3
+testCases:
+  - inputs:
+      - promptInput:
+          - referenceName: CaseDescription
+            value: Customer reports login failures since yesterday.
+          - referenceName: CustomerTone
+            value: frustrated
+      - promptInput:
+          - referenceName: CaseDescription
+            value: Customer asks how to reset their password.
+          - referenceName: CustomerTone
+            value: neutral
+    scorers:
+      - name: factuality
+      - name: completeness
+      - name: response_match
+        expected: A concise, accurate case summary
+  - inputs:
+      - promptInput:
+          - referenceName: CaseDescription
+            value: Customer requests refund for a damaged item.
+    scorers:
+      - name: coherence

--- a/test/fixtures/ngt-prompt-xml-summarize-case.xml
+++ b/test/fixtures/ngt-prompt-xml-summarize-case.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Validates the SummarizeCase prompt template.</description>
+    <name>SummarizeCasePromptSuite</name>
+    <subjectName>SummarizeCasePrompt</subjectName>
+    <subjectType>PROMPT</subjectType>
+    <subjectVersion>v3</subjectVersion>
+    <testCase>
+        <number>1</number>
+        <inputs>
+            <promptInput>
+                <referenceName>CaseDescription</referenceName>
+                <value>Customer reports login failures since yesterday.</value>
+            </promptInput>
+            <promptInput>
+                <referenceName>CustomerTone</referenceName>
+                <value>frustrated</value>
+            </promptInput>
+        </inputs>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>completeness</name>
+        </scorer>
+        <scorer>
+            <name>response_match</name>
+            <expectedValue>A concise, accurate case summary</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>2</number>
+        <inputs>
+            <promptInput>
+                <referenceName>CaseDescription</referenceName>
+                <value>Customer asks how to reset their password.</value>
+            </promptInput>
+            <promptInput>
+                <referenceName>CustomerTone</referenceName>
+                <value>neutral</value>
+            </promptInput>
+        </inputs>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>completeness</name>
+        </scorer>
+        <scorer>
+            <name>response_match</name>
+            <expectedValue>A concise, accurate case summary</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>3</number>
+        <inputs>
+            <promptInput>
+                <referenceName>CaseDescription</referenceName>
+                <value>Customer requests refund for a damaged item.</value>
+            </promptInput>
+        </inputs>
+        <scorer>
+            <name>coherence</name>
+        </scorer>
+    </testCase>
+</AiTestingDefinition>


### PR DESCRIPTION
### What does this PR do?

**[Demo video link](https://drive.google.com/file/d/1PZC89mxNL4EkYzLmFdqlbhSOoES0gQSr/view?usp=sharing)**

Adds client-side support for the **PROMPT** subject type (prompt template testing) to the NGT (Agentforce Studio) `sf agent test create` code path, alongside the existing **AGENT** subject type. Covers the full round trip:

- **Types** (`src/types.ts`, `src/index.ts`): new `AiPromptTestCase`, `AiTestCasePromptInputXml`, `NgtPromptInputSet`, `NgtPromptTestCase`, discriminated by `subjectType: 'AGENT' | 'PROMPT'`.
- **YAML → metadata XML** (`convertToTestingMetadata` + new `toPromptInputsXml`): serializes a PROMPT spec's `promptInput` slots into `AiTestingDefinition` XML.
- **Metadata XML → spec** (`convertToNgtSpec` + new `parsePromptTestCaseXml`; `collapseContiguousTestCases` genericized): parses a deployed PROMPT `AiTestingDefinition` back into an `NgtTestSpec`, including multi-invocation fan-out/collapse.
- **Validation** (`validateNgtSpec` + new `validatePromptTestCases`, shared `validateScorers` extracted): PROMPT specs get structural + `promptInput` content checks (non-blank `referenceName`/`value`), and correctly skip the AGENT-only multi-agent-handoff / `task_resolution`+conversationHistory / conversationHistory-index rules.
- **Scorer validation** (`src/ngtScorerCatalog.ts`, `validateScorers`): each catalog scorer now declares which subject types it supports. AGENT keeps all 11 existing scorers; PROMPT supports 5 (`coherence`, `conciseness`, `factuality`, `completeness`, `response_match`). Using any other catalog scorer on a PROMPT spec now emits a Lifecycle warning instead of passing through silently — the deploy still proceeds and is validated server-side. AGENT behavior is unchanged.
- **Wiring** (`AgentTest.create()`): skips the `BotDefinition.IsMultiAgent` org lookup for PROMPT subjects, since multi-agent handoff is structurally an AGENT-only concept.
- Reorganized the subject-type dispatch in `convertToTestingMetadata`, `convertToNgtSpec`, and `validateNgtSpec` into small per-subject handler functions routed through one shared helper. The default path is the existing AGENT path; the PROMPT path is only taken when `subjectType` is exactly `PROMPT`. No behavior change for the AGENT path.
- 3 new user-facing message keys in `messages/agentTest.md`, 2 new fixtures (`test/fixtures/ngt-prompt-*`), and unit tests for every new code path.

**Example PROMPT spec:**

```yaml
name: SummarizeCasePromptSuite
description: Validates the SummarizeCase prompt template.
subjectType: PROMPT
subjectName: SummarizeCasePrompt
subjectVersion: v3
testCases:
  - inputs:
      - promptInput:
          - referenceName: CaseDescription
            value: Customer reports login failures since yesterday.
          - referenceName: CustomerTone
            value: frustrated
    scorers:
      - name: factuality
      - name: completeness
      - name: response_match
        expected: A concise, accurate case summary
```

```bash
sf agent test create --spec ./summarize-case-spec.yaml --test-runner agentforce-studio --api-name SummarizeCasePromptSuite --target-org myOrgAlias
```

**Testing:**
- Unit: `yarn test` — 435 passing, 1 pending, 0 failing, coverage thresholds met.
- Manually verified end-to-end against a live org (`sf agent test create --test-runner agentforce-studio`, linked build of this branch into `plugin-agent`) across 16 scenarios spanning both subject types — validation failures, server-side rejections, and successful deploys with XML inspection:

| # | Scenario | Result | As expected? |
|---|---|---|---|
| 1 | AGENT subject: full 11-scorer catalog on a single test case | Client-side `ngtTaskResolutionRequiresConversationHistory` (fixture's `task_resolution` scorer needs conversationHistory) | Yes |
| 2 | AGENT subject: baseline smoke test | Deploy failed: `BotVersion not found` (org-state — bot has no deployed version) | Yes |
| 3 | AGENT subject: baseline smoke test (second bot) | Deploy failed: `BotVersion not found` (org-state) | Yes |
| 4 | PROMPT subject: baseline multi-invocation spec | Deployed successfully | Yes |
| 5 | PROMPT subject: baseline multi-invocation spec (variant) | Deployed successfully | Yes |
| 6 | PROMPT subject: AGENT-only scorer (`topic_sequence_match`) | Client warning ("not supported for subject type 'PROMPT'"); deploy also rejected server-side | Yes |
| 7 | PROMPT subject: blank `referenceName` | Client-side `ngtPromptInputMissingReferenceName` | Yes |
| 8 | PROMPT subject: blank `value` | Client-side `ngtPromptInputMissingValue` | Yes |
| 9 | PROMPT subject: empty `promptInput:` list | Client-side `ngtPromptInputSetEmpty` | Yes |
| 10 | Misspelled `subjectType: PROMT` | Deploy failed: `BotVersion not found` (took the AGENT path) | Yes — the default path is AGENT; the PROMPT path is only taken when `subjectType` is exactly `PROMPT` |
| 11 | PROMPT subject: scorer missing `expected:` | Client-side `ngtScorerMissingExpected` | Yes |
| 12 | PROMPT subject: multi-invocation fan-out | Deployed successfully | Yes |
| 13 | PROMPT subject: non-adjacent matching scorer sets | Deployed successfully (no false collapse) | Yes |
| 14 | PROMPT subject: unquoted numeric value | Deployed successfully | Yes |
| 15 | PROMPT subject: quality scorer (`coherence`) with `expected:` supplied anyway | XML omits `<expectedValue>`; deployed successfully | Yes |
| 16 | PROMPT subject: scorer unknown to the local catalog | Client warning only; deploy rejected server-side with the org's full scorer allow-list | Yes |

### What issues does this PR fix or reference?

@W-23524165@
