### PR TITLE
docs: add downstream-consumers reference for compat checks @W-24014386

### DIFF
--- a/.claude/skills/sf-agents-dev-guide/SKILL.md
+++ b/.claude/skills/sf-agents-dev-guide/SKILL.md
@@ -73,11 +73,11 @@ check a change for breaking / backwards-incompatible impact — see
 1. Branch off `main` (prefix: `<developer-name>/`)
 2. Keep branch up-to-date using `rebase`
 3. Write code + tests (95%+ coverage on new code)
-4. Commit using `type: message` format (enforced by Husky + commitizen)
+4. Commit using `type: message` format (enforced by Husky + commitlint; commitizen available as an authoring helper)
 5. PR is squash-merged — the PR title becomes the final commit message
 6. Include a GUS work item: `@W-XXXXXXXX@` in PR body
 
-Valid commit types: `feat, fix, improvement, docs, style, refactor, perf, test, build, ci, chore, revert`
+Valid commit types (`@commitlint/config-conventional`): `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert`
 
 Semver: `feat:` → minor, `fix:` → patch, breaking changes → major.
 
@@ -90,29 +90,15 @@ yarn compile              # TypeScript → JavaScript only
 yarn lint                 # eslint
 yarn test                 # unit tests + bundle + compile check + link check
 yarn test:nuts            # non-unit tests (require org connection)
-yarn docs                 # generate TypeDoc API docs
-yarn local:link <path>    # link into plugin-agent or vscode-agents for local dev
-yarn local:unlink <path>  # unlink
-yarn local:install <path> # install as NPM module (QA the published artifact)
+yarn docs                 # generate API docs
 yarn fix-license          # add Apache 2.0 headers to new files
 ```
 
 ### Cross-Repo Development
 
-To test library changes in a downstream consumer before merging:
-
-```bash
-# In this repo — build your changes
-yarn build
-
-# Link into plugin-agent for CLI testing
-yarn local:link /path/to/plugin-agent
-
-# Or link into vscode-agents for extension testing
-yarn local:link /path/to/vscode-agents
-```
-
-Use `yarn local:install` to QA the actual published artifact shape.
+To test library changes in a downstream consumer (`plugin-agent`, `vscode-agents`) before
+merging — `yarn link` for a live symlink, or `yarn pack` to QA the published artifact
+shape — see [`ai-docs/local-testing.md`](../../../ai-docs/local-testing.md).
 
 ## Code Conventions
 
@@ -172,5 +158,3 @@ New agent types should extend `AgentBase`. Static methods on the `Agent` class a
 - CLI questions: Willie Ruemmele
 - Extension questions: Steve Hetzel
 - Design: Marcelino Llano
-
-For partner team contacts (SFAP APIs, SF Eval, AI Assist, Agent Script, etc.), see `references/external-contacts.md`.

--- a/.claude/skills/sf-agents-dev-guide/SKILL.md
+++ b/.claude/skills/sf-agents-dev-guide/SKILL.md
@@ -25,8 +25,8 @@ This repo is the **foundational library** that manages all API calls for preview
     ├─► vscode-agents (forcedotcom/vscode-agents)
     │     VS Code extension: preview, publish, test UI, session management
     │
-    └─► afv-library (forcedotcom/afv-library)
-          Agent skills for vibe coding (developing/observing/testing-agentforce)
+    └─► sf-skills (forcedotcom/sf-skills)
+          Curated agent skills for Agentforce Vibes (works with all AI tools)
 ```
 
 Template or logic changes here automatically benefit all downstream consumers.
@@ -37,11 +37,12 @@ Template or logic changes here automatically benefit all downstream consumers.
 |------|--------|------|
 | agents (this repo) | forcedotcom/agents | Core TypeScript library — APIs for agent lifecycle |
 | plugin-agent | salesforcecli/plugin-agent | CLI commands (`sf agent *`), Oclif core plugin |
-| vscode-agents | forcedotcom/vscode-agents (private) | VS Code extension — UI for preview, publish, test, debug |
-| afv-library | forcedotcom/afv-library | Agent skills used by AFV, Claude Code, Cursor |
-| platformdx-shared-skills | forcedotcom/platformdx-shared-skills | Shared Claude/Cursor skills for all DX teams |
-| afdx-skill-dev | forcedotcom/afdx-skill-dev (private) | Skill development |
-| afdx-skill-test | forcedotcom/afdx-skill-test (private) | Skill testing |
+| vscode-agents | forcedotcom/vscode-agents | VS Code extension — UI for preview, publish, test, debug |
+| sf-skills | forcedotcom/sf-skills | Curated agent skills for Agentforce Vibes; works with all AI tools |
+
+For the public-API consumer contract — which repos are bound to the published API and how to
+check a change for breaking / backwards-incompatible impact — see
+[`ai-docs/downstream-consumers.md`](../../../ai-docs/downstream-consumers.md).
 
 ## How Changes Flow Downstream
 

--- a/.claude/skills/sf-agents-dev-guide/SKILL.md
+++ b/.claude/skills/sf-agents-dev-guide/SKILL.md
@@ -105,6 +105,10 @@ To test library changes in a downstream consumer (`plugin-agent`, `vscode-agents
 merging — `yarn link` for a live symlink, or `yarn pack` to QA the published artifact
 shape — see [`ai-docs/local-testing.md`](../../../ai-docs/local-testing.md).
 
+The `sf` CLI has no direct dependency on this library; it bundles `plugin-agent`, so you
+test the `sf agent` experience transitively through that plugin (`sf plugins link .`), not
+by building the CLI. See [`ai-docs/local-testing.md`](../../../ai-docs/local-testing.md).
+
 ## Code Conventions
 
 - **No `any` types** — uses `tsconfig-strict-esm`

--- a/.claude/skills/sf-agents-dev-guide/SKILL.md
+++ b/.claude/skills/sf-agents-dev-guide/SKILL.md
@@ -88,10 +88,15 @@ yarn install              # install deps
 yarn build                # compile + lint
 yarn compile              # TypeScript → JavaScript only
 yarn lint                 # eslint
+yarn lint-fix             # eslint --fix
+yarn format               # prettier
 yarn test                 # unit tests + bundle + compile check + link check
 yarn test:nuts            # non-unit tests (require org connection)
 yarn docs                 # generate API docs
+yarn clean                # remove generated files (clean-all also removes node_modules)
 yarn fix-license          # add Apache 2.0 headers to new files
+yarn link                 # live symlink into a consumer for local testing
+yarn pack                 # build the publishable .tgz to QA the artifact
 ```
 
 ### Cross-Repo Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ we expect every change to follow. Read the linked docs before writing code in th
 - **[Logging](ai-docs/logging.md)** — how we log. Log through `CtxLogger`, keep messages
   static with variable data in structured fields, and write every line to pass the 3am test.
   Read this before adding or changing any log line.
+- **[Downstream consumers](ai-docs/downstream-consumers.md)** — who depends on this
+  package's public API (`plugin-agent`, `vscode-agents`, the `sf` CLI) and how to check a
+  change against the latest `main` of each. Read this when generating or reading a code
+  review to judge whether a change is breaking or backwards-incompatible, and where.
 
 _Add new convention docs under `ai-docs/` and link them here as the hub grows._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ we expect every change to follow. Read the linked docs before writing code in th
   package's public API (`plugin-agent`, `vscode-agents`, the `sf` CLI) and how to check a
   change against the latest `main` of each. Read this when generating or reading a code
   review to judge whether a change is breaking or backwards-incompatible, and where.
+- **[Local testing](ai-docs/local-testing.md)** — how to test a change inside a consumer
+  before publishing: `yarn link` for a live symlink, or `yarn pack` to QA the exact
+  published artifact. Read this when you need to verify a change against `plugin-agent` or
+  `vscode-agents` locally.
 
 _Add new convention docs under `ai-docs/` and link them here as the hub grows._
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -40,25 +40,37 @@ Utilize the `Run Tests` VS Code debugger configuration to run the test suite wit
 
 ### Testing in another package
 
-To test the library in another local package, you can link it to such module so any changes that are built will be automatically present without reinstalling:
+`@salesforce/agents` is a library — test your change inside a consumer (`plugin-agent`,
+`vscode-agents`) before publishing. Use `yarn link` for a live symlink while iterating:
 
 ```
-yarn local:link /path/to/other/project
+# In this repo
+yarn build            # or `yarn compile --watch` to rebuild on save
+yarn link
+
+# In the consumer
+yarn link @salesforce/agents
 ```
 
-to unlink the library:
-
-```
-yarn local:unlink /path/to/other/project
-```
+Undo with `yarn unlink @salesforce/agents` (+ `yarn install --force`) in the consumer and
+`yarn unlink` here.
 
 ### Testing with the NPM artifact
 
-The library can also be installed to another local project as a regular NPM module. This is useful for manually testing the package that will be deployed to NPM. Use this instead of the linking process that's described under Development to QA changes before they are published:
+To QA the exact package that will be published — catching problems a symlink hides, such as
+a file missing from the published set — install the packed tarball instead of linking:
 
 ```
-yarn local:install /path/to/other/package
+# In this repo
+yarn build
+yarn pack             # produces salesforce-agents-v<version>.tgz
+
+# In the consumer
+yarn add /absolute/path/to/salesforce-agents-v<version>.tgz
 ```
+
+See `ai-docs/local-testing.md` for the full flows, including the duplicate
+`@salesforce/core` caveat.
 
 ## Debugging
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -69,8 +69,7 @@ yarn pack             # produces salesforce-agents-v<version>.tgz
 yarn add /absolute/path/to/salesforce-agents-v<version>.tgz
 ```
 
-See `ai-docs/local-testing.md` for the full flows, including the duplicate
-`@salesforce/core` caveat.
+See `ai-docs/local-testing.md` for the full flows and gotchas.
 
 ## Debugging
 

--- a/ai-docs/downstream-consumers.md
+++ b/ai-docs/downstream-consumers.md
@@ -1,0 +1,51 @@
+# Downstream consumers
+
+`@salesforce/agents` is a published library. Other Salesforce repos depend on it and are
+pinned to a released version — they cannot redeploy in lockstep with a change here. That
+makes the exported surface of this package (types, function/class signatures, option
+shapes, defaults, enum values, thrown errors, wire/output shapes) a **contract**. A change
+that reads fine in isolation, and passes this repo's own tests, can still break a consumer
+that is bound to the old shape.
+
+Use this doc whenever a **code review is being generated or read** for a change to this
+repo's public API: check the change against the consumers below to decide whether it is
+breaking or backwards-incompatible, and point at the exact consumer call site it would
+break.
+
+## The consumers
+
+| Repo | Package | How it consumes `@salesforce/agents` |
+| --- | --- | --- |
+| [salesforcecli/plugin-agent](https://github.com/salesforcecli/plugin-agent) | `@salesforce/plugin-agent` | **Direct** — declared dependency, imported across many command files. The heaviest consumer of the API. |
+| [forcedotcom/vscode-agents](https://github.com/forcedotcom/vscode-agents) | `salesforcedx-vscode-agents` | **Direct** — declared dependency, imported across the extension. |
+| [forcedotcom/cli](https://github.com/forcedotcom/cli) | `@salesforce/cli` | **Indirect / transitive** — does not import `@salesforce/agents` itself; it bundles `plugin-agent`, so it inherits the contract through that plugin. |
+
+## Always check against the latest default branch
+
+These repos move. Never reason from a stale local checkout or from memory of the API.
+Before judging compatibility, cross-check against the **latest default branch** (`main`)
+of each relevant consumer:
+
+- If a repo is already cloned locally, `git fetch` and read the `origin/main` state — do
+  not trust the working tree, which may be behind or on a feature branch.
+- Otherwise clone it fresh to a temp dir, e.g.
+  `git clone --depth 1 https://github.com/salesforcecli/plugin-agent /tmp/plugin-agent`.
+
+## How to cross-check a change
+
+1. Identify what changed in this repo's **exported** surface — a renamed/removed export,
+   a changed signature or option shape, a narrowed input, a widened or restructured
+   output, a changed default, an altered enum set, a new required field, a different
+   thrown error.
+2. In each direct consumer (`plugin-agent`, `vscode-agents`), grep for the affected symbol
+   to find every call site — e.g. `grep -rn "publishAgent\|from '@salesforce/agents'" src`.
+3. Decide per call site whether the old usage still compiles and behaves the same. If any
+   does not, the change is **breaking** for that consumer.
+4. For the CLI, remember the dependency is transitive: a break in `plugin-agent`'s usage
+   is a break for the CLI. Check `plugin-agent`, not the CLI's own source.
+5. In the review, name the specific consumer, file, and call site the change would break,
+   and whether it can be made backwards-compatible (e.g. additive/optional instead of a
+   rename, keep the old export as a deprecated alias).
+
+A pure addition — a new optional field, a brand-new export — is safe; say so briefly
+rather than manufacturing a concern.

--- a/ai-docs/local-testing.md
+++ b/ai-docs/local-testing.md
@@ -49,6 +49,22 @@ yarn unlink
 breaks `instanceof` checks and connection/auth state in confusing ways. If you hit odd
 runtime errors under a link, prefer the packed-artifact flow below.
 
+## Exercising the real `sf agent` CLI
+
+You do **not** clone or build [forcedotcom/cli](https://github.com/forcedotcom/cli) to test
+a change here. The `sf` CLI has no direct dependency on `@salesforce/agents` — it only
+*bundles* `plugin-agent` (which imports this library), so the CLI inherits your change
+transitively through the plugin. See [downstream-consumers.md](downstream-consumers.md).
+
+So you always test through `plugin-agent`, at one of two fidelities:
+
+- **Fastest** — run the plugin standalone: `./bin/dev.js agent ...` from `plugin-agent`,
+  with `@salesforce/agents` linked into it (above). No `sf` CLI involved.
+- **End-user experience** — to run it as `sf agent ...`, link the plugin into your installed
+  CLI with `sf plugins link .` from `plugin-agent`. With `@salesforce/agents` still
+  `yarn link`ed into that plugin, your library change flows all the way through to
+  `sf agent`.
+
 ## Packed artifact with `yarn pack`
 
 Install the library exactly as it would ship to npm — this respects the published `files`

--- a/ai-docs/local-testing.md
+++ b/ai-docs/local-testing.md
@@ -1,0 +1,67 @@
+# Testing changes locally in a consumer
+
+`@salesforce/agents` is a library — its behavior only really shows up once a consumer
+(`plugin-agent`, `vscode-agents`) runs against it. Before publishing, test your change
+inside a consumer one of two ways. See [downstream-consumers.md](downstream-consumers.md)
+for who the consumers are.
+
+There is **no `yarn local:*` script** — those were never real in this repo. Use the plain
+`yarn link` / `yarn pack` flows below.
+
+## Which flow to use
+
+- **Live symlink (`yarn link`)** — iterate on the library and see edits in the consumer
+  immediately, without reinstalling. Use this while developing.
+- **Packed artifact (`yarn pack`)** — install the exact tarball that would be published, to
+  QA the real package shape. Use this to catch problems a symlink hides (a file missing
+  from the published `files` set, a bad `main`/`types`, a missing dependency).
+
+## Live symlink with `yarn link`
+
+Iterate on the library with changes reflected in a consumer as soon as they're built.
+
+```bash
+# In this repo (@salesforce/agents)
+yarn build                 # produce lib/ (or `yarn compile --watch` to rebuild on save)
+yarn link                  # register @salesforce/agents as a global link
+
+# In the consumer (e.g. ../plugin-agent or ../vscode-agents)
+yarn link @salesforce/agents
+```
+
+Then run the consumer as usual — for `plugin-agent`, `./bin/dev.js agent ...` (or
+`sf plugins link .`); for `vscode-agents`, launch the extension. Rebuilds in this repo
+(`yarn build`, or a running `yarn compile --watch`) flow straight through the symlink.
+
+Undo when done:
+
+```bash
+# In the consumer
+yarn unlink @salesforce/agents
+yarn install --force        # restore the real published dependency
+
+# In this repo
+yarn unlink
+```
+
+**Caveat — duplicate `@salesforce/core`:** a symlinked library brings its own
+`node_modules`, so the consumer can end up with two copies of `@salesforce/core`. That
+breaks `instanceof` checks and connection/auth state in confusing ways. If you hit odd
+runtime errors under a link, prefer the packed-artifact flow below.
+
+## Packed artifact with `yarn pack`
+
+Install the library exactly as it would ship to npm — this respects the published `files`
+set (`/lib`, `/messages`) and surfaces packaging problems a symlink cannot.
+
+```bash
+# In this repo (@salesforce/agents)
+yarn build
+yarn pack                   # produces e.g. salesforce-agents-v<version>.tgz
+
+# In the consumer
+yarn add /absolute/path/to/salesforce-agents-v<version>.tgz
+```
+
+Undo by restoring the real dependency (revert the consumer's `package.json` change and
+`yarn install --force`).

--- a/ai-docs/local-testing.md
+++ b/ai-docs/local-testing.md
@@ -5,9 +5,6 @@
 inside a consumer one of two ways. See [downstream-consumers.md](downstream-consumers.md)
 for who the consumers are.
 
-There is **no `yarn local:*` script** — those were never real in this repo. Use the plain
-`yarn link` / `yarn pack` flows below.
-
 ## Which flow to use
 
 - **Live symlink (`yarn link`)** — iterate on the library and see edits in the consumer


### PR DESCRIPTION
## What

Docs-only changes that give code reviews (and sessions consuming a review) a consistent way to reason about this published library and how to test it, plus a cleanup of stale references in the dev-guide skill.

### New references
- **`ai-docs/downstream-consumers.md`** — the repos consuming `@salesforce/agents`' public API, so reviews can judge whether a change is breaking / backwards-incompatible and point at where:
  - **plugin-agent** ([salesforcecli/plugin-agent](https://github.com/salesforcecli/plugin-agent)) — direct, heaviest API usage.
  - **vscode-agents** ([forcedotcom/vscode-agents](https://github.com/forcedotcom/vscode-agents)) — direct.
  - **sf CLI** ([forcedotcom/cli](https://github.com/forcedotcom/cli)) — indirect/transitive; bundles `plugin-agent` rather than importing the API.
  - Guidance to cross-check against the latest `main` of each consumer, with a step-by-step for finding call sites a change would break.
- **`ai-docs/local-testing.md`** — how to test a change inside a consumer before publishing: `yarn link` for a live symlink (with the duplicate-`@salesforce/core` caveat) and `yarn pack` to QA the exact published artifact. Clarifies that the `sf` CLI is exercised transitively through `plugin-agent` — you do not build `forcedotcom/cli`.

### Hub + doc wiring
- `CLAUDE.md` links both new references from the convention hub.

### DEVELOPING.md
- Replaced the documented `yarn local:link/unlink/install` commands (which never existed in `package.json`) with the real `yarn link` / `yarn pack` flows, pointing at `ai-docs/local-testing.md` for the full detail.

### dev-guide skill (`.claude/skills/sf-agents-dev-guide/SKILL.md`)
- Fixed stale repo references: `afv-library` → `sf-skills` (renamed), dropped `(private)` on `vscode-agents`, removed three repos that no longer resolve (`platformdx-shared-skills`, `afdx-skill-dev`, `afdx-skill-test`).
- Pointed the API-consumer/compat content at `ai-docs/downstream-consumers.md` instead of duplicating it.
- Dropped the phantom `yarn local:*` commands (now points at `ai-docs/local-testing.md`), corrected the valid commit types to match `@commitlint/config-conventional` (removed `improvement`) and the enforcement mechanism (commitlint, not commitizen), and removed a dead link to a nonexistent `references/external-contacts.md`.

## Why

`@salesforce/agents` is published and consumers are pinned to released versions — they can't redeploy in lockstep. A change that passes this repo's own tests can still silently break a consumer bound to the old shape. These docs give reviewers a consistent way to catch that and to verify a change locally, and remove stale/incorrect guidance that had drifted from the actual repo.

## Notes

Docs only — no code or test changes.

@W-24014386
