### PR TITLE
fix: @W-24143688 add stage.api.salesforce.com to Agent API endpoint fallback

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -733,7 +733,7 @@ export type RequestInfo = {
 
 /**
  * Makes an API request with automatic endpoint fallback.
- * Tries api.salesforce.com first, then test.api.salesforce.com on 404, then dev.api.salesforce.com on 404.
+ * Tries api.salesforce.com first, then test., dev., and stage.api.salesforce.com on 404.
  *
  * @param connection - The Salesforce connection
  * @param requestInfo - The request information (url, method, headers, body, etc.)
@@ -746,7 +746,7 @@ export async function requestWithEndpointFallback<T>(
   requestInfo: RequestInfo,
   options?: { retry?: { maxRetries?: number } }
 ): Promise<T> {
-  const endpoints = ['', 'test.', 'dev.']; // Try production, test, dev in that order
+  const endpoints = ['', 'test.', 'dev.', 'stage.']; // Try production, test, dev, stage in that order
   const attemptedEndpoints: string[] = [];
   const logger = CtxLogger.child('AgentApiRequest');
 
@@ -755,7 +755,7 @@ export async function requestWithEndpointFallback<T>(
   for (const endpoint of endpoints) {
     // Replace the domain with the endpoint variant
     const modifiedUrl = requestInfo.url.replace(
-      /https:\/\/(?:test\.|dev\.)?api\.salesforce\.com/,
+      /https:\/\/(?:test\.|dev\.|stage\.)?api\.salesforce\.com/,
       `https://${endpoint}api.salesforce.com`
     );
     attemptedEndpoints.push(`${endpoint || 'production '}api.salesforce.com`);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -126,6 +126,36 @@ describe('requestWithEndpointFallback', () => {
     );
   });
 
+  it('should retry with stage endpoint after dev endpoint 404', async () => {
+    const error404 = new Error('Not Found') as Error & { name: string };
+    error404.name = 'ERROR_HTTP_404';
+
+    const requestStub = $$.SANDBOX.stub(connection, 'request');
+    requestStub.onCall(0).rejects(error404);
+    requestStub.onCall(1).rejects(error404);
+    requestStub.onCall(2).rejects(error404);
+    requestStub.onCall(3).resolves({ success: true });
+
+    const result = await requestWithEndpointFallback(connection, {
+      method: 'POST',
+      url: 'https://api.salesforce.com/einstein/ai-agent/v1/test',
+      headers: { 'x-client-name': 'test' },
+      body: '{}',
+    });
+
+    expect(result).to.deep.equal({ success: true });
+    expect(requestStub.callCount).to.equal(4);
+    expect((requestStub.getCall(1).args[0] as RequestInfo).url).to.equal(
+      'https://test.api.salesforce.com/einstein/ai-agent/v1/test'
+    );
+    expect((requestStub.getCall(2).args[0] as RequestInfo).url).to.equal(
+      'https://dev.api.salesforce.com/einstein/ai-agent/v1/test'
+    );
+    expect((requestStub.getCall(3).args[0] as RequestInfo).url).to.equal(
+      'https://stage.api.salesforce.com/einstein/ai-agent/v1/test'
+    );
+  });
+
   it('should throw AgentApiNotFound after all endpoints fail with 404', async () => {
     const error404 = new Error('Not Found');
     error404.name = 'ERROR_HTTP_404';
@@ -146,7 +176,7 @@ describe('requestWithEndpointFallback', () => {
       expect((error as SfError).message).to.include('Unable to access the Salesforce Agent API');
     }
 
-    expect(requestStub.calledThrice).to.be.true;
+    expect(requestStub.callCount).to.equal(4);
   });
 
   it('should throw immediately on non-404 errors', async () => {


### PR DESCRIPTION
## What

Adds the `stage.` SFAP gateway host to the endpoint-fallback list in `requestWithEndpointFallback`, so `sf agent preview` (and other Agent API calls routed through it) can reach agents on orgs served by `stage.api.salesforce.com` (the `aws-stage1` falcon instance).

## Why

`requestWithEndpointFallback` only tried `api.`, `test.api.`, and `dev.api.salesforce.com`. Orgs on the `aws-stage1` falcon instance are served by `stage.api.salesforce.com`, which was never attempted — so every request 404s and the CLI throws `AgentApiNotFound` ("...ensure the user has the necessary permissions..."), which misdiagnoses a routing 404 as an authorization problem. Backend logs confirm the request never reaches the Agent API service; it 404s at the public edge because no attempted host maps to the `aws-stage1` backend. The same agent previews fine in the Agent Builder UI, which routes internally through that gateway.

Fixes forcedotcom/cli#3645.

Fixes gus work item: @W-24143688@

## Changes

- `src/utils.ts`: add `'stage.'` to the `endpoints` fallback list and `stage\.` to the host-matching regex; update the doc comment.
- `test/utils.test.ts`: add a "retry with stage endpoint after dev endpoint 404" case, and update the "all endpoints fail" assertion to expect 4 attempts.

`stage.` is only reached as the final fallback after `api.`/`test.`/`dev.` return 404, matching the existing pattern — prod/test/dev behavior is unchanged.

## Testing

- `yarn tsc -b` — clean.
- `yarn mocha test/utils.test.ts` — 67 passing (includes the new stage-fallback test).
- Verified end-to-end by applying the equivalent change to the installed `@salesforce/agents` in `sf` 2.150.6 and re-running `sf agent preview -o <aws-stage1 org> -n <Agent>`: the request now reaches `stage.api.salesforce.com` and proceeds past the 404 (previously it failed with `AgentApiNotFound` before any backend contact).

## Follow-up (not in this PR)

The `AgentApiNotFound` message frames a 404 as a permissions failure. Consider a follow-up to have it report that all Agent API endpoints returned 404 and list `attemptedEndpoints`, so routing failures aren't misread as auth failures.
