### PR TITLE
test: fix flaky legacy-layout `agent create` NUT (Bot User race)

### DIFF
--- a/test/nuts/agent.nut.ts
+++ b/test/nuts/agent.nut.ts
@@ -709,6 +709,10 @@ describe('agent NUTs', () => {
           saveAgent: true,
           agentSettings: {
             agentName: legacyAgentName,
+            // Reuse the already-provisioned Bot User (see before()) so core does not auto-create
+            // (and race-validate) one, which intermittently fails with "User doesn't have access
+            // to agent." Mirrors the fix already applied to the sibling spec-create test above.
+            userId: botUserId,
           },
           generationInfo: {
             defaultInfo: {


### PR DESCRIPTION
## What

The `agent create > should retrieve the legacy Bot / GenAiPlanner layout ...` NUT (`test/nuts/agent.nut.ts`) fails intermittently, pod-dependent, with:

```
Error creating agent : User doesn't have access to agent.
isSuccess: false   // expected false to equal true
```

## Root cause

The `customer` agentType maps to core's `EinsteinServiceAgent`, which requires a Bot User holding the Digital Agent license + `AgentforceServiceAgentUser` permset. When `Agent.create` is called with no `agentSettings.userId`, core auto-creates that Bot User in the **same transaction** as the BotDefinition save; the pre-save validation trigger intermittently cannot see the just-created license/permset assignment and rejects with "User doesn't have access to agent."

The describe's `before` hook already pre-provisions a Bot User, assigns the permset, and waits for the assignment to commit (`waitForPermSetAssignment`), storing it in `botUserId`. The sibling `should create an agent from a spec` test already passes `userId: botUserId`; this legacy test never got the same fix.

## Fix

Pass `userId: botUserId` in the legacy test's `agentSettings` so core reuses the already-committed user instead of racing on a fresh one.

## Testing

- `yarn tsc -b` passes.
- The NUT needs a scratch org + default dev hub, not run in this environment. Because the failure is a race, verify with several runs across pods:
  ```sh
  TESTKIT_HUB_USERNAME="<devhub>" yarn mocha "test/nuts/agent.nut.ts" --grep "agent create" --timeout 1800000 --slow 4500
  ```

Test-only change; no runtime code touched.